### PR TITLE
increase the multi_agent_replay_buffer efficiency

### DIFF
--- a/agilerl/components/multi_agent_replay_buffer.py
+++ b/agilerl/components/multi_agent_replay_buffer.py
@@ -110,7 +110,12 @@ class MultiAgentReplayBuffer:
         num_entries = len(next(iter(args[0].values())))
         for i in range(num_entries):
             for j, arg in enumerate(args):
-                new_dict = {key: np.array(value[i]) for key, value in arg.items()}
+                new_dict = {
+                    key: np.array(value[i])
+                    if type(value[i]) != np.ndarray
+                    else value[i]
+                    for key, value in arg.items()
+                }
                 results[j].append(new_dict)
         return tuple(results)
 

--- a/agilerl/components/multi_agent_replay_buffer.py
+++ b/agilerl/components/multi_agent_replay_buffer.py
@@ -66,10 +66,8 @@ class MultiAgentReplayBuffer:
                 if not np_array:
                     # Handle torch tensor creation
                     ts = torch.from_numpy(ts).float()
-                    if self.device == "cuda":
-                        ts = ts.cuda()
                     # Place on device
-                    elif self.device is not None:
+                    if self.device is not None:
                         ts = ts.to(self.device)
 
                 field_dict[agent_id] = ts


### PR DESCRIPTION
current version creates an extra np.ndarray even when it is not required, by profiling I realized that this may cause significant performance overhead.