### PR TITLE
doc: add gymnasium breakage note; fix TD doc errors

### DIFF
--- a/docs/on_policy/index.rst
+++ b/docs/on_policy/index.rst
@@ -187,6 +187,18 @@ The easiest way to train a population of agents using PPO is to use our online t
         wb=True,  # Weights and Biases tracking
     )
 
+.. note::
+
+   Known `Gymnasium issue <https://github.com/Farama-Foundation/Gymnasium/issues/722>`_ - running vectorize environments as top-level code (without ``if __name__ == "__main__":``) may cause multiprocessing errors. To fix, run the above as a method under ``main``, e.g.
+
+   .. code-block:: python
+
+      def train_agent():
+          # ... training code
+
+      if __name__ == "__main__":
+          train_agent()
+
 Alternatively, use a custom on-policy training loop:
 
 .. code-block:: python

--- a/docs/tutorials/gymnasium/agilerl_ppo_tutorial.rst
+++ b/docs/tutorials/gymnasium/agilerl_ppo_tutorial.rst
@@ -255,6 +255,18 @@ fitnesses (fitness is each agents test scores on the environment).
         elite_path=save_path,
     )
 
+.. note::
+
+   Known `Gymnasium issue <https://github.com/Farama-Foundation/Gymnasium/issues/722>`_ - running vectorize environments as top-level code (without ``if __name__ == "__main__":``) may cause multiprocessing errors. To fix, run the above as a method under ``main``, e.g.
+
+   .. code-block:: python
+
+      def train_agent():
+          # ... training code
+
+      if __name__ == "__main__":
+          train_agent()
+
 Using a custom training loop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If we wanted to have more control over the training process, it is also possible to write our own custom

--- a/docs/tutorials/gymnasium/agilerl_rainbow_dqn_tutorial.rst
+++ b/docs/tutorials/gymnasium/agilerl_rainbow_dqn_tutorial.rst
@@ -227,6 +227,18 @@ for both the tournament and mutation arguments.
         checkpoint_path="RainbowDQN.pt",
     )
 
+.. note::
+
+   Known `Gymnasium issue <https://github.com/Farama-Foundation/Gymnasium/issues/722>`_ - running vectorize environments as top-level code (without ``if __name__ == "__main__":``) may cause multiprocessing errors. To fix, run the above as a method under ``main``, e.g.
+
+   .. code-block:: python
+
+      def train_agent():
+          # ... training code
+
+      if __name__ == "__main__":
+          train_agent()
+
 Using a custom training loop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If we wanted to have more control over the training process, it is also possible to write our own custom

--- a/docs/tutorials/gymnasium/agilerl_td3_tutorial.rst
+++ b/docs/tutorials/gymnasium/agilerl_td3_tutorial.rst
@@ -91,6 +91,10 @@ Additionally, we also define our upper and lower limits for these hyperparameter
         "TARGET_SCORE": 200.0,  # Target score that will beat the environment
         "EVO_LOOP": 3,  # Number of evaluation episodes
         "MAX_STEPS": 500,  # Maximum number of steps an agent takes in an environment
+        "LEARNING_DELAY": 1000,  # Steps before starting learning
+        "EVO_STEPS": 10000,  # Evolution frequency
+        "EVAL_STEPS": None,  # Number of evaluation steps per episode
+        "EVAL_LOOP": 1,  # Number of evaluation episodes
         "TOURN_SIZE": 2,  # Tournament size
         "ELITISM": True,  # Elitism in tournament selection
     }
@@ -277,7 +281,7 @@ fitnesses (fitness is each agents test scores on the environment).
         INIT_HP=INIT_HP,
         MUT_P=MUT_P,
         swap_channels=INIT_HP["CHANNELS_LAST"],
-        INIT_HP["MAX_STEPS"]=INIT_HP["MAX_STEPS"],
+        max_steps=INIT_HP["MAX_STEPS"],
         evo_steps=INIT_HP["EVO_STEPS"],
         eval_steps=INIT_HP["EVAL_STEPS"],
         eval_loop=INIT_HP["EVAL_LOOP"],
@@ -290,6 +294,17 @@ fitnesses (fitness is each agents test scores on the environment).
         elite_path="TD3_trained_agent.pt",
     )
 
+.. note::
+
+   Known `Gymnasium issue <https://github.com/Farama-Foundation/Gymnasium/issues/722>`_ - running vectorize environments as top-level code (without ``if __name__ == "__main__":``) may cause multiprocessing errors. To fix, run the above as a method under ``main``, e.g.
+
+   .. code-block:: python
+
+      def train_agent():
+          # ... training code
+
+      if __name__ == "__main__":
+          train_agent()
 
 Using a custom training loop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Two doc fixes:
1. add note about gymnasium breakage when run as top-level code (without `__main__`). Fix #286 
2. fix missing param and param code error in TD example doc