### PR TITLE
Small Refactoring and Bug Fixes in Self-play Connect4 with DQN Tutorial

### DIFF
--- a/tutorials/PettingZoo/agilerl_dqn_curriculum.py
+++ b/tutorials/PettingZoo/agilerl_dqn_curriculum.py
@@ -67,9 +67,7 @@ class CurriculumEnv:
             while not (done or truncation):
                 # Player 0's turn
                 p0_action_mask = observation["action_mask"]
-                p0_state = np.moveaxis(observation["observation"], [-1], [-3])
-                p0_state_flipped = np.expand_dims(np.flip(p0_state, 2), 0)
-                p0_state = np.expand_dims(p0_state, 0)
+                p0_state, p0_state_flipped = transform_and_flip(observation, player = 0)
                 if opponent_first:
                     p0_action = self.env.action_space("player_0").sample(p0_action_mask)
                 else:
@@ -81,9 +79,7 @@ class CurriculumEnv:
                         p0_action = opponent.getAction(player=0)
                 self.step(p0_action)  # Act in environment
                 observation, env_reward, done, truncation, _ = self.last()
-                p0_next_state = np.moveaxis(observation["observation"], [-1], [-3])
-                p0_next_state_flipped = np.expand_dims(np.flip(p0_next_state, 2), 0)
-                p0_next_state = np.expand_dims(p0_next_state, 0)
+                p0_next_state, p0_next_state_flipped = transform_and_flip(observation, player = 0)
 
                 if done or truncation:
                     reward = self.reward(done=True, player=0)
@@ -121,10 +117,7 @@ class CurriculumEnv:
 
                     # Player 1's turn
                     p1_action_mask = observation["action_mask"]
-                    p1_state = np.moveaxis(observation["observation"], [-1], [-3])
-                    p1_state[[0, 1], :, :] = p1_state[[0, 1], :, :]
-                    p1_state_flipped = np.expand_dims(np.flip(p1_state, 2), 0)
-                    p1_state = np.expand_dims(p1_state, 0)
+                    p1_state, p1_state_flipped = transform_and_flip(observation, player = 1)
                     if not opponent_first:
                         p1_action = self.env.action_space("player_1").sample(
                             p1_action_mask
@@ -138,10 +131,7 @@ class CurriculumEnv:
                             p1_action = opponent.getAction(player=1)
                     self.step(p1_action)  # Act in environment
                     observation, env_reward, done, truncation, _ = self.last()
-                    p1_next_state = np.moveaxis(observation["observation"], [-1], [-3])
-                    p1_next_state[[0, 1], :, :] = p1_next_state[[0, 1], :, :]
-                    p1_next_state_flipped = np.expand_dims(np.flip(p1_next_state, 2), 0)
-                    p1_next_state = np.expand_dims(p1_next_state, 0)
+                    p1_next_state, p1_next_state_flipped = transform_and_flip(observation, player = 1)
 
                     if done or truncation:
                         reward = self.reward(done=True, player=1)

--- a/tutorials/PettingZoo/agilerl_dqn_curriculum.py
+++ b/tutorials/PettingZoo/agilerl_dqn_curriculum.py
@@ -67,7 +67,7 @@ class CurriculumEnv:
             while not (done or truncation):
                 # Player 0's turn
                 p0_action_mask = observation["action_mask"]
-                p0_state, p0_state_flipped = transform_and_flip(observation, player = 0)
+                p0_state, p0_state_flipped = transform_and_flip(observation, player=0)
                 if opponent_first:
                     p0_action = self.env.action_space("player_0").sample(p0_action_mask)
                 else:
@@ -79,7 +79,9 @@ class CurriculumEnv:
                         p0_action = opponent.getAction(player=0)
                 self.step(p0_action)  # Act in environment
                 observation, env_reward, done, truncation, _ = self.last()
-                p0_next_state, p0_next_state_flipped = transform_and_flip(observation, player = 0)
+                p0_next_state, p0_next_state_flipped = transform_and_flip(
+                    observation, player=0
+                )
 
                 if done or truncation:
                     reward = self.reward(done=True, player=0)
@@ -117,7 +119,9 @@ class CurriculumEnv:
 
                     # Player 1's turn
                     p1_action_mask = observation["action_mask"]
-                    p1_state, p1_state_flipped = transform_and_flip(observation, player = 1)
+                    p1_state, p1_state_flipped = transform_and_flip(
+                        observation, player=1
+                    )
                     if not opponent_first:
                         p1_action = self.env.action_space("player_1").sample(
                             p1_action_mask
@@ -131,7 +135,9 @@ class CurriculumEnv:
                             p1_action = opponent.getAction(player=1)
                     self.step(p1_action)  # Act in environment
                     observation, env_reward, done, truncation, _ = self.last()
-                    p1_next_state, p1_next_state_flipped = transform_and_flip(observation, player = 1)
+                    p1_next_state, p1_next_state_flipped = transform_and_flip(
+                        observation, player=1
+                    )
 
                     if done or truncation:
                         reward = self.reward(done=True, player=1)
@@ -478,6 +484,8 @@ def transform_and_flip(observation, player):
 
     :param observation: Observation to preprocess
     :type observation: dict[str, np.ndarray]
+    :param player: Player, 0 or 1
+    :type player: int
     """
     state = observation["observation"]
     # Pre-process dimensions for PyTorch (N, C, H, W)
@@ -488,6 +496,7 @@ def transform_and_flip(observation, player):
     state_flipped = np.expand_dims(np.flip(state, 2), 0)
     state = np.expand_dims(state, 0)
     return state, state_flipped
+
 
 if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -717,7 +726,9 @@ if __name__ == "__main__":
                     for idx_step in range(max_steps):
                         # Player 0"s turn
                         p0_action_mask = observation["action_mask"]
-                        p0_state, p0_state_flipped = transform_and_flip(observation, player = 0)
+                        p0_state, p0_state_flipped = transform_and_flip(
+                            observation, player=0
+                        )
 
                         if opponent_first:
                             if LESSON["opponent"] == "self":
@@ -741,7 +752,7 @@ if __name__ == "__main__":
                         env.step(p0_action)  # Act in environment
                         observation, cumulative_reward, done, truncation, _ = env.last()
                         p0_next_state, p0_next_state_flipped = transform_and_flip(
-                            observation, player = 0
+                            observation, player=0
                         )
                         if not opponent_first:
                             score = cumulative_reward
@@ -791,7 +802,9 @@ if __name__ == "__main__":
 
                             # Player 1"s turn
                             p1_action_mask = observation["action_mask"]
-                            p1_state, p1_state_flipped = transform_and_flip(observation, player = 1)
+                            p1_state, p1_state_flipped = transform_and_flip(
+                                observation, player=1
+                            )
 
                             if not opponent_first:
                                 if LESSON["opponent"] == "self":
@@ -815,9 +828,11 @@ if __name__ == "__main__":
                                 train_actions_hist[p1_action] += 1
 
                             env.step(p1_action)  # Act in environment
-                            observation, cumulative_reward, done, truncation, _ = env.last()
+                            observation, cumulative_reward, done, truncation, _ = (
+                                env.last()
+                            )
                             p1_next_state, p1_next_state_flipped = transform_and_flip(
-                                observation, player = 1
+                                observation, player=1
                             )
 
                             if opponent_first:
@@ -916,7 +931,9 @@ if __name__ == "__main__":
                         rewards = []
                         for i in range(evo_loop):
                             env.reset()  # Reset environment at start of episode
-                            observation, cumulative_reward, done, truncation, _ = env.last()
+                            observation, cumulative_reward, done, truncation, _ = (
+                                env.last()
+                            )
 
                             player = -1  # Tracker for which player"s turn it is
 
@@ -966,7 +983,9 @@ if __name__ == "__main__":
                                         eval_actions_hist[action] += 1
 
                                 env.step(action)  # Act in environment
-                                observation, cumulative_reward, done, truncation, _ = env.last()
+                                observation, cumulative_reward, done, truncation, _ = (
+                                    env.last()
+                                )
 
                                 if (player > 0 and opponent_first) or (
                                     player < 0 and not opponent_first

--- a/tutorials/PettingZoo/agilerl_dqn_curriculum.py
+++ b/tutorials/PettingZoo/agilerl_dqn_curriculum.py
@@ -682,7 +682,7 @@ if __name__ == "__main__":
             for agent in pop:  # Loop through population
                 for episode in range(episodes_per_epoch):
                     env.reset()  # Reset environment at start of episode
-                    observation, env_reward, done, truncation, _ = env.last()
+                    observation, cumulative_reward, done, truncation, _ = env.last()
 
                     (
                         p1_state,
@@ -735,7 +735,7 @@ if __name__ == "__main__":
                             train_actions_hist[p0_action] += 1
 
                         env.step(p0_action)  # Act in environment
-                        observation, env_reward, done, truncation, _ = env.last()
+                        observation, cumulative_reward, done, truncation, _ = env.last()
                         p0_next_state = np.moveaxis(
                             observation["observation"], [-1], [-3]
                         )
@@ -745,7 +745,7 @@ if __name__ == "__main__":
                         p0_next_state = np.expand_dims(p0_next_state, 0)
 
                         if not opponent_first:
-                            score += env_reward
+                            score = cumulative_reward
                         turns += 1
 
                         # Check if game is over (Player 0 win)
@@ -822,7 +822,7 @@ if __name__ == "__main__":
                                 train_actions_hist[p1_action] += 1
 
                             env.step(p1_action)  # Act in environment
-                            observation, env_reward, done, truncation, _ = env.last()
+                            observation, cumulative_reward, done, truncation, _ = env.last()
                             p1_next_state = np.moveaxis(
                                 observation["observation"], [-1], [-3]
                             )
@@ -833,7 +833,7 @@ if __name__ == "__main__":
                             p1_next_state = np.expand_dims(p1_next_state, 0)
 
                             if opponent_first:
-                                score += env_reward
+                                score = cumulative_reward
                             turns += 1
 
                             # Check if game is over (Player 1 win)
@@ -928,7 +928,7 @@ if __name__ == "__main__":
                         rewards = []
                         for i in range(evo_loop):
                             env.reset()  # Reset environment at start of episode
-                            observation, reward, done, truncation, _ = env.last()
+                            observation, cumulative_reward, done, truncation, _ = env.last()
 
                             player = -1  # Tracker for which player"s turn it is
 
@@ -978,12 +978,12 @@ if __name__ == "__main__":
                                         eval_actions_hist[action] += 1
 
                                 env.step(action)  # Act in environment
-                                observation, reward, done, truncation, _ = env.last()
+                                observation, cumulative_reward, done, truncation, _ = env.last()
 
                                 if (player > 0 and opponent_first) or (
                                     player < 0 and not opponent_first
                                 ):
-                                    score += reward
+                                    score = cumulative_reward
 
                                 eval_turns += 1
 


### PR DESCRIPTION
# Description
I have made some small changes to improve the Self-play Connect4 with DQN tutorial. The changes include refactoring repeated code into a function and fixing minor bugs.

# Changes Made
1. Added a `transform_and_flip` function that preprocesses observations, swaps planes if necessary, and flips the observation. Replaced repeated code lines with a call to this function.
2. Fixed a bug in **swapping channels** for player 1. Previously, it did not swap channels due to incorrect indices.
3. Fixed a bug related to incorrect **score calculation** for episodes in training and evaluating agents. PZ's `last()` returns cumulative rewards, so now it assigns `score` the cumulative reward.
4. Update the tutorial documentation

Regarding point 3, I previously shared in the Discord channel that I add instantaneous rewards by accessing each agent's reward after each step. However, in the context of the current tutorial, it is not the most concise way, as we do not use the instantaneous rewards from Connect4 in transitions. So, just using the cumulative rewards is enough
