### PR TITLE
feat(util): utils.utils.make_vect_envs with higher versatility

### DIFF
--- a/agilerl/utils/utils.py
+++ b/agilerl/utils/utils.py
@@ -23,7 +23,7 @@ def make_vect_envs(
     *,
     make_env: Optional[Callable] = None,
     should_async_vector: bool = True,
-    **kwargs
+    **env_kwargs
 ):
     """Returns async-vectorized gym environments.
 
@@ -44,7 +44,7 @@ def make_vect_envs(
     )
 
     def default_make_env():
-        return gym.make(env_name, **kwargs)
+        return gym.make(env_name, **env_kwargs)
 
     make_env = make_env or default_make_env
 

--- a/agilerl/utils/utils.py
+++ b/agilerl/utils/utils.py
@@ -18,7 +18,7 @@ from agilerl.vector.pz_async_vec_env import AsyncPettingZooVecEnv
 
 
 def make_vect_envs(
-    env_name,
+    env_name: Optional[str] = None,
     num_envs=1,
     *,
     make_env: Optional[Callable] = None,
@@ -36,6 +36,9 @@ def make_vect_envs(
     :param should_async_vector: Whether to asynchronous vectorized environments, defaults to True
     :type should_async_vector: bool, optional
     """
+    if env_name is None and make_env is None:
+        raise ValueError("Either env_name or make_env must be provided")
+
     vectorize = (
         gym.vector.AsyncVectorEnv if should_async_vector else gym.vector.SyncVectorEnv
     )

--- a/agilerl/utils/utils.py
+++ b/agilerl/utils/utils.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 import gymnasium as gym
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,17 +17,35 @@ from agilerl.algorithms.td3 import TD3
 from agilerl.vector.pz_async_vec_env import AsyncPettingZooVecEnv
 
 
-def make_vect_envs(env_name, num_envs=1):
+def make_vect_envs(
+    env_name,
+    num_envs=1,
+    *,
+    make_env: Optional[Callable] = None,
+    should_async_vector: bool = True,
+    **kwargs
+):
     """Returns async-vectorized gym environments.
 
     :param env_name: Gym environment name
     :type env_name: str
     :param num_envs: Number of vectorized environments, defaults to 1
     :type num_envs: int, optional
+    :param make_env: Function that creates a gym environment, defaults use gym.make(env_name)
+    :type make_env: Callable, optional
+    :param should_async_vector: Whether to asynchronous vectorized environments, defaults to True
+    :type should_async_vector: bool, optional
     """
-    return gym.vector.AsyncVectorEnv(
-        [lambda: gym.make(env_name) for i in range(num_envs)]
+    vectorize = (
+        gym.vector.AsyncVectorEnv if should_async_vector else gym.vector.SyncVectorEnv
     )
+
+    def default_make_env():
+        return gym.make(env_name, **kwargs)
+
+    make_env = make_env or default_make_env
+
+    return vectorize([make_env for _ in range(num_envs)])
 
 
 def make_multi_agent_vect_envs(env, num_envs=1, **env_kwargs):


### PR DESCRIPTION
By reading the documentation and examples I didn't realize that behind the hood of `make_vect_envs` is just `gym.vector.AsyncVectorEnv` and it makes me think that is necessary to vectorize environments for AgileRL.

I made the make_vect_envs more versatile that you can give it whatever arguments you want and have some more control on it.