### PR TITLE
Fix PettingZooAutoResetParallelWrapper Bug

### DIFF
--- a/agilerl/wrappers/pettingzoo_wrappers.py
+++ b/agilerl/wrappers/pettingzoo_wrappers.py
@@ -39,7 +39,7 @@ class PettingZooAutoResetParallelWrapper(ParallelEnv):
         dict[AgentID, dict],
     ]:
         obs, rewards, terminations, truncations, infos = self.env.step(actions)
-        if np.any(list(terminations.values())) or np.any(list(truncations.values())):
+        if len(self.agents) <= 0:
             obs, infos = self.env.reset()
         return obs, rewards, terminations, truncations, infos
 


### PR DESCRIPTION
The condition of pettingzoo env reset should not be `any`.