### PR TITLE
added support for the Conv1D & added tests

### DIFF
--- a/agilerl/utils/evolvable_networks.py
+++ b/agilerl/utils/evolvable_networks.py
@@ -189,13 +189,13 @@ def get_conv_layer(
     :return: Convolutional layer
     :rtype: nn.Module
     """
-    if conv_layer_name not in ["Conv2d", "Conv3d"]:
+    if conv_layer_name not in ["Conv1d", "Conv2d", "Conv3d"]:
         raise ValueError(
-            f"Invalid convolutional layer {conv_layer_name}. Must be one of 'Conv2d', 'Conv3d'."
+            f"Invalid convolutional layer {conv_layer_name}. Must be one of 'Conv1d', 'Conv2d', 'Conv3d'."
         )
 
     convolutional_layers = {
-        # "1d": nn.Conv1d,
+        "1d": nn.Conv1d,
         "2d": nn.Conv2d,
         "3d": nn.Conv3d,
     }


### PR DESCRIPTION

**Description:**

This pull request introduces support for 1D Convolutional Neural Networks (Conv1D) within the `EvolvableCNN` module, enabling its use with sequential or time-series data.

**Motivation:**

The `EvolvableCNN` was previously limited to 2D/3D convolutions. Adding `Conv1D` expands its versatility to a broader range of RL input types.

**Key Changes:**

*   **`EvolvableCNN` (`agilerl/modules/cnn.py`):**
    *   `BlockType` now includes `"Conv1d"`.
    *   Updated kernel size handling (`_assert_correct_kernel_sizes`, `MutableKernelSizes`) for 1D kernels (e.g., `(length,)`).
    *   Input shape for `Conv1d` is now `(channels, length)`, with sample input as `(batch, channels, length)`.
    *   `forward` method correctly handles dimensions for `Conv1d`.
    *   Architectural mutation logic (`add_layer`) adapted for 1D operations.
*   **Utilities (`agilerl/utils/evolvable_networks.py`):**
    *   `get_conv_layer` now supports `"Conv1d"`.
*   **Testing (`tests/test_modules/test_cnn.py`):**
    *   Added new tests specifically for `Conv1D` instantiation, forward pass, architectural mutations, and cloning.

**Impact on Users:**

*   Specify `block_type="Conv1d"` and use `input_shape=(num_channels, sequence_length)` when creating `EvolvableCNN` for 1D data.
*   Architectural mutations now correctly operate on `Conv1d` layers.

**Testing:**

*   Unit tests added to `tests/test_modules/test_cnn.py` to validate `Conv1d` functionality.
