### PR TITLE
updating docs to fix typo (- env.single_action_space)

### DIFF
--- a/docs/distributed_training/index.rst
+++ b/docs/distributed_training/index.rst
@@ -61,7 +61,7 @@ Example distributed training loop:
     num_envs = 8
     env = make_vect_envs("LunarLander-v2", num_envs=num_envs)  # Create environment
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
 
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)

--- a/docs/off_policy/index.rst
+++ b/docs/off_policy/index.rst
@@ -71,7 +71,7 @@ are more likely to remain present in the population. The sequence of evolution (
     env = make_vect_envs("LunarLander-v2", num_envs=num_envs)  # Create environment
 
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
 
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)
@@ -186,7 +186,7 @@ Alternatively, use a custom training loop. Combining all of the above:
     env = make_vect_envs("LunarLander-v2", num_envs=num_envs)  # Create environment
 
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
 
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)

--- a/docs/offline_training/index.rst
+++ b/docs/offline_training/index.rst
@@ -53,7 +53,7 @@ are more likely to remain present in the population. The sequence of evolution (
     dataset = h5py.File("data/cartpole/cartpole_random_v1.1.0.h5", "r")  # Load dataset
 
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)
 
@@ -191,7 +191,7 @@ Alternatively, use a custom training loop. Combining all of the above:
     dataset = h5py.File("data/cartpole/cartpole_random_v1.1.0.h5", "r")  # Load dataset
 
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)
 

--- a/docs/on_policy/index.rst
+++ b/docs/on_policy/index.rst
@@ -69,7 +69,7 @@ are more likely to remain present in the population. The sequence of evolution (
     env = make_vect_envs("LunarLander-v2", num_envs=num_envs)  # Create environment
 
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)
 
@@ -166,7 +166,7 @@ Alternatively, use a custom on-policy training loop:
     env = make_vect_envs("LunarLander-v2", num_envs=num_envs)  # Create environment
 
     observation_space = env.single_observation_space
-    action_space - env.single_action_space
+    action_space = env.single_action_space
     if INIT_HP['CHANNELS_LAST']:
         observation_space = observation_space_channels_to_first(observation_space)
 


### PR DESCRIPTION
replaced instances of `- env.single_action_space` with `= env.single_action_space` in the docs