### PR TITLE
python-app CI: Update Action and Python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,11 +16,11 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
-            - name: Set up Python 3.9
-              uses: actions/setup-python@v3
+            - uses: actions/checkout@v4
+            - name: Set up Python 3.11
+              uses: actions/setup-python@v4
               with:
-                  python-version: '3.9'
+                  python-version: '3.11'
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip


### PR DESCRIPTION
Update the python-app GitHub Action CI to the latest Python version (3.11) and Actions.