### PR TITLE
IPPO Complex Spaces & Bug Fixes

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -286,18 +286,20 @@ class EvolvableAlgorithm(ABC, metaclass=RegistryMeta):
             return tuple(
                 EvolvableAlgorithm.get_state_dim(space) for space in observation_space
             )
-        elif isinstance(observation_space, spaces.Discrete):
-            return (observation_space.n,)
-        elif isinstance(observation_space, spaces.MultiDiscrete):
-            return (sum(observation_space.nvec),)
-        elif isinstance(observation_space, spaces.Box):
-            return observation_space.shape
         elif isinstance(observation_space, spaces.Dict):
             assert_supported_space(observation_space)
             return {
                 key: EvolvableAlgorithm.get_state_dim(subspace)
                 for key, subspace in observation_space.spaces.items()
             }
+        elif isinstance(observation_space, spaces.Discrete):
+            return (observation_space.n,)
+        elif isinstance(observation_space, spaces.MultiDiscrete):
+            return (sum(observation_space.nvec),)
+        elif isinstance(observation_space, spaces.Box):
+            return observation_space.shape
+        elif isinstance(observation_space, spaces.MultiBinary):
+            return (observation_space.n,)
         else:
             raise AttributeError(
                 f"Can't access state dimensions for {type(observation_space)} spaces."
@@ -1197,7 +1199,7 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
         )
 
         # For continuous action spaces, store the min and max action values
-        if not self.discrete_actions:
+        if all(isinstance(space, spaces.Box) for space in action_spaces):
             self.min_action = [
                 np.array(space.low).astype(np.float32) for space in action_spaces
             ]

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -1423,7 +1423,6 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
         """
         output_dict = {}
         for unique_id in self.shared_agent_ids:
-            print(unique_id, homo_outputs[unique_id].shape, vect_dim)
             homo_outputs[unique_id] = np.reshape(
                 homo_outputs[unique_id],
                 (len(self.homogeneous_agents[unique_id]), vect_dim, -1),

--- a/agilerl/algorithms/dqn.py
+++ b/agilerl/algorithms/dqn.py
@@ -230,6 +230,8 @@ class DQN(RLAlgorithm):
             if isinstance(torch_obs, dict):
                 sample = next(iter(torch_obs.values()))
                 batch_size = sample.size(0)
+            elif isinstance(torch_obs, tuple):
+                batch_size = torch_obs[0].size(0)
             else:
                 batch_size = torch_obs.size(0)
 

--- a/agilerl/algorithms/ippo.py
+++ b/agilerl/algorithms/ippo.py
@@ -271,6 +271,7 @@ class IPPO(MultiAgentRLAlgorithm):
 
                 # Create one actor and critic per inhomogeneous (unique) type of agent,
                 # which will be used by all homogeneous (identical) agents of that type
+                print("Net config", net_config)
                 actor = StochasticActor(
                     obs_space,
                     action_space,

--- a/agilerl/algorithms/ippo.py
+++ b/agilerl/algorithms/ippo.py
@@ -27,12 +27,15 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     concatenate_experiences_into_batches,
+    concatenate_tensors,
     contains_image_space,
     get_experiences_samples,
+    get_vect_dim,
     key_in_nested_dict,
     make_safe_deepcopies,
     obs_channels_to_first,
     preprocess_observation,
+    stack_experiences,
     vectorize_experiences_by_agent,
 )
 
@@ -271,7 +274,6 @@ class IPPO(MultiAgentRLAlgorithm):
 
                 # Create one actor and critic per inhomogeneous (unique) type of agent,
                 # which will be used by all homogeneous (identical) agents of that type
-                print("Net config", net_config)
                 actor = StochasticActor(
                     obs_space,
                     action_space,
@@ -339,11 +341,7 @@ class IPPO(MultiAgentRLAlgorithm):
         action_masks = {homo_id: [] for homo_id in self.shared_agent_ids}
         for agent_id, info in infos.items():
             if isinstance(info, dict):
-                homo_id = (
-                    agent_id.rsplit("_", 1)[0]
-                    if isinstance(agent_id, str)
-                    else agent_id
-                )
+                homo_id = self.get_homo_id(agent_id)
                 action_masks[homo_id].append(
                     info.get("action_mask", None) if isinstance(info, dict) else None
                 )
@@ -376,9 +374,7 @@ class IPPO(MultiAgentRLAlgorithm):
         """
         preprocessed = {homo_id: [] for homo_id in self.shared_agent_ids}
         for agent_id, obs in observation.items():
-            homo_id = (
-                agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
-            )
+            homo_id = self.get_homo_id(agent_id)
             preprocessed[homo_id].append(
                 preprocess_observation(
                     observation=obs,
@@ -388,7 +384,7 @@ class IPPO(MultiAgentRLAlgorithm):
                 )
             )
         for homo_id in self.shared_agent_ids:
-            preprocessed[homo_id] = torch.cat(preprocessed[homo_id], dim=0)
+            preprocessed[homo_id] = concatenate_tensors(preprocessed[homo_id])
 
         return preprocessed
 
@@ -419,11 +415,9 @@ class IPPO(MultiAgentRLAlgorithm):
         infos: Optional[InfosDict] = None,
     ) -> Tuple[ArrayDict, ArrayDict]:
         """Returns the next action to take in the environment.
-        Epsilon is the probability of taking a random action, used for exploration.
-        For epsilon-greedy behaviour, set epsilon to 0.
 
         :param obs: Environment observations: {'agent_0': state_dim_0, ..., 'agent_n': state_dim_n}
-        :type obs: Dict[str, numpy.Array]
+        :type obs: Dict[str, numpy.Array | Dict[str, numpy.Array] | Tuple[numpy.Array, ...]]
         :param infos: Information dictionary returned by env.step(actions)
         :type infos: Dict[str, Dict[str, ...]]
         :return: Tuple of actions for each agent
@@ -435,12 +429,7 @@ class IPPO(MultiAgentRLAlgorithm):
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
 
-        first_obs_shape = list(obs.values())[0].shape
-        vect_dim = (
-            first_obs_shape[0]
-            if len(first_obs_shape) > len(self.observation_spaces[0].shape)
-            else 1
-        )
+        vect_dim = get_vect_dim(obs, self.observation_space)
 
         # Preprocess observations
         preprocessed = self.preprocess_observation(obs)
@@ -451,7 +440,7 @@ class IPPO(MultiAgentRLAlgorithm):
         action_logprob_dict = {}
         dist_entropy_dict = {}
         state_values_dict = {}
-        for idx, (agent_id, obs, action_mask, actor, critic) in enumerate(
+        for idx, (shared_id, obs, action_mask, actor, critic) in enumerate(
             zip(
                 shared_agent_ids,
                 preprocessed_states,
@@ -466,10 +455,20 @@ class IPPO(MultiAgentRLAlgorithm):
                 action, log_prob, entropy = actor(obs, action_mask=action_mask)
                 state_values = critic(obs).squeeze(-1)
 
-            action_dict[agent_id] = action.cpu().data.numpy()
-            action_logprob_dict[agent_id] = log_prob.cpu().data.numpy()
-            dist_entropy_dict[agent_id] = entropy.cpu().data.numpy()
-            state_values_dict[agent_id] = state_values.cpu().data.numpy()
+            # Clip to action space during inference
+            agent_id = self.homogeneous_agents[shared_id][0]
+            agent_space = self.action_space[agent_id]
+            action = action.cpu().data.numpy()
+            if not self.training and isinstance(agent_space, spaces.Box):
+                if actor.squash_output:
+                    action = actor.scale_action(action)
+                else:
+                    action = np.clip(action, agent_space.low, agent_space.high)
+
+            action_dict[shared_id] = action
+            action_logprob_dict[shared_id] = log_prob.cpu().data.numpy()
+            dist_entropy_dict[shared_id] = entropy.cpu().data.numpy()
+            state_values_dict[shared_id] = state_values.cpu().data.numpy()
 
         action_dict = self.disassemble_homogeneous_outputs(action_dict, vect_dim)
 
@@ -487,28 +486,20 @@ class IPPO(MultiAgentRLAlgorithm):
             self.disassemble_homogeneous_outputs(state_values_dict, vect_dim),
         )
 
-    def assemble_shared_inputs(
-        self, input: Dict[str, np.ndarray]
-    ) -> Dict[str, TorchObsType]:
+    def assemble_shared_inputs(self, input: ExperiencesType) -> ExperiencesType:
         """Preprocesses inputs by constructing dictionaries by shared agents
 
         :param input: input to reshape from environment
-        :type input: numpy.ndarray[float] or dict[str, numpy.ndarray[float]]
+        :type ExperiencesType
 
         :return: Preprocessed inputs
-        :rtype: torch.Tensor[float] or dict[str, torch.Tensor[float]] or Tuple[torch.Tensor[float], ...]
+        :rtype: ExperiencesType
         """
         shared = {homo_id: {} for homo_id in self.shared_agent_ids}
         for agent_id, inp in input.items():
-            homo_id = (
-                agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
-            )
-            shared[homo_id][agent_id] = inp
-        for agent_id, inp in input.items():
-            homo_id = (
-                agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
-            )
-            shared[homo_id][agent_id] = np.stack(shared[homo_id][agent_id])
+            homo_id = self.get_homo_id(agent_id)
+            shared[homo_id][agent_id] = stack_experiences(inp, to_torch=False)[0]
+
         return shared
 
     def learn(self, experiences: ExperiencesType) -> TensorDict:
@@ -664,8 +655,8 @@ class IPPO(MultiAgentRLAlgorithm):
             values = values.reshape((-1,))
             returns = advantages + values
 
-        states = concatenate_experiences_into_batches(states, obs_space.shape)
-        actions = concatenate_experiences_into_batches(actions, action_space.shape)
+        states = concatenate_experiences_into_batches(states, obs_space)
+        actions = concatenate_experiences_into_batches(actions, action_space)
         log_probs = log_probs.reshape((-1,))
         experiences = (states, actions, log_probs, advantages, returns, values)
 
@@ -795,6 +786,7 @@ class IPPO(MultiAgentRLAlgorithm):
         :rtype: float
         """
         self.set_training_mode(False)
+
         with torch.no_grad():
             rewards = []
             if hasattr(env, "num_envs"):

--- a/agilerl/algorithms/td3.py
+++ b/agilerl/algorithms/td3.py
@@ -16,7 +16,7 @@ from agilerl.modules.configs import MlpNetConfig
 from agilerl.networks.actors import DeterministicActor
 from agilerl.networks.base import EvolvableNetwork
 from agilerl.networks.q_networks import ContinuousQNetwork
-from agilerl.typing import ArrayOrTensor, ExperiencesType, GymEnvType, NumpyObsType
+from agilerl.typing import ExperiencesType, GymEnvType, NumpyObsType
 from agilerl.utils.algo_utils import (
     make_safe_deepcopies,
     obs_channels_to_first,
@@ -83,10 +83,12 @@ class TD3(RLAlgorithm):
     :type wrap: bool, optional
     """
 
+    action_space: spaces.Box
+
     def __init__(
         self,
         observation_space: spaces.Space,
-        action_space: spaces.Space,
+        action_space: spaces.Box,
         O_U_noise: bool = True,
         vect_noise_dim: int = 1,
         expl_noise: float = 0.1,
@@ -341,17 +343,16 @@ class TD3(RLAlgorithm):
 
         return torch.max(torch.min(input, max), min)
 
-    def get_action(self, obs: NumpyObsType, training: bool = True) -> ArrayOrTensor:
-        """Returns the next action to take in the environment.
-        Epsilon is the probability of taking a random action, used for exploration.
-        For epsilon-greedy behaviour, set epsilon to 0.
+    def get_action(self, obs: NumpyObsType, training: bool = True) -> np.ndarray:
+        """Returns the next action to take in the environment. If training, random noise
+        is added to the action to promote exploration.
 
         :param obs: Environment observation, or multiple observations in a batch
         :type obs: numpy.ndarray[float], dict, tuple
         :param training: Agent is training, use exploration noise, defaults to True
         :type training: bool, optional
         :return: Action
-        :rtype: numpy.ndarray[float], torch.Tensor
+        :rtype: numpy.ndarray[float]
         """
         obs = self.preprocess_observation(obs)
 
@@ -359,13 +360,13 @@ class TD3(RLAlgorithm):
         with torch.no_grad():
             action = self.actor(obs)
 
+        action = action.cpu().data.numpy()
+
         self.actor.train()
         if training:
-            action = (action.cpu().data.numpy() + self.action_noise()).clip(
-                self.min_action, self.max_action
-            )
+            action += self.action_noise()
 
-        return action
+        return action.clip(self.action_space.low, self.action_space.high)
 
     def action_noise(self) -> np.ndarray:
         """Create action noise for exploration, either Ornstein Uhlenbeck or

--- a/agilerl/networks/distributions.py
+++ b/agilerl/networks/distributions.py
@@ -340,8 +340,9 @@ class EvolvableDistribution(EvolvableWrapper):
         # deviation (log_std) of the action distribution
         if isinstance(action_space, spaces.Box):
             self.log_std = torch.nn.Parameter(
-                torch.ones(1, np.prod(action_space.shape)) * action_std_init
-            ).to(device)
+                torch.ones(1, np.prod(action_space.shape), device=device)
+                * action_std_init
+            )
 
     @property
     def net_config(self) -> ConfigType:

--- a/agilerl/training/train_multi_agent_on_policy.py
+++ b/agilerl/training/train_multi_agent_on_policy.py
@@ -255,15 +255,17 @@ def train_multi_agent_on_policy(
                         agent_space = agent.action_space[agent_id]
                         if isinstance(agent_space, spaces.Box):
                             if agent.actors[actor_idx].squash_output:
-                                agent_action = agent.actors[actor_idx].scale_action(
-                                    agent_action
-                                )
+                                clipped_agent_action = agent.actors[
+                                    actor_idx
+                                ].scale_action(agent_action)
                             else:
-                                agent_action = np.clip(
+                                clipped_agent_action = np.clip(
                                     agent_action, agent_space.low, agent_space.high
                                 )
+                        else:
+                            clipped_agent_action = agent_action
 
-                        clipped_action[agent_id] = agent_action
+                        clipped_action[agent_id] = clipped_agent_action
 
                     # Act in environment
                     next_obs, reward, termination, truncation, info = env.step(

--- a/agilerl/training/train_multi_agent_on_policy.py
+++ b/agilerl/training/train_multi_agent_on_policy.py
@@ -6,11 +6,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import gymnasium as gym
 import numpy as np
-import wandb
 from accelerate import Accelerator
+from gymnasium import spaces
 from tqdm import trange
 
-from agilerl.algorithms.core.base import MultiAgentRLAlgorithm
+import wandb
+from agilerl.algorithms import IPPO
 from agilerl.hpo.mutation import Mutations
 from agilerl.hpo.tournament import TournamentSelection
 from agilerl.utils.algo_utils import obs_channels_to_first
@@ -21,7 +22,8 @@ from agilerl.utils.utils import (
 )
 
 InitDictType = Optional[Dict[str, Any]]
-PopulationType = List[MultiAgentRLAlgorithm]
+MultiAgentOnPolicyAlgorithms = IPPO
+PopulationType = List[MultiAgentOnPolicyAlgorithms]
 
 
 def train_multi_agent_on_policy(
@@ -201,6 +203,8 @@ def train_multi_agent_on_policy(
         pop_episode_scores = []
         pop_fps = []
         for agent_idx, agent in enumerate(pop):  # Loop through population
+            agent.set_training_mode(True)
+
             obs, info = env.reset()  # Reset environment at start of episode
             scores = (
                 np.zeros((num_envs, 1))
@@ -243,8 +247,28 @@ def train_multi_agent_on_policy(
                         entropy = {agent: ent[0] for agent, ent in entropy.items()}
                         value = {agent: val[0] for agent, val in value.items()}
 
+                    # Clip to action space
+                    clipped_action = {}
+                    for agent_id, agent_action in action.items():
+                        shared_id = agent.get_homo_id(agent_id)
+                        actor_idx = agent.shared_agent_ids.index(shared_id)
+                        agent_space = agent.action_space[agent_id]
+                        if isinstance(agent_space, spaces.Box):
+                            if agent.actors[actor_idx].squash_output:
+                                agent_action = agent.actors[actor_idx].scale_action(
+                                    agent_action
+                                )
+                            else:
+                                agent_action = np.clip(
+                                    agent_action, agent_space.low, agent_space.high
+                                )
+
+                        clipped_action[agent_id] = agent_action
+
                     # Act in environment
-                    next_obs, reward, termination, truncation, info = env.step(action)
+                    next_obs, reward, termination, truncation, info = env.step(
+                        clipped_action
+                    )
                     score_increment = (
                         (
                             np.sum(
@@ -301,8 +325,6 @@ def train_multi_agent_on_policy(
                             if not is_vectorised:
                                 obs, info = env.reset()
 
-                    pbar.update(num_envs)
-
                 experiences = (
                     states,
                     actions,
@@ -325,6 +347,7 @@ def train_multi_agent_on_policy(
                     )
 
             agent.steps[-1] += steps
+            pbar.update(evo_steps // len(pop))
             fps = steps / (time.time() - start_time)
             pop_fps.append(fps)
             pop_episode_scores.append(completed_episode_scores)

--- a/agilerl/training/train_on_policy.py
+++ b/agilerl/training/train_on_policy.py
@@ -5,11 +5,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import gymnasium as gym
 import numpy as np
-import wandb
 from accelerate import Accelerator
+from gymnasium import spaces
 from tqdm import trange
 
-from agilerl.algorithms.core.base import RLAlgorithm
+import wandb
+from agilerl.algorithms import PPO
 from agilerl.hpo.mutation import Mutations
 from agilerl.hpo.tournament import TournamentSelection
 from agilerl.utils.algo_utils import obs_channels_to_first
@@ -20,7 +21,8 @@ from agilerl.utils.utils import (
 )
 
 InitDictType = Optional[Dict[str, Any]]
-PopulationType = List[RLAlgorithm]
+OnPolicyAlgorithms = PPO
+PopulationType = List[OnPolicyAlgorithms]
 
 
 def train_on_policy(
@@ -200,13 +202,14 @@ def train_on_policy(
         pop_episode_scores = []
         pop_fps = []
         for agent_idx, agent in enumerate(pop):  # Loop through population
+            agent.set_training_mode(True)
+
             state, info = env.reset()  # Reset environment at start of episode
             scores = np.zeros(num_envs)
             completed_episode_scores = []
             steps = 0
             start_time = time.time()
             for _ in range(-(evo_steps // -agent.learn_step)):
-
                 states = []
                 actions = []
                 log_probs = []
@@ -235,8 +238,19 @@ def train_on_policy(
                     # Store entropy value
                     pop_entropy[agent_idx].append(entropy)
 
+                    # Clip to action space
+                    if isinstance(agent.action_space, spaces.Box):
+                        if agent.actor.squash_output:
+                            clipped_action = agent.actor.scale_action(action)
+                        else:
+                            clipped_action = np.clip(
+                                action, agent.action_space.low, agent.action_space.high
+                            )
+                    else:
+                        clipped_action = action
+
                     # Act in environment
-                    next_state, reward, term, trunc, info = env.step(action)
+                    next_state, reward, term, trunc, info = env.step(clipped_action)
                     next_done = np.logical_or(term, trunc).astype(np.int8)
 
                     total_steps += num_envs

--- a/agilerl/typing.py
+++ b/agilerl/typing.py
@@ -26,7 +26,12 @@ ArrayTuple = Tuple[ArrayLike, ...]
 NetConfigType = Dict[str, Any]
 KernelSizeType = Union[int, Tuple[int, ...]]
 SupportedGymSpaces = Union[
-    spaces.Box, spaces.Discrete, spaces.MultiDiscrete, spaces.Dict, spaces.Tuple
+    spaces.Box,
+    spaces.Discrete,
+    spaces.MultiDiscrete,
+    spaces.Dict,
+    spaces.Tuple,
+    spaces.MultiBinary,
 ]
 GymSpaceType = Union[SupportedGymSpaces, List[SupportedGymSpaces]]
 GymEnvType = Union[str, gym.Env, gym.vector.VectorEnv]

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -27,8 +27,8 @@ from agilerl.protocols import (
     OptimizerWrapper,
 )
 from agilerl.typing import (
-    ArrayDict,
     ArrayOrTensor,
+    ExperiencesType,
     MaybeObsList,
     NetworkType,
     NumpyObsType,
@@ -489,27 +489,59 @@ def obs_to_tensor(
 
 
 def maybe_add_batch_dim(
-    obs: TorchObsType, space_shape: Tuple[int, ...]
-) -> TorchObsType:
+    obs: ObservationType, space_shape: Tuple[int, ...]
+) -> ObservationType:
     """Adds batch dimension if necessary.
 
     :param obs: Observation tensor
-    :type obs: torch.Tensor[float]
+    :type obs: ObservationType
     :param space_shape: Observation space shape
     :type space_shape: Tuple[int, ...]
     :return: Observation tensor with batch dimension
-    :rtype: torch.Tensor[float]
+    :rtype: ObservationType
     """
-    if obs.dim() == len(space_shape):
-        obs = obs.unsqueeze(0)
-    elif obs.dim() == len(space_shape) + 2:
-        obs = obs.view(-1, *space_shape)
-    elif obs.dim() != len(space_shape) + 1:
+    if len(obs.shape) == len(space_shape):
+        if isinstance(obs, np.ndarray):
+            obs = np.expand_dims(obs, 0)
+        else:
+            obs = obs.unsqueeze(0)
+    elif len(obs.shape) == len(space_shape) + 2:
+        if isinstance(obs, np.ndarray):
+            obs = obs.reshape(-1, *space_shape)
+        else:
+            obs = obs.view(-1, *space_shape)
+    elif len(obs.shape) != len(space_shape) + 1:
         raise ValueError(
             f"Expected observation to have {len(space_shape) + 1} dimensions, got {obs.dim()}."
         )
 
     return obs
+
+
+def get_vect_dim(observation: NumpyObsType, observation_space: spaces.Space) -> int:
+    """Returns the number of vectorized environments given an observation and
+    its corresponding space.
+
+    :param observation: Observation
+    :type observation: NumpyObsType
+    :param observation_space: Observation space
+    :type observation_space: spaces.Space
+    :return: Number of vectorized environments
+    """
+    if isinstance(observation_space, spaces.Dict):
+        first_key, first_obs = next(iter(observation.items()))
+        return get_vect_dim(first_obs, observation_space[first_key])
+    elif isinstance(observation_space, spaces.Tuple):
+        return get_vect_dim(observation[0], observation_space[0])
+    elif isinstance(observation_space, spaces.MultiBinary):
+        return (
+            observation.shape[0]
+            if len(observation.shape) > observation_space.shape
+            else 1
+        )
+    else:
+        array_shape = observation.shape
+        return array_shape[0] if len(array_shape) > len(observation_space.shape) else 1
 
 
 def preprocess_observation(
@@ -583,6 +615,10 @@ def preprocess_observation(
         space_shape = (observation_space.n,)
 
     elif isinstance(observation_space, spaces.MultiDiscrete):
+        # Need to add batch dimension prior to splitting
+        space_shape = (sum(observation_space.nvec),)
+        observation: torch.Tensor = maybe_add_batch_dim(observation, space_shape)
+
         # Tensor concatenation of one hot encodings of each Categorical sub-space
         observation = torch.cat(
             [
@@ -593,7 +629,6 @@ def preprocess_observation(
             ],
             dim=-1,
         )
-        space_shape = (sum(observation_space.nvec),)
     elif isinstance(observation_space, spaces.MultiBinary):
         observation = observation.float()
         space_shape = (observation_space.n,)
@@ -675,7 +710,7 @@ def get_experiences_samples(
 
 def stack_experiences(
     *experiences: MaybeObsList, to_torch: bool = True
-) -> Tuple[ArrayOrTensor, ...]:
+) -> Tuple[ObservationType, ...]:
     """Stacks experiences into a single array or tensor.
 
     :param experiences: Experiences to stack
@@ -721,7 +756,7 @@ def stack_experiences(
             stacked_exp = tuple(stacked_exp)
 
         elif isinstance(exp[0], (np.ndarray, Number)):
-            stacked_exp = np.array(exp)
+            stacked_exp = np.stack(exp)
             if to_torch:
                 stacked_exp = torch.from_numpy(stacked_exp)
 
@@ -910,8 +945,8 @@ def remove_nested_files(files: str) -> None:
 
 
 def vectorize_experiences_by_agent(
-    experiences: ArrayDict, dim: int = 1
-) -> torch.Tensor:
+    experiences: ExperiencesType, dim: int = 1
+) -> Union[torch.Tensor, Dict[str, torch.Tensor], Tuple[torch.Tensor, ...]]:
     """Reorganizes experiences into a tensor, vectorized by time step
 
     Example input:
@@ -920,22 +955,118 @@ def vectorize_experiences_by_agent(
     torch.Tensor([[1, 2, 3, 4, 5, 6, 7, 8]])
 
     :param experiences: Dictionaries containing experiences indexed by agent_id that share a policy agent.
-    :type experiences: Tuple[Dict[str, np.ndarray]]
+    :type experiences: ExperiencesType
     :param dim: New dimension to stack along
     :type dim: int
-    :return: Tensor of experiences, stacked along provided dimension
-    :rtype: torch.Tensor
+    :return: Tensor, dict of tensors, or tuple of tensors of experiences, stacked along provided dimension
+    :rtype: Union[torch.Tensor, Dict[str, torch.Tensor], Tuple[torch.Tensor, ...]]
     """
-    tensors = [
-        torch.Tensor(np.array(experiences[agent_id])) for agent_id in experiences.keys()
-    ]
-    stacked_tensor = torch.stack(tensors, dim=dim)
-    return stacked_tensor
+    if not experiences:
+        return torch.tensor([])
+
+    # Get a sample value to determine the type
+    sample_value = next(iter(experiences.values()))
+
+    if isinstance(sample_value, dict):
+        # Handle dictionary observations
+        keys = sample_value.keys()
+        return {
+            k: vectorize_experiences_by_agent(
+                {agent_id: experiences[agent_id][k] for agent_id in experiences},
+                dim=dim,
+            )
+            for k in keys
+        }
+    elif isinstance(sample_value, tuple):
+        # Handle tuple observations
+        tuple_length = len(sample_value)
+        return tuple(
+            vectorize_experiences_by_agent(
+                {agent_id: experiences[agent_id][i] for agent_id in experiences},
+                dim=dim,
+            )
+            for i in range(tuple_length)
+        )
+    else:
+        # Original implementation for array/tensor observations
+        tensors = [
+            torch.Tensor(np.array(experiences[agent_id]))
+            for agent_id in experiences.keys()
+        ]
+        stacked_tensor = torch.stack(tensors, dim=dim)
+        return stacked_tensor
+
+
+def experience_to_tensors(experience: dict | tuple | np.ndarray) -> TorchObsType:
+    """Convert experience to numpy array
+
+    :param experience: Experience to convert
+    :type experience: dict | tuple | np.ndarray
+    :return: Numpy array of experience
+    :rtype: np.ndarray
+    """
+    if isinstance(experience, dict):
+        return {key: experience_to_tensors(value) for key, value in experience.items()}
+    elif isinstance(experience, tuple):
+        return tuple(experience_to_tensors(exp) for exp in experience)
+    else:
+        array = np.array(experience)
+
+        # Ensure expreience has a batch dimension
+        array = maybe_add_batch_dim(array, (1,))
+        return torch.from_numpy(array)
+
+
+def concatenate_tensors(tensors: List[TorchObsType]) -> TorchObsType:
+    """Concatenate tensors along first dimension
+
+    :param tensors: List of tensors to concatenate
+    :type tensors: List[TorchObsType]
+    :return: Concatenated tensor
+    :rtype: TorchObsType
+    """
+    if isinstance(tensors[0], dict):
+        return {
+            key: concatenate_tensors([t[key] for t in tensors])
+            for key in tensors[0].keys()
+        }
+    elif isinstance(tensors[0], tuple):
+        return tuple(
+            concatenate_tensors([t[i] for t in tensors]) for i in range(len(tensors[0]))
+        )
+    else:
+        return torch.cat(tensors, dim=0)
+
+
+def reshape_from_space(tensor: TorchObsType, space: spaces.Space) -> TorchObsType:
+    """Reshape tensor from space
+
+    :param tensor: Tensor to reshape
+    :type tensor: TorchObsType
+    :param space: Space to reshape tensor to
+    :type space: spaces.Space
+    :return: Reshaped tensor
+    :rtype: TorchObsType
+    """
+    if isinstance(tensor, dict):
+        return {
+            key: reshape_from_space(value, space[key]) for key, value in tensor.items()
+        }
+    elif isinstance(tensor, tuple):
+        return tuple(
+            reshape_from_space(value, space[i]) for i, value in enumerate(tensor)
+        )
+    else:
+        reshaped: torch.Tensor = tensor.reshape(-1, *space.shape)
+        for squeeze_dim in [0, -1]:
+            if reshaped.size(squeeze_dim) == 1:
+                reshaped = reshaped.squeeze(squeeze_dim)
+        return reshaped
 
 
 def concatenate_experiences_into_batches(
-    experiences: ArrayDict, shape: Tuple[int]
-) -> torch.Tensor:
+    experiences: ExperiencesType, space: spaces.Space
+) -> TorchObsType:
     """Reorganizes experiences into a batched tensor
 
     Example input:
@@ -946,21 +1077,16 @@ def concatenate_experiences_into_batches(
     torch.Tensor([...1], [...2], [...3], [...4], [...5], [...6], [...7], [...8])
 
     :param experiences: Dictionaries containing experiences indexed by agent_id that share a policy agent.
-    :type experiences: Dict[str, np.ndarray]
-    :param shape: Observation/action/etc shape space to maintain
-    :type obs_space: Tuple[int]
-    :return: Tensor of experiences, stacked along first dimension, with shape (num_experiences, *shape)
-    :rtype: torch.Tensor
+    :type experiences: ExperiencesType
+    :param space: Observation/action/etc space to maintain
+    :type space: spaces.Space
+    :return: Tensor, dict of tensors, or tuple of tensors of experiences, stacked along first dimension, with shape (num_experiences, *shape)
+    :rtype: Union[torch.Tensor, Dict[str, torch.Tensor], Tuple[torch.Tensor, ...]]
     """
     tensors = []
     for agent_id in experiences.keys():
-        exp = np.array(experiences[agent_id])
-        if len(exp.shape) < 2:
-            exp = np.expand_dims(exp, 0)
-        tensors.append(torch.Tensor(exp))
-    stacked_tensor = torch.cat(tensors, dim=0)
-    stacked_tensor = stacked_tensor.reshape(-1, *shape)
-    for squeeze_dim in [0, -1]:
-        if stacked_tensor.size(squeeze_dim) == 1:
-            stacked_tensor = stacked_tensor.squeeze(squeeze_dim)
-    return stacked_tensor
+        exp = experience_to_tensors(experiences[agent_id])
+        tensors.append(exp)
+
+    stacked_tensor = concatenate_tensors(tensors)
+    return reshape_from_space(stacked_tensor, space)

--- a/benchmarking/benchmarking_on_policy.py
+++ b/benchmarking/benchmarking_on_policy.py
@@ -107,7 +107,6 @@ def main(INIT_HP, MUTATION_PARAMS, NET_CONFIG, use_net=False):
         device=device,
     )
 
-    print("Actor network: ", agent_pop[0].actor)
     trained_pop, pop_fitnesses = train_on_policy(
         env,
         INIT_HP["ENV_NAME"],

--- a/configs/training/multi_agent/ippo.yaml
+++ b/configs/training/multi_agent/ippo.yaml
@@ -22,11 +22,11 @@ INIT_HP:
     UPDATE_EPOCHS: 4           # Number of policy update epochs
     TOURN_SIZE: 2              # Tournament size
     ELITISM: true              # Elitism in tournament selection
-    POP_SIZE: 4                # Population size
+    POP_SIZE: 1                # Population size
     EVO_STEPS: 10_000          # Evolution frequency
     EVAL_STEPS:                # Evaluation steps
     EVAL_LOOP: 1               # Evaluation episodes
-    WANDB: true                # Log with Weights and Biases
+    WANDB: false                # Log with Weights and Biases
     TORCH_COMPILE: default
 
 

--- a/configs/training/multi_agent/ippo.yaml
+++ b/configs/training/multi_agent/ippo.yaml
@@ -26,7 +26,7 @@ INIT_HP:
     EVO_STEPS: 10_000          # Evolution frequency
     EVAL_STEPS:                # Evaluation steps
     EVAL_LOOP: 1               # Evaluation episodes
-    WANDB: false                # Log with Weights and Biases
+    WANDB: true                # Log with Weights and Biases
     TORCH_COMPILE: default
 
 

--- a/configs/training/ppo/ppo.yaml
+++ b/configs/training/ppo/ppo.yaml
@@ -1,13 +1,13 @@
 ---
 # Define initial hyperparameters
 INIT_HP:
-    ENV_NAME: LunarLanderContinuous-v3   # Gym environment name
+    ENV_NAME: LunarLander-v3   # Gym environment name
     ALGO: PPO                  # Algorithm
     # Swap image channels dimension from last to first [H, W, C] -> [C, H, W]
     CHANNELS_LAST: false
     NUM_ENVS: 16               # No. parallel environments for training
     BATCH_SIZE: 128             # Batch size
-    LR: 0.0003                  # Learning rate
+    LR: 0.001                  # Learning rate
     LEARN_STEP: 2048           # Learning frequency
     MAX_STEPS: 2_000_000       # Max no. steps
     TARGET_SCORE: 250.         # Early training stop at avg score of last 100 episodes
@@ -22,7 +22,7 @@ INIT_HP:
     UPDATE_EPOCHS: 4           # Number of policy update epochs
     TOURN_SIZE: 2              # Tournament size
     ELITISM: true              # Elitism in tournament selection
-    POP_SIZE: 1                # Population size
+    POP_SIZE: 4                # Population size
     EVO_STEPS: 10_240          # Evolution frequency
     EVAL_STEPS:                # Evaluation steps
     EVAL_LOOP: 1               # Evaluation episodes

--- a/configs/training/td3.yaml
+++ b/configs/training/td3.yaml
@@ -1,7 +1,7 @@
 ---
 # Define initial hyperparameters
 INIT_HP:
-    ENV_NAME: LunarLanderContinuous-v2   # Gym environment name
+    ENV_NAME: LunarLanderContinuous-v3   # Gym environment name
     ALGO: TD3                            # Algorithm
     # Swap image channels dimension from last to first [H, W, C] -> [C, H, W]
     CHANNELS_LAST: false

--- a/docs/api/algorithms/ddpg.rst
+++ b/docs/api/algorithms/ddpg.rst
@@ -40,7 +40,7 @@ Example
 
   # Create environment and Experience Replay Buffer
   num_envs = 1
-  env = make_vect_envs('LunarLanderContinuous-v2', num_envs=num_envs)
+  env = make_vect_envs('LunarLanderContinuous-v3', num_envs=num_envs)
   observation_space = env.observation_space
   action_space = env.action_space
 

--- a/docs/api/algorithms/ippo.rst
+++ b/docs/api/algorithms/ippo.rst
@@ -154,8 +154,22 @@ Example Training Loop
                 # Get next action from agent
                 action, log_prob, _, value = agent.get_action(obs=state, infos=info)
 
+                # Clip to action space
+                clipped_action = {}
+                for agent_id, agent_action in action.items():
+                    shared_id = agent.get_homo_id(agent_id)
+                    actor_idx = agent.shared_agent_ids.index(shared_id)
+                    agent_space = agent.action_space[agent_id]
+                    if isinstance(agent_space, spaces.Box):
+                        if agent.actors[actor_idx].squash_output:
+                            agent_action = agent.actors[actor_idx].scale_action(agent_action)
+                        else:
+                            agent_action = np.clip(agent_action, agent_space.low, agent_space.high)
+
+                    clipped_action[agent_id] = agent_action
+
                 # Act in environment
-                next_state, reward, termination, truncation, info = env.step(action)
+                next_state, reward, termination, truncation, info = env.step(clipped_action)
                 scores += np.array(list(reward.values())).transpose()
 
                 steps += num_envs

--- a/docs/api/algorithms/ippo.rst
+++ b/docs/api/algorithms/ippo.rst
@@ -162,11 +162,13 @@ Example Training Loop
                     agent_space = agent.action_space[agent_id]
                     if isinstance(agent_space, spaces.Box):
                         if agent.actors[actor_idx].squash_output:
-                            agent_action = agent.actors[actor_idx].scale_action(agent_action)
+                            clipped_agent_action = agent.actors[actor_idx].scale_action(agent_action)
                         else:
-                            agent_action = np.clip(agent_action, agent_space.low, agent_space.high)
+                            clipped_agent_action = np.clip(agent_action, agent_space.low, agent_space.high)
+                    else:
+                        clipped_agent_action = agent_action
 
-                    clipped_action[agent_id] = agent_action
+                    clipped_action[agent_id] = clipped_agent_action
 
                 # Act in environment
                 next_state, reward, termination, truncation, info = env.step(clipped_action)

--- a/docs/api/algorithms/td3.rst
+++ b/docs/api/algorithms/td3.rst
@@ -41,7 +41,7 @@ Example
 
   # Create environment and Experience Replay Buffer
   num_envs = 1
-  env = make_vect_envs('LunarLanderContinuous-v2', num_envs=num_envs)
+  env = make_vect_envs('LunarLanderContinuous-v3', num_envs=num_envs)
   observation_space = env.observation_space
   action_space = env.action_space
 

--- a/docs/tutorials/gymnasium/agilerl_ppo_tutorial.rst
+++ b/docs/tutorials/gymnasium/agilerl_ppo_tutorial.rst
@@ -293,6 +293,15 @@ function and is an example of how we might choose to make use of a population of
                     # Get next action from agent
                     action, log_prob, _, value = agent.get_action(state)
 
+                    # Clip to action space
+                    if isinstance(agent.action_space, spaces.Box):
+                        if agent.actor.squash_output:
+                            clipped_action = agent.actor.scale_action(action)
+                        else:
+                            clipped_action = np.clip(action, agent.action_space.low, agent.action_space.high)
+                    else:
+                        clipped_action = action
+
                     # Act in environment
                     next_state, reward, terminated, truncated, info = env.step(action)
                     next_done = np.logical_or(terminated, truncated).astype(np.int8)

--- a/docs/tutorials/gymnasium/agilerl_td3_tutorial.rst
+++ b/docs/tutorials/gymnasium/agilerl_td3_tutorial.rst
@@ -134,7 +134,7 @@ used with continuous action environments.
 
     # Create vectorized environment
     num_envs = 8
-    env = make_vect_envs("LunarLanderContinuous-v2", num_envs=num_envs)  # Create environment
+    env = make_vect_envs("LunarLanderContinuous-v3", num_envs=num_envs)  # Create environment
 
     observation_space = env.single_observation_space
     action_space = env.single_action_space
@@ -276,7 +276,7 @@ fitnesses (fitness is each agents test scores on the environment).
 
     trained_pop, pop_fitnesses = train_off_policy(
         env=env,
-        env_name="LunarLanderContinuous-v2",
+        env_name="LunarLanderContinuous-v3",
         algo="TD3",
         pop=pop,
         memory=memory,
@@ -441,7 +441,7 @@ Test loop for inference
 ~~~~~~~~~~~~~~~~~~~~~~~
 .. code-block:: python
 
-    test_env = gym.make("LunarLanderContinuous-v2", render_mode="rgb_array")
+    test_env = gym.make("LunarLanderContinuous-v3", render_mode="rgb_array")
     rewards = []
     frames = []
     testing_eps = 7

--- a/docs/tutorials/skills/index.rst
+++ b/docs/tutorials/skills/index.rst
@@ -228,7 +228,7 @@ Once the skills have been defined, training agents to solve them is very straigh
       }
 
       INIT_HP = {
-         "ENV_NAME": "LunarLander-v2",
+         "ENV_NAME": "LunarLander-v3",
          "ALGO": "PPO",
          "POPULATION_SIZE": 1,  # Population size
          "BATCH_SIZE": 128,  # Batch size
@@ -416,6 +416,15 @@ Finally, we can run the training loop for the selector agent. Each skill agent's
                for idx_step in range(500):
                   # Get next action from agent
                   action, log_prob, _, value = agent.get_action(state)
+
+                  # Clip to action space
+                  if isinstance(agent.action_space, spaces.Box):
+                      if agent.actor.squash_output:
+                          clipped_action = agent.actor.scale_action(action)
+                      else:
+                          clipped_action = np.clip(action, agent.action_space.low, agent.action_space.high)
+                  else:
+                      clipped_action = action
 
                   # Internal loop to execute trained skill
                   skill_agent = trained_skills[action[0]]["agent"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agilerl"
-version = "2.2.3"
+version = "2.2.2"
 
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = ["Nick Ustaran-Anderegg <dev@agilerl.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agilerl"
-version = "2.2.1"
+version = "2.2.3"
 
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = ["Nick Ustaran-Anderegg <dev@agilerl.com>"]

--- a/tests/test_algorithms/test_ddpg.py
+++ b/tests/test_algorithms/test_ddpg.py
@@ -18,7 +18,13 @@ from agilerl.modules.mlp import EvolvableMLP
 from agilerl.networks.actors import DeterministicActor
 from agilerl.networks.q_networks import ContinuousQNetwork
 from agilerl.wrappers.make_evolvable import MakeEvolvable
-from tests.helper_functions import generate_discrete_space, generate_random_box_space
+from tests.helper_functions import (
+    generate_dict_or_tuple_space,
+    generate_discrete_space,
+    generate_multidiscrete_space,
+    generate_random_box_space,
+    get_sample_from_space,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -398,25 +404,34 @@ def test_initialize_ddpg_with_actor_network_no_critic(
     assert isinstance(ddpg.criterion, nn.MSELoss)
 
 
-# Returns the expected action when given a state observation and epsilon=0 or 1.
-def test_returns_expected_action_training():
+@pytest.mark.parametrize(
+    "observation_space",
+    [
+        generate_discrete_space(4),
+        generate_random_box_space(shape=(4,)),
+        generate_multidiscrete_space(2, 2),
+        generate_dict_or_tuple_space(2, 2, dict_space=True),
+        generate_dict_or_tuple_space(2, 2, dict_space=False),
+    ],
+)
+def test_returns_expected_action_training(observation_space):
     accelerator = Accelerator()
-    observation_space = generate_discrete_space(4)
     action_space = generate_random_box_space(shape=(2,), low=-1, high=1)
 
     ddpg = DDPG(observation_space, action_space)
-    state = np.array([0, 1, 2, 3])
+    state = get_sample_from_space(observation_space)
 
+    print(state)
     training = False
     action = ddpg.get_action(state, training)[0]
 
     assert len(action) == action_space.shape[0]
     for act in action:
-        assert isinstance(act, torch.Tensor)
+        assert isinstance(act, np.float32)
         assert -1 <= act <= 1
 
     ddpg = DDPG(observation_space, action_space, accelerator=accelerator)
-    state = np.array([1])
+    state = get_sample_from_space(observation_space)
     training = True
     action = ddpg.get_action(state, training)[0]
 
@@ -428,7 +443,7 @@ def test_returns_expected_action_training():
     ddpg = DDPG(
         observation_space, action_space, O_U_noise=False, accelerator=accelerator
     )
-    state = np.array([1])
+    state = get_sample_from_space(observation_space)
     training = True
     action = ddpg.get_action(state, training)[0]
 

--- a/tests/test_algorithms/test_ppo.py
+++ b/tests/test_algorithms/test_ppo.py
@@ -1223,18 +1223,17 @@ def test_save_load_checkpoint_correct_data_and_format_cnn_network(
 
 
 @pytest.mark.parametrize(
-    "device, accelerator",
-    [
-        ("cpu", None),
-        ("cpu", Accelerator()),
-    ],
+    "device", ["cpu", torch.device("cuda" if torch.cuda.is_available() else "cpu")]
 )
+@pytest.mark.parametrize("accelerator", [None, Accelerator()])
 # The saved checkpoint file contains the correct data and format.
 def test_load_from_pretrained(device, accelerator, tmpdir):
     # Initialize the ppo agent
     ppo = PPO(
         observation_space=generate_random_box_space(shape=(4,), low=0, high=1),
         action_space=generate_random_box_space(shape=(2,), low=0, high=1),
+        device=device,
+        accelerator=accelerator,
     )
 
     # Save the checkpoint to a file
@@ -1251,8 +1250,8 @@ def test_load_from_pretrained(device, accelerator, tmpdir):
     assert isinstance(new_ppo.actor.encoder, EvolvableMLP)
     assert isinstance(new_ppo.critic.encoder, EvolvableMLP)
     assert new_ppo.lr == ppo.lr
-    assert str(new_ppo.actor.to("cpu").state_dict()) == str(ppo.actor.state_dict())
-    assert str(new_ppo.critic.to("cpu").state_dict()) == str(ppo.critic.state_dict())
+    assert str(new_ppo.actor.state_dict()) == str(ppo.actor.state_dict())
+    assert str(new_ppo.critic.state_dict()) == str(ppo.critic.state_dict())
     assert new_ppo.batch_size == ppo.batch_size
     assert new_ppo.gamma == ppo.gamma
     assert new_ppo.mut == ppo.mut
@@ -1263,12 +1262,9 @@ def test_load_from_pretrained(device, accelerator, tmpdir):
 
 
 @pytest.mark.parametrize(
-    "device, accelerator",
-    [
-        ("cpu", None),
-        ("cpu", Accelerator()),
-    ],
+    "device", ["cpu", torch.device("cuda" if torch.cuda.is_available() else "cpu")]
 )
+@pytest.mark.parametrize("accelerator", [None, Accelerator()])
 # The saved checkpoint file contains the correct data and format.
 def test_load_from_pretrained_cnn(device, accelerator, tmpdir):
     # Initialize the ppo agent
@@ -1282,6 +1278,8 @@ def test_load_from_pretrained_cnn(device, accelerator, tmpdir):
                 "stride_size": [1],
             }
         },
+        device=device,
+        accelerator=accelerator,
     )
 
     # Save the checkpoint to a file
@@ -1298,8 +1296,8 @@ def test_load_from_pretrained_cnn(device, accelerator, tmpdir):
     assert isinstance(new_ppo.actor.encoder, EvolvableCNN)
     assert isinstance(new_ppo.critic.encoder, EvolvableCNN)
     assert new_ppo.lr == ppo.lr
-    assert str(new_ppo.actor.to("cpu").state_dict()) == str(ppo.actor.state_dict())
-    assert str(new_ppo.critic.to("cpu").state_dict()) == str(ppo.critic.state_dict())
+    assert str(new_ppo.actor.state_dict()) == str(ppo.actor.state_dict())
+    assert str(new_ppo.critic.state_dict()) == str(ppo.critic.state_dict())
     assert new_ppo.batch_size == ppo.batch_size
     assert new_ppo.gamma == ppo.gamma
     assert new_ppo.mut == ppo.mut

--- a/tests/test_train/test_train.py
+++ b/tests/test_train/test_train.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 import torch
 from accelerate import Accelerator
-from gymnasium.spaces import Box, Discrete
+from gymnasium.spaces import Box, Dict, Discrete
 from pettingzoo import ParallelEnv
 from tensordict import TensorDict
 
@@ -50,6 +50,7 @@ class DummyEnv:
     def __init__(self, state_size, action_size, vect=True, num_envs=2):
         self.state_size = state_size
         self.action_size = action_size
+        self.action_space = Discrete(action_size)
         self.vect = vect
         if self.vect:
             self.state_size = (num_envs,) + self.state_size
@@ -95,6 +96,7 @@ class DummyAgentOffPolicy:
         self.action_size = env.action_size
         self.action_dim = env.action_size
         self.batch_size = batch_size
+        self.training = True
         self.beta = beta
         self.learn_step = 1
         self.scores = []
@@ -102,6 +104,9 @@ class DummyAgentOffPolicy:
         self.fitness = []
         self.mut = "mutation"
         self.index = 1
+
+    def set_training_mode(self, training):
+        self.training = training
 
     def get_action(self, *args, **kwargs):
         return np.random.rand(self.action_size)
@@ -139,6 +144,11 @@ class DummyAgentOnPolicy(DummyAgentOffPolicy):
     def __init__(self, batch_size, env):
         super().__init__(batch_size, env)
         self.learn_step = 128
+        self.action_space = Box(0, 1, (1,))
+        self.actor = MagicMock()
+        self.actor.squash_output = False
+        self.actor.scale_action = lambda x: x
+        self.actor.action_space = self.action_space
 
     def learn(self, *args, **kwargs):
         return random.random()
@@ -254,6 +264,20 @@ class DummyMultiAgent(DummyAgentOffPolicy):
         self.discrete_actions = False
         self.num_envs = 1
         self.on_policy = on_policy
+        self.actors = [MagicMock() for _ in range(2)]
+        self.actors[0].squash_output = False
+        self.actors[0].scale_action = lambda x: x
+        self.actors[1].squash_output = False
+        self.actors[1].scale_action = lambda x: x
+        self.action_space = Dict(
+            {
+                "agent_0": Discrete(2),
+                "other_agent_0": Discrete(2),
+            }
+        )
+
+    def get_homo_id(self, agent_id: str) -> str:
+        return agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
 
     def get_action(self, *args, **kwargs):
         output_dict = {
@@ -652,6 +676,7 @@ def mocked_agent_on_policy(env, algo):
     mock_agent.batch_size = 5
     mock_agent.state_size = env.state_size
     mock_agent.action_size = env.action_size
+    mock_agent.action_space = env.action_space
     mock_agent.beta = 0.4
     mock_agent.scores = []
     mock_agent.steps = [0]
@@ -716,6 +741,15 @@ def mocked_multi_agent(multi_env, algo):
     mock_agent.mut = "mutation"
     mock_agent.index = 1
     mock_agent.discrete_actions = False
+    mock_agent.action_space = Dict(
+        {
+            "agent_0": multi_env.action_space("agent_0"),
+            "other_agent_0": multi_env.action_space("other_agent_0"),
+        }
+    )
+    mock_agent.get_homo_id.side_effect = lambda x: (
+        x.rsplit("_", 1)[0] if isinstance(x, str) else x
+    )
 
     def get_action(*args, **kwargs):
         out = {


### PR DESCRIPTION
- Issue with training DQN on `spaces.Tuple` observations.
- Issue with training on `spaces.MultiBinary` observations generally.
- TD3 and DDPG `get_action()` was returning `torch.Tensor`'s instead of `np.ndarray`.
- Add support for complex spaces in `IPPO`.
- Clip actions in single and multi-agent on-policy training loops.
- Test for all observation spaces `get_action()`
- Bug fix `StochasticActor` with log_std not being saved in state_dict()