### PR TITLE
Update function call to train_off_policy in TD3 tutorial

### DIFF
--- a/docs/tutorials/gymnasium/agilerl_td3_tutorial.rst
+++ b/docs/tutorials/gymnasium/agilerl_td3_tutorial.rst
@@ -52,7 +52,7 @@ Dependencies
     from agilerl.components.replay_buffer import ReplayBuffer
     from agilerl.hpo.mutation import Mutations
     from agilerl.hpo.tournament import TournamentSelection
-    from agilerl.training.train import train
+    from agilerl.training.train_off_policy import train_off_policy
     from agilerl.utils.utils import (
         calculate_vectorized_scores,
         initialPopulation,
@@ -250,17 +250,17 @@ Tournament selection and mutation should be applied sequentially to fully evolve
 Training and Saving an Agent
 ----------------------------
 
-Using AgileRL ``train`` function
+Using AgileRL ``train_off_policy`` function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The simplest way to train an AgileRL agent is to use one of the implemented AgileRL train functions.
-Given that TD3 is an off-policy algorithm, we can make use of the ``train`` function. This
+Given that TD3 is an off-policy algorithm, we can make use of the ``train_off_policy`` function. This
 training function will orchestrate the training and hyperparameter optimisation process, removing the
 the need to implement a custom training loop. It will return a trained population, as well as the associated
 fitnesses (fitness is each agents test scores on the environment).
 
 .. code-block:: python
 
-    trained_pop, pop_fitnesses = train(
+    trained_pop, pop_fitnesses = train_off_policy(
         env=env,
         env_name="LunarLanderContinuous-v2",
         algo="TD3",
@@ -284,7 +284,7 @@ fitnesses (fitness is each agents test scores on the environment).
 Using a custom training loop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If we wanted to have more control over the training process, it is also possible to write our own custom
-training loops to train our agents. The training loop below can be used alternatively to the above ``train``
+training loops to train our agents. The training loop below can be used alternatively to the above ``train_off_policy``
 function and is an example of how we might choose to make use of a population of AgileRL agents in our own training loop.
 
 .. code-block:: python


### PR DESCRIPTION
I was following the TD3 tutorial and noticed that the import `from agilerl.training.train import train` doesn't work anymore, as this function and module were renamed.

The PR should fix that and the mentions in the text to the function.