### PR TITLE
Fix NeuralUCB tutorial: add missing replay buffer usage and correct plot label

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/tutorials/Bandits/agilerl_neural_ucb.py
+++ b/tutorials/Bandits/agilerl_neural_ucb.py
@@ -103,6 +103,9 @@ if __name__ == "__main__":
                 transition = transition.unsqueeze(0)
                 transition.batch_size = [1]
 
+                # Save experience to replay buffer
+                memory.add(transition)
+
                 # Learn according to learning frequency
                 if len(memory) >= agent.batch_size:
                     for _ in range(agent.learn_step):
@@ -141,7 +144,7 @@ if __name__ == "__main__":
         plt.plot(
             np.linspace(0, total_steps, len(agent_regret)),
             agent_regret,
-            label=f"NeuralTS: Agent {i}",
+            label=f"NeuralUCB: Agent {i}",
         )
     plt.xlabel("Training Step")
     plt.ylabel("Regret")
@@ -155,7 +158,7 @@ if __name__ == "__main__":
         plt.plot(
             np.linspace(0, total_steps, len(smoothed_score)),
             smoothed_score,
-            label=f"NeuralTS: Agent {i}",
+            label=f"NeuralUCB: Agent {i}",
         )
     plt.xlabel("Training Step")
     plt.ylabel("Reward")


### PR DESCRIPTION
### Summary

This PR fixes two issues in the official `NeuralUCB` tutorial example using the IRIS dataset:

1. **Replay buffer not used**:
   - The original training loop lacked the code to add transitions to the replay buffer.
   - This meant the agent was attempting to learn without ever storing experiences, rendering training ineffective.

2. **Incorrect plot label**:
   - In the regret and reward plot generation, the label was incorrectly set as `"NeuralTS"` instead of `"NeuralUCB"`.
   - This has been corrected to reflect the actual algorithm being run.

### Impact

- Enables proper experience collection and learning for the NeuralUCB agent.
- Corrects misleading labeling in visualizations, improving clarity and consistency.

### Notes

- The tutorial now functions as expected, and the generated plots reflect valid learning behavior.
- Changes tested and confirmed with `agilerl`'s IRIS bandit environment.
