### PR TITLE
Tests Refactoring & Optimizations

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -1299,7 +1299,7 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
         preprocessed = {}
         for agent_id, agent_obs in observation.items():
             preprocessed[agent_id] = preprocess_observation(
-                self.observation_space.get(agent_id),
+                self.possible_observation_spaces.get(agent_id),
                 observation=agent_obs,
                 device=self.device,
                 normalize_images=self.normalize_images,

--- a/agilerl/modules/cnn.py
+++ b/agilerl/modules/cnn.py
@@ -313,12 +313,12 @@ class EvolvableCNN(EvolvableModule):
         self.max_channel_size = max_channel_size
         self.layer_norm = layer_norm
         self.init_layers = init_layers
-        self.sample_input = sample_input
+        self.sample_input = sample_input.to(device)
         self.name = name
         self.mut_kernel_size = MutableKernelSizes(
             sizes=kernel_size,
             cnn_block_type=block_type,
-            sample_input=sample_input,
+            sample_input=self.sample_input,
             rng=self.rng,
         )
 
@@ -327,7 +327,7 @@ class EvolvableCNN(EvolvableModule):
             channel_size=channel_size,
             kernel_size=self.mut_kernel_size.sizes,
             stride_size=stride_size,
-            sample_input=sample_input,
+            sample_input=self.sample_input,
         )
 
     @property

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,38 @@
+[tool:pytest]
+# Performance optimizations
+addopts =
+    # Reduce output verbosity for faster execution
+    -q
+    # Show failures immediately
+    --tb=short
+    # Disable warnings by default (can re-enable with -W)
+    --disable-warnings
+    # Use faster assertion introspection
+    --assert=plain
+    # Reduce memory usage
+    --maxfail=3
+    # Show progress
+    --show-capture=no
+
+# Test discovery optimization
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Markers to organize tests by speed
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    gpu: marks tests that require GPU
+    unit: marks unit tests
+    integration: marks integration tests
+
+# Filter warnings to reduce noise
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
+    ignore::UserWarning:gym.*
+    ignore::UserWarning:gymnasium.*
+
+# Minimum version requirement
+minversion = 6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,144 @@ import gc
 
 import pytest
 import torch
+import torch.nn as nn
+from gymnasium import spaces
+
+from tests.helper_functions import (
+    gen_multi_agent_dict_or_tuple_spaces,
+    generate_dict_or_tuple_space,
+    generate_discrete_space,
+    generate_multi_agent_box_spaces,
+    generate_multi_agent_discrete_spaces,
+    generate_multi_agent_multidiscrete_spaces,
+    generate_multidiscrete_space,
+    generate_random_box_space,
+)
 
 
-@pytest.fixture(autouse=True)
+# Only clear CUDA cache when actually needed
+@pytest.fixture(autouse=True, scope="function")
 def cleanup():
     yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
-    gc.collect()  # Collect garbage
+    # Only clear CUDA cache if CUDA was actually used
+    if torch.cuda.is_available() and torch.cuda.is_initialized():
+        torch.cuda.empty_cache()
+    # Only collect garbage periodically, not after every test
+    if hasattr(cleanup, "call_count"):
+        cleanup.call_count += 1
+    else:
+        cleanup.call_count = 1
+
+    # Only run garbage collection every 10 tests
+    if cleanup.call_count % 10 == 0:
+        gc.collect()
+
+
+# Shared device fixture to avoid repeated device checks
+@pytest.fixture(scope="session")
+def device():
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+# Common observation spaces (session-scoped for reuse)
+@pytest.fixture(scope="session")
+def vector_space():
+    return generate_random_box_space(shape=(4,))
+
+
+@pytest.fixture(scope="session")
+def discrete_space():
+    return generate_discrete_space(2)
+
+
+@pytest.fixture(scope="session")
+def dict_space():
+    return generate_dict_or_tuple_space(2, 2, dict_space=True)
+
+
+@pytest.fixture(scope="session")
+def multidiscrete_space():
+    return generate_multidiscrete_space(2, 2)
+
+
+@pytest.fixture(scope="session")
+def multibinary_space():
+    return spaces.MultiBinary(4)
+
+
+@pytest.fixture(scope="session")
+def image_space():
+    return generate_random_box_space(shape=(3, 32, 32), low=0, high=255)
+
+
+# Common multi-agent spaces
+@pytest.fixture(scope="session")
+def ma_vector_space():
+    return generate_multi_agent_box_spaces(3, (6,))
+
+
+@pytest.fixture(scope="session")
+def ma_discrete_space():
+    return generate_multi_agent_discrete_spaces(3, 2)
+
+
+@pytest.fixture(scope="session")
+def ma_multidiscrete_space():
+    return generate_multi_agent_multidiscrete_spaces(3, 2)
+
+
+@pytest.fixture(scope="session")
+def ma_multibinary_space():
+    return [spaces.MultiBinary(2) for _ in range(3)]
+
+
+@pytest.fixture(scope="session")
+def ma_image_space():
+    return generate_multi_agent_box_spaces(3, (3, 32, 32), low=0, high=255)
+
+
+@pytest.fixture(scope="session")
+def ma_dict_space():
+    return gen_multi_agent_dict_or_tuple_spaces(3, 2, 2, dict_space=True)
+
+
+# Simple network fixtures (function-scoped to avoid state issues)
+@pytest.fixture(scope="function")
+def simple_mlp():
+    return nn.Sequential(
+        nn.Linear(4, 20),
+        nn.ReLU(),
+        nn.Linear(20, 10),
+        nn.ReLU(),
+        nn.Linear(10, 2),
+        nn.Softmax(dim=-1),
+    )
+
+
+@pytest.fixture(scope="function")
+def simple_mlp_critic():
+    return nn.Sequential(
+        nn.Linear(6, 20),
+        nn.ReLU(),
+        nn.Linear(20, 10),
+        nn.ReLU(),
+        nn.Linear(10, 1),
+        nn.Tanh(),
+    )
+
+
+@pytest.fixture(scope="function")
+def simple_cnn():
+    return nn.Sequential(
+        nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1),
+        nn.ReLU(),
+        nn.MaxPool2d(kernel_size=2, stride=2),
+        nn.Conv2d(16, 32, kernel_size=3, stride=1, padding=1),
+        nn.ReLU(),
+        nn.MaxPool2d(kernel_size=2, stride=2),
+        nn.Flatten(),
+        nn.Linear(32 * 8 * 8, 128),
+        nn.ReLU(),
+        nn.Linear(128, 2),
+        nn.Softmax(dim=-1),
+    )

--- a/tests/test_algorithms/test_cqn.py
+++ b/tests/test_algorithms/test_cqn.py
@@ -1,7 +1,5 @@
 import copy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -14,18 +12,7 @@ from gymnasium import spaces
 from agilerl.algorithms.cqn import CQN
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.wrappers.make_evolvable import MakeEvolvable
-from tests.helper_functions import (
-    assert_not_equal_state_dict,
-    assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_random_box_space,
-)
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
+from tests.helper_functions import assert_not_equal_state_dict, assert_state_dicts_equal
 
 
 class DummyCQN(CQN):
@@ -59,7 +46,7 @@ class DummyEnv:
         )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def simple_mlp():
     network = nn.Sequential(
         nn.Linear(4, 20),
@@ -72,7 +59,7 @@ def simple_mlp():
     return network
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def simple_cnn():
     network = nn.Sequential(
         nn.Conv2d(
@@ -97,15 +84,16 @@ def simple_cnn():
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
+        ("multidiscrete_space", EvolvableMLP),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_cqn(observation_space, encoder_cls, accelerator):
+def test_initialize_cqn(observation_space, encoder_cls, accelerator, request):
     action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     cqn = CQN(observation_space, action_space, accelerator=accelerator)
 
     expected_device = accelerator.device if accelerator else "cpu"
@@ -135,9 +123,9 @@ def test_initialize_cqn(observation_space, encoder_cls, accelerator):
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
         (
-            spaces.Box(0, 255, shape=(3, 32, 32)),
+            "image_space",
             "simple_cnn",
             torch.randn(1, 3, 64, 64),
         ),
@@ -147,6 +135,7 @@ def test_initialize_cqn_with_make_evo(
     observation_space, actor_network, input_tensor, request
 ):
     action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
@@ -173,12 +162,15 @@ def test_initialize_cqn_with_make_evo(
 @pytest.mark.parametrize(
     "observation_space, net_type",
     [
-        (spaces.Box(0, 1, shape=(4,)), "mlp"),
-        (spaces.Box(0, 255, shape=(3, 32, 32)), "cnn"),
+        ("vector_space", "mlp"),
+        ("image_space", "cnn"),
     ],
 )
-def test_initialize_cqn_with_actor_network_evo_net(observation_space, net_type):
+def test_initialize_cqn_with_actor_network_evo_net(
+    observation_space, net_type, request
+):
     action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     if net_type == "mlp":
         actor_network = EvolvableMLP(
             num_inputs=observation_space.shape[0],
@@ -216,13 +208,12 @@ def test_initialize_cqn_with_actor_network_evo_net(observation_space, net_type):
     assert isinstance(cqn.criterion, nn.MSELoss)
 
 
-def test_init_with_incorrect_actor_net():
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_init_with_incorrect_actor_net(vector_space):
     action_space = spaces.Discrete(2)
     actor_network = "String"
 
     with pytest.raises(TypeError) as e:
-        cqn = CQN(observation_space, action_space, actor_network=actor_network)
+        cqn = CQN(vector_space, action_space, actor_network=actor_network)
         assert cqn
         assert (
             e
@@ -231,11 +222,10 @@ def test_init_with_incorrect_actor_net():
 
 
 # Returns the expected action when given a state observation and epsilon=0 or 1.
-def test_returns_expected_action_epsilon_greedy():
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_returns_expected_action_epsilon_greedy(vector_space):
     action_space = spaces.Discrete(2)
 
-    cqn = CQN(observation_space, action_space)
+    cqn = CQN(vector_space, action_space)
     state = np.array([1, 2, 3, 4])
 
     action_mask = None
@@ -254,13 +244,12 @@ def test_returns_expected_action_epsilon_greedy():
 
 
 # Returns the expected action when given a state observation and action mask.
-def test_returns_expected_action_mask():
+def test_returns_expected_action_mask(vector_space):
     accelerator = Accelerator()
-    observation_space = spaces.Discrete(4)
     action_space = spaces.Discrete(2)
 
-    cqn = CQN(observation_space, action_space, accelerator=accelerator)
-    state = np.array([1])
+    cqn = CQN(vector_space, action_space, accelerator=accelerator)
+    state = np.array([1, 2, 3, 4])
 
     action_mask = np.array([0, 1])
 
@@ -278,19 +267,18 @@ def test_returns_expected_action_mask():
 
 
 # learns from experiences and updates network parameters
-def test_learns_from_experiences():
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_learns_from_experiences(vector_space):
     action_space = spaces.Discrete(2)
     batch_size = 64
 
     # Create an instance of the cqn class
-    cqn = CQN(observation_space, action_space, batch_size=batch_size)
+    cqn = CQN(vector_space, action_space, batch_size=batch_size)
 
     # Create a batch of experiences
-    states = torch.randn(batch_size, observation_space.shape[0])
+    states = torch.randn(batch_size, vector_space.shape[0])
     actions = torch.randint(0, action_space.n, (batch_size, 1))
     rewards = torch.randn((batch_size, 1))
-    next_states = torch.randn(batch_size, observation_space.shape[0])
+    next_states = torch.randn(batch_size, vector_space.shape[0])
     dones = torch.randint(0, 2, (batch_size, 1))
 
     experiences = [states, actions, rewards, next_states, dones]
@@ -313,16 +301,15 @@ def test_learns_from_experiences():
 
 
 # handles double Q-learning
-def test_handles_double_q_learning():
+def test_handles_double_q_learning(discrete_space):
     accelerator = Accelerator()
-    observation_space = spaces.Discrete(4)
     action_space = spaces.Discrete(2)
     double = True
     batch_size = 64
 
     # Create an instance of the cqn class
     cqn = CQN(
-        observation_space,
+        discrete_space,
         action_space,
         double=double,
         batch_size=batch_size,
@@ -330,10 +317,10 @@ def test_handles_double_q_learning():
     )
 
     # Create a batch of experiences
-    states = torch.randint(0, observation_space.n, (batch_size, 1))
+    states = torch.randint(0, discrete_space.n, (batch_size, 1))
     actions = torch.randint(0, action_space.n, (batch_size, 1))
     rewards = torch.randn((batch_size, 1))
-    next_states = torch.randint(0, observation_space.n, (batch_size, 1))
+    next_states = torch.randint(0, discrete_space.n, (batch_size, 1))
     dones = torch.randint(0, 2, (batch_size, 1))
 
     experiences = [states, actions, rewards, next_states, dones]
@@ -356,8 +343,7 @@ def test_handles_double_q_learning():
 
 
 # Updates target network parameters with soft update
-def test_soft_update():
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_soft_update(vector_space):
     action_space = spaces.Discrete(2)
     net_config = {"encoder_config": {"hidden_size": [64, 64]}}
     batch_size = 64
@@ -373,7 +359,7 @@ def test_soft_update():
     wrap = True
 
     cqn = CQN(
-        observation_space,
+        vector_space,
         action_space,
         net_config=net_config,
         batch_size=batch_size,
@@ -408,13 +394,13 @@ def test_soft_update():
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
+        "vector_space",
+        "image_space",
     ],
 )
 @pytest.mark.parametrize("num_envs", [1, 3])
-def test_algorithm_test_loop(observation_space, num_envs):
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_algorithm_test_loop(observation_space, num_envs, request):
+    observation_space = request.getfixturevalue(observation_space)
     action_space = spaces.Discrete(2)
 
     vect = num_envs > 1
@@ -428,14 +414,15 @@ def test_algorithm_test_loop(observation_space, num_envs):
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
+        "vector_space",
+        "image_space",
+        "dict_space",
+        "multidiscrete_space",
     ],
 )
-def test_clone_returns_identical_agent(observation_space):
+def test_clone_returns_identical_agent(observation_space, request):
     action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
 
     cqn = DummyCQN(observation_space, action_space)
     cqn.tensor_attribute = torch.randn(1)
@@ -517,259 +504,22 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.scores == cqn.scores
 
 
-def test_clone_new_index():
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_clone_new_index(vector_space):
     action_space = spaces.Discrete(2)
 
-    cqn = CQN(observation_space, action_space)
+    cqn = CQN(vector_space, action_space)
     clone_agent = cqn.clone(index=100)
 
     assert clone_agent.index == 100
 
 
 # The method successfully unwraps the actor and actor_target models when an accelerator is present.
-def test_unwrap_models():
+def test_unwrap_models(vector_space):
     cqn = CQN(
-        observation_space=spaces.Box(0, 1, shape=(4,)),
+        observation_space=vector_space,
         action_space=spaces.Discrete(2),
         accelerator=Accelerator(),
     )
     cqn.unwrap_models()
     assert isinstance(cqn.actor.encoder, nn.Module)
     assert isinstance(cqn.actor_target.encoder, nn.Module)
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    observation_space, encoder_cls, tmpdir
-):
-    # Initialize the cqn agent
-    cqn = CQN(observation_space=observation_space, action_space=spaces.Discrete(2))
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    cqn.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    cqn = CQN(observation_space=observation_space, action_space=spaces.Discrete(2))
-    # Load checkpoint
-    cqn.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(cqn.actor.encoder, encoder_cls)
-    assert isinstance(cqn.actor_target.encoder, encoder_cls)
-    assert cqn.lr == 1e-4
-    assert_state_dicts_equal(cqn.actor.state_dict(), cqn.actor_target.state_dict())
-    assert cqn.batch_size == 64
-    assert cqn.learn_step == 5
-    assert cqn.gamma == 0.99
-    assert cqn.tau == 1e-3
-    assert cqn.mut is None
-    assert cqn.index == 0
-    assert cqn.scores == []
-    assert cqn.fitness == []
-    assert cqn.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "actor_network, input_tensor",
-    [
-        ("simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_cnn_network(
-    actor_network, input_tensor, request, tmpdir
-):
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the cqn agent
-    cqn = CQN(
-        observation_space=spaces.Box(0, 255, shape=(3, 32, 32)),
-        action_space=spaces.Discrete(2),
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    cqn.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    cqn = CQN(
-        observation_space=spaces.Box(0, 1, shape=(4,)), action_space=spaces.Discrete(2)
-    )
-    # Load checkpoint
-    cqn.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(cqn.actor, nn.Module)
-    assert isinstance(cqn.actor_target, nn.Module)
-    assert cqn.lr == 1e-4
-    assert_state_dicts_equal(cqn.actor.state_dict(), cqn.actor_target.state_dict())
-    assert cqn.batch_size == 64
-    assert cqn.learn_step == 5
-    assert cqn.gamma == 0.99
-    assert cqn.tau == 1e-3
-    assert cqn.mut is None
-    assert cqn.index == 0
-    assert cqn.scores == []
-    assert cqn.fitness == []
-    assert cqn.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_load_from_pretrained(observation_space, encoder_cls, accelerator, tmpdir):
-    device = "cpu"
-
-    # Initialize the cqn agent
-    cqn = CQN(observation_space=observation_space, action_space=spaces.Discrete(2))
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    cqn.save_checkpoint(checkpoint_path)
-
-    checkpoint = torch.load(
-        checkpoint_path, map_location=device, pickle_module=dill, weights_only=False
-    )
-    assert "agilerl_version" in checkpoint
-
-    # Create new agent object
-    new_cqn = CQN.load(checkpoint_path, device=device, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_cqn.observation_space == cqn.observation_space
-    assert new_cqn.action_space == cqn.action_space
-    assert isinstance(new_cqn.actor.encoder, encoder_cls)
-    assert isinstance(new_cqn.actor_target.encoder, encoder_cls)
-    assert new_cqn.lr == cqn.lr
-    assert_state_dicts_equal(
-        new_cqn.actor.to("cpu").state_dict(), cqn.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_cqn.actor_target.to("cpu").state_dict(), cqn.actor_target.state_dict()
-    )
-    assert new_cqn.batch_size == cqn.batch_size
-    assert new_cqn.learn_step == cqn.learn_step
-    assert new_cqn.gamma == cqn.gamma
-    assert new_cqn.tau == cqn.tau
-    assert new_cqn.mut == cqn.mut
-    assert new_cqn.index == cqn.index
-    assert new_cqn.scores == cqn.scores
-    assert new_cqn.fitness == cqn.fitness
-    assert new_cqn.steps == cqn.steps
-
-
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (
-            spaces.Box(0, 255, shape=(3, 32, 32)),
-            "simple_cnn",
-            torch.randn(1, 3, 64, 64),
-        ),
-    ],
-)
-# The saved checkpoint file contains the correct data and format.
-def test_load_from_pretrained_make_evo(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = spaces.Discrete(2)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the cqn agent
-    cqn = CQN(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    cqn.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_cqn = CQN.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_cqn.observation_space == cqn.observation_space
-    assert new_cqn.action_space == cqn.action_space
-    assert isinstance(new_cqn.actor, nn.Module)
-    assert isinstance(new_cqn.actor_target, nn.Module)
-    assert new_cqn.lr == cqn.lr
-    assert_state_dicts_equal(
-        new_cqn.actor.to("cpu").state_dict(), cqn.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_cqn.actor_target.to("cpu").state_dict(), cqn.actor_target.state_dict()
-    )
-    assert new_cqn.batch_size == cqn.batch_size
-    assert new_cqn.learn_step == cqn.learn_step
-    assert new_cqn.gamma == cqn.gamma
-    assert new_cqn.tau == cqn.tau
-    assert new_cqn.mut == cqn.mut
-    assert new_cqn.index == cqn.index
-    assert new_cqn.scores == cqn.scores
-    assert new_cqn.fitness == cqn.fitness
-    assert new_cqn.steps == cqn.steps

--- a/tests/test_algorithms/test_dqn.py
+++ b/tests/test_algorithms/test_dqn.py
@@ -1,8 +1,5 @@
 import copy
-from copy import deepcopy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -10,7 +7,6 @@ import torch.nn as nn
 import torch.optim as optim
 from accelerate import Accelerator
 from accelerate.optimizer import AcceleratedOptimizer
-from gymnasium import spaces
 
 from agilerl.algorithms.dqn import DQN
 from agilerl.components.data import Transition
@@ -18,19 +14,11 @@ from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_discrete_space,
-    generate_multidiscrete_space,
-    generate_random_box_space,
     get_experiences_batch,
     get_sample_from_space,
 )
 
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
+# Cleanup fixture moved to conftest.py for better performance
 
 
 class DummyDQN(DQN):
@@ -64,53 +52,22 @@ class DummyEnv:
         )
 
 
-@pytest.fixture
-def simple_mlp():
-    network = nn.Sequential(
-        nn.Linear(4, 20),
-        nn.ReLU(),
-        nn.Linear(20, 10),
-        nn.ReLU(),
-        nn.Linear(10, 1),
-        nn.Tanh(),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_cnn():
-    network = nn.Sequential(
-        nn.Conv2d(
-            3, 16, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 3 (for RGB images), Output channels: 16
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Conv2d(
-            16, 32, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 16, Output channels: 32
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Flatten(),  # Flatten the 2D feature map to a 1D vector
-        nn.Linear(32 * 16 * 16, 128),  # Fully connected layer with 128 output features
-        nn.ReLU(),
-        nn.Linear(128, 1),  # Output layer with num_classes output features
-    )
-    return network
-
-
 # initialize DQN with valid parameters
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
+        ("multidiscrete_space", EvolvableMLP),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_dqn(observation_space, encoder_cls, accelerator):
-    action_space = generate_discrete_space(2)
+def test_initialize_dqn(
+    observation_space, encoder_cls, accelerator, discrete_space, request
+):
+    action_space = discrete_space
+    observation_space = request.getfixturevalue(observation_space)
     dqn = DQN(observation_space, action_space, accelerator=accelerator)
 
     expected_device = accelerator.device if accelerator else "cpu"
@@ -142,18 +99,19 @@ def test_initialize_dqn(observation_space, encoder_cls, accelerator):
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (generate_random_box_space(shape=(4,)), "simple_mlp", torch.randn(1, 4)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
         (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
+            "image_space",
             "simple_cnn",
-            torch.randn(1, 3, 64, 64),
+            torch.randn(1, 3, 32, 32),
         ),
     ],
 )
 def test_initialize_dqn_with_actor_network_make_evo(
-    observation_space, actor_network, input_tensor, request
+    observation_space, actor_network, input_tensor, request, discrete_space
 ):
-    action_space = generate_discrete_space(2)
+    action_space = discrete_space
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
@@ -181,12 +139,15 @@ def test_initialize_dqn_with_actor_network_make_evo(
 @pytest.mark.parametrize(
     "observation_space, net_type",
     [
-        (generate_random_box_space(shape=(4,)), "mlp"),
-        (generate_random_box_space(shape=(3, 64, 64), low=0, high=255), "cnn"),
+        ("vector_space", "mlp"),
+        ("image_space", "cnn"),
     ],
 )
-def test_initialize_dqn_with_actor_network_evo_net(observation_space, net_type):
-    action_space = generate_discrete_space(2)
+def test_initialize_dqn_with_actor_network_evo_net(
+    observation_space, net_type, discrete_space, request
+):
+    action_space = discrete_space
+    observation_space = request.getfixturevalue(observation_space)
     if net_type == "mlp":
         actor_network = EvolvableMLP(
             num_inputs=observation_space.shape[0],
@@ -225,13 +186,11 @@ def test_initialize_dqn_with_actor_network_evo_net(observation_space, net_type):
     assert isinstance(dqn.criterion, nn.MSELoss)
 
 
-def test_initialize_dqn_with_incorrect_actor_net_type():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_initialize_dqn_with_incorrect_actor_net_type(vector_space, discrete_space):
     actor_network = "dummy"
 
     with pytest.raises(TypeError) as a:
-        dqn = DQN(observation_space, action_space, actor_network=actor_network)
+        dqn = DQN(vector_space, discrete_space, actor_network=actor_network)
 
         assert dqn
         assert (
@@ -244,16 +203,18 @@ def test_initialize_dqn_with_incorrect_actor_net_type():
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_discrete_space(4),
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        generate_multidiscrete_space(2, 2),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
+        "vector_space",
+        "discrete_space",
+        "image_space",
+        "multidiscrete_space",
+        "dict_space",
     ],
 )
-def test_returns_expected_action_epsilon_greedy(observation_space):
-    action_space = generate_discrete_space(2)
+def test_returns_expected_action_epsilon_greedy(
+    observation_space, discrete_space, request
+):
+    action_space = discrete_space
+    observation_space = request.getfixturevalue(observation_space)
 
     dqn = DQN(observation_space, action_space)
     state = get_sample_from_space(observation_space)
@@ -274,13 +235,11 @@ def test_returns_expected_action_epsilon_greedy(observation_space):
 
 
 # Returns the expected action when given a state observation and action mask.
-def test_returns_expected_action_mask():
+def test_returns_expected_action_mask(vector_space, discrete_space):
     accelerator = Accelerator()
-    observation_space = spaces.Discrete(4)
-    action_space = generate_discrete_space(2)
 
-    dqn = DQN(observation_space, action_space, accelerator=accelerator)
-    state = get_sample_from_space(observation_space)
+    dqn = DQN(vector_space, discrete_space, accelerator=accelerator)
+    state = get_sample_from_space(vector_space)
 
     action_mask = np.array([0, 1])
 
@@ -297,13 +256,10 @@ def test_returns_expected_action_mask():
     assert action == 1
 
 
-def test_returns_expected_action_mask_vectorized():
+def test_returns_expected_action_mask_vectorized(vector_space, discrete_space):
     accelerator = Accelerator()
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
-
-    dqn = DQN(observation_space, action_space, accelerator=accelerator)
-    state = get_sample_from_space(observation_space, batch_size=2)
+    dqn = DQN(vector_space, discrete_space, accelerator=accelerator)
+    state = get_sample_from_space(vector_space, batch_size=2)
 
     action_mask = np.array([[0, 1], [1, 0]])
 
@@ -318,10 +274,8 @@ def test_returns_expected_action_mask_vectorized():
     assert np.array_equal(action, [1, 0])
 
 
-def test_dqn_optimizer_parameters():
-    observation_space = spaces.Box(low=0, high=1, shape=(4,), dtype=np.float32)
-    action_space = spaces.Discrete(2)
-    dqn = DQN(observation_space, action_space)
+def test_dqn_optimizer_parameters(vector_space, discrete_space):
+    dqn = DQN(vector_space, discrete_space)
 
     # Store initial parameters
     initial_params = {
@@ -352,17 +306,20 @@ def test_dqn_optimizer_parameters():
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_discrete_space(4),
-        generate_random_box_space(shape=(4,)),
-        generate_multidiscrete_space(2, 2),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
+        "vector_space",
+        "discrete_space",
+        "image_space",
+        "multidiscrete_space",
+        "dict_space",
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("double", [False, True])
-def test_learns_from_experiences(observation_space, accelerator, double):
-    action_space = generate_discrete_space(2)
+def test_learns_from_experiences(
+    observation_space, accelerator, double, discrete_space, request
+):
+    action_space = discrete_space
+    observation_space = request.getfixturevalue(observation_space)
     batch_size = 64
 
     # Create an instance of the DQN class
@@ -396,9 +353,7 @@ def test_learns_from_experiences(observation_space, accelerator, double):
 
 
 # Updates target network parameters with soft update
-def test_soft_update():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_soft_update(vector_space, discrete_space):
     net_config = {"encoder_config": {"hidden_size": [64, 64]}}
     batch_size = 64
     lr = 1e-4
@@ -413,8 +368,8 @@ def test_soft_update():
     wrap = True
 
     dqn = DQN(
-        observation_space,
-        action_space,
+        vector_space,
+        discrete_space,
         net_config=net_config,
         batch_size=batch_size,
         lr=lr,
@@ -445,45 +400,36 @@ def test_soft_update():
 
 
 # Runs algorithm test loop
-def test_algorithm_test_loop():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_algorithm_test_loop(vector_space, discrete_space):
     num_envs = 3
 
-    env = DummyEnv(observation_space=observation_space, vect=True, num_envs=num_envs)
+    env = DummyEnv(observation_space=vector_space, vect=True, num_envs=num_envs)
 
     # env = make_vect_envs("CartPole-v1", num_envs=num_envs)
-    agent = DQN(observation_space=observation_space, action_space=action_space)
+    agent = DQN(observation_space=vector_space, action_space=discrete_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
 
 # Runs algorithm test loop with unvectorised env
-def test_algorithm_test_loop_unvectorized():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
-
-    env = DummyEnv(observation_space=observation_space, vect=False)
-
-    agent = DQN(observation_space=observation_space, action_space=action_space)
+def test_algorithm_test_loop_unvectorized(vector_space, discrete_space):
+    env = DummyEnv(observation_space=vector_space, vect=False)
+    agent = DQN(observation_space=vector_space, action_space=discrete_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
 
 # Runs algorithm test loop with images
-def test_algorithm_test_loop_images():
-    observation_space = generate_random_box_space(shape=(3, 32, 32), low=0, high=255)
-    action_space = generate_discrete_space(2)
-
-    env = DummyEnv(observation_space=observation_space, vect=True)
+def test_algorithm_test_loop_images(image_space, discrete_space):
+    env = DummyEnv(observation_space=image_space, vect=True)
 
     net_config_cnn = {
         "encoder_config": {"channel_size": [3], "kernel_size": [3], "stride_size": [1]}
     }
 
     agent = DQN(
-        observation_space=observation_space,
-        action_space=action_space,
+        observation_space=image_space,
+        action_space=discrete_space,
         net_config=net_config_cnn,
     )
     mean_score = agent.test(env, max_steps=10)
@@ -491,31 +437,25 @@ def test_algorithm_test_loop_images():
 
 
 # Runs algorithm test loop with unvectorized images
-def test_algorithm_test_loop_images_unvectorized():
-    observation_space = spaces.Box(0, 1, shape=(32, 32, 3))
-    action_space = generate_discrete_space(2)
-
-    env = DummyEnv(observation_space=observation_space, vect=False)
+def test_algorithm_test_loop_images_unvectorized(image_space, discrete_space):
+    env = DummyEnv(observation_space=image_space, vect=False)
 
     net_config_cnn = {
         "encoder_config": {"channel_size": [3], "kernel_size": [3], "stride_size": [1]}
     }
 
     agent = DQN(
-        observation_space=generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        action_space=action_space,
+        observation_space=image_space,
+        action_space=discrete_space,
         net_config=net_config_cnn,
     )
-    mean_score = agent.test(env, max_steps=10, swap_channels=True)
+    mean_score = agent.test(env, max_steps=10, swap_channels=False)
     assert isinstance(mean_score, float)
 
 
 # Clones the agent and returns an identical agent.
-def test_clone_returns_identical_agent():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
-
-    dqn = DummyDQN(observation_space, action_space)
+def test_clone_returns_identical_agent(vector_space, discrete_space):
+    dqn = DummyDQN(vector_space, discrete_space)
     dqn.tensor_attribute = torch.randn(1)
     clone_agent = dqn.clone()
 
@@ -541,7 +481,7 @@ def test_clone_returns_identical_agent():
     assert clone_agent.tensor_test == dqn.tensor_test
 
     accelerator = Accelerator()
-    dqn = DQN(observation_space, action_space, accelerator=accelerator)
+    dqn = DQN(vector_space, discrete_space, accelerator=accelerator)
     clone_agent = dqn.clone()
 
     assert clone_agent.observation_space == dqn.observation_space
@@ -564,7 +504,7 @@ def test_clone_returns_identical_agent():
     assert clone_agent.scores == dqn.scores
 
     accelerator = Accelerator()
-    dqn = DQN(observation_space, action_space, accelerator=accelerator, wrap=False)
+    dqn = DQN(vector_space, discrete_space, accelerator=accelerator, wrap=False)
     clone_agent = dqn.clone(wrap=False)
 
     assert clone_agent.observation_space == dqn.observation_space
@@ -587,26 +527,21 @@ def test_clone_returns_identical_agent():
     assert clone_agent.scores == dqn.scores
 
 
-def test_clone_new_index():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
-
-    dqn = DummyDQN(observation_space, action_space)
+def test_clone_new_index(vector_space, discrete_space):
+    dqn = DummyDQN(vector_space, discrete_space)
     clone_agent = dqn.clone(index=100)
 
     assert clone_agent.index == 100
 
 
-def test_clone_after_learning():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_clone_after_learning(vector_space, discrete_space):
     batch_size = 8
-    dqn = DQN(observation_space, action_space)
+    dqn = DQN(vector_space, discrete_space)
 
-    states = torch.randn(batch_size, observation_space.shape[0])
+    states = torch.randn(batch_size, vector_space.shape[0])
     actions = torch.randint(0, 2, (batch_size, 1))
     rewards = torch.rand(batch_size, 1)
-    next_states = torch.randn(batch_size, observation_space.shape[0])
+    next_states = torch.randn(batch_size, vector_space.shape[0])
     dones = torch.zeros(batch_size, 1)
 
     experiences = Transition(
@@ -616,6 +551,7 @@ def test_clone_after_learning():
         next_obs=next_states,
         done=dones,
     ).to_tensordict()
+
     dqn.learn(experiences)
     clone_agent = dqn.clone()
 
@@ -639,258 +575,12 @@ def test_clone_after_learning():
 
 
 # The method successfully unwraps the actor and actor_target models when an accelerator is present.
-def test_unwrap_models():
+def test_unwrap_models(vector_space, discrete_space):
     dqn = DQN(
-        observation_space=generate_random_box_space(shape=(4,)),
-        action_space=generate_discrete_space(2),
+        observation_space=vector_space,
+        action_space=discrete_space,
         accelerator=Accelerator(),
     )
     dqn.unwrap_models()
     assert isinstance(dqn.actor, nn.Module)
     assert isinstance(dqn.actor_target, nn.Module)
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    observation_space, encoder_cls, tmpdir
-):
-    # Initialize the DQN agent
-    dqn = DQN(
-        observation_space=observation_space,
-        action_space=generate_discrete_space(2),
-    )
-
-    initial_actor_state_dict = deepcopy(dqn.actor.state_dict())
-    init_optim_state_dict = deepcopy(dqn.optimizer.state_dict())
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    dqn = DQN(
-        observation_space=generate_random_box_space(shape=(4,)),
-        action_space=generate_discrete_space(2),
-    )
-    # Load checkpoint
-    dqn.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(dqn.actor.encoder, encoder_cls)
-    assert isinstance(dqn.actor_target.encoder, encoder_cls)
-    assert dqn.lr == 1e-4
-    assert_state_dicts_equal(initial_actor_state_dict, dqn.actor.state_dict())
-    assert_state_dicts_equal(init_optim_state_dict, dqn.optimizer.state_dict())
-    assert dqn.batch_size == 64
-    assert dqn.learn_step == 5
-    assert dqn.gamma == 0.99
-    assert dqn.tau == 1e-3
-    assert dqn.mut is None
-    assert dqn.index == 0
-    assert dqn.scores == []
-    assert dqn.fitness == []
-    assert dqn.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future.
-@pytest.mark.parametrize(
-    "actor_network, input_tensor",
-    [
-        ("simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_cnn_network(
-    actor_network, input_tensor, request, tmpdir
-):
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the DQN agent
-    dqn = DQN(
-        observation_space=generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
-        action_space=generate_discrete_space(2),
-        actor_network=actor_network,
-    )
-
-    initial_actor_state_dict = deepcopy(dqn.actor.state_dict())
-    init_optim_state_dict = deepcopy(dqn.optimizer.state_dict())
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    dqn = DQN(
-        observation_space=generate_random_box_space(shape=(4,)),
-        action_space=generate_discrete_space(2),
-    )
-    # Load checkpoint
-    dqn.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(dqn.actor, nn.Module)
-    assert isinstance(dqn.actor_target, nn.Module)
-    assert dqn.lr == 1e-4
-    assert_state_dicts_equal(initial_actor_state_dict, dqn.actor.state_dict())
-    assert_state_dicts_equal(init_optim_state_dict, dqn.optimizer.state_dict())
-    assert dqn.batch_size == 64
-    assert dqn.learn_step == 5
-    assert dqn.gamma == 0.99
-    assert dqn.tau == 1e-3
-    assert dqn.mut is None
-    assert dqn.index == 0
-    assert dqn.scores == []
-    assert dqn.fitness == []
-    assert dqn.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize(
-    "device", ["cpu", "cuda" if torch.cuda.is_available() else "cpu"]
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_load_from_pretrained(
-    observation_space, encoder_cls, device, accelerator, tmpdir
-):
-    # Initialize the DQN agent
-    dqn = DQN(
-        observation_space=observation_space,
-        action_space=generate_discrete_space(2),
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_dqn = DQN.load(checkpoint_path, device=device, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_dqn.observation_space == dqn.observation_space
-    assert new_dqn.action_space == dqn.action_space
-    assert isinstance(new_dqn.actor.encoder, encoder_cls)
-    assert isinstance(new_dqn.actor_target.encoder, encoder_cls)
-    assert new_dqn.lr == dqn.lr
-    assert_state_dicts_equal(
-        new_dqn.actor.to("cpu").state_dict(), dqn.actor.state_dict()
-    )
-    assert new_dqn.batch_size == dqn.batch_size
-    assert new_dqn.learn_step == dqn.learn_step
-    assert new_dqn.gamma == dqn.gamma
-    assert new_dqn.tau == dqn.tau
-    assert new_dqn.mut == dqn.mut
-    assert new_dqn.index == dqn.index
-    assert new_dqn.scores == dqn.scores
-    assert new_dqn.fitness == dqn.fitness
-    assert new_dqn.steps == dqn.steps
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future.
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (generate_random_box_space(shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
-            "simple_cnn",
-            torch.randn(1, 3, 64, 64),
-        ),
-    ],
-)
-def test_load_from_pretrained_networks(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = generate_discrete_space(2)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the DQN agent
-    dqn = DQN(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_dqn = DQN.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_dqn.observation_space == dqn.observation_space
-    assert new_dqn.action_space == dqn.action_space
-    assert isinstance(new_dqn.actor, nn.Module)
-    assert isinstance(new_dqn.actor_target, nn.Module)
-    assert new_dqn.lr == dqn.lr
-    assert_state_dicts_equal(
-        new_dqn.actor.to("cpu").state_dict(), dqn.actor.state_dict()
-    )
-    assert new_dqn.batch_size == dqn.batch_size
-    assert new_dqn.learn_step == dqn.learn_step
-    assert new_dqn.gamma == dqn.gamma
-    assert new_dqn.tau == dqn.tau
-    assert new_dqn.mut == dqn.mut
-    assert new_dqn.index == dqn.index
-    assert new_dqn.scores == dqn.scores
-    assert new_dqn.fitness == dqn.fitness
-    assert new_dqn.steps == dqn.steps

--- a/tests/test_algorithms/test_dqn_rainbow.py
+++ b/tests/test_algorithms/test_dqn_rainbow.py
@@ -1,7 +1,5 @@
 import copy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -18,19 +16,9 @@ from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_not_equal_state_dict,
     assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_discrete_space,
-    generate_multidiscrete_space,
-    generate_random_box_space,
     get_experiences_batch,
     get_sample_from_space,
 )
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
 
 
 class DummyRainbowDQN(RainbowDQN):
@@ -64,59 +52,26 @@ class DummyEnv:
         )
 
 
-@pytest.fixture
-def simple_mlp():
-    network = nn.Sequential(
-        nn.Linear(4, 20),
-        nn.ReLU(),
-        nn.Linear(20, 10),
-        nn.ReLU(),
-        nn.Linear(10, 1),
-        nn.Tanh(),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_cnn():
-    network = nn.Sequential(
-        nn.Conv2d(
-            3, 16, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 3 (for RGB images), Output channels: 16
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Conv2d(
-            16, 32, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 16, Output channels: 32
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Flatten(),  # Flatten the 2D feature map to a 1D vector
-        nn.Linear(32 * 16 * 16, 128),  # Fully connected layer with 128 output features
-        nn.ReLU(),
-        nn.Linear(128, 1),  # Output layer with num_classes output features
-    )
-    return network
-
-
 # initialize DQN with valid parameters
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
+        ("multidiscrete_space", EvolvableMLP),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_dqn(observation_space, encoder_cls, accelerator):
-    action_space = generate_discrete_space(2)
-
-    dqn = RainbowDQN(observation_space, action_space, accelerator=accelerator)
+def test_initialize_dqn(
+    observation_space, discrete_space, encoder_cls, accelerator, request
+):
+    observation_space = request.getfixturevalue(observation_space)
+    dqn = RainbowDQN(observation_space, discrete_space, accelerator=accelerator)
 
     expected_device = accelerator.device if accelerator else "cpu"
     assert dqn.observation_space == observation_space
-    assert dqn.action_space == action_space
+    assert dqn.action_space == discrete_space
     assert dqn.batch_size == 64
     assert dqn.lr == 0.0001
     assert dqn.learn_step == 5
@@ -139,19 +94,19 @@ def test_initialize_dqn(observation_space, encoder_cls, accelerator):
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
+        ("vector_space", EvolvableMLP),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 def test_initialize_dqn_with_actor_network_evo_net(
-    observation_space, encoder_cls, accelerator
+    observation_space, discrete_space, encoder_cls, accelerator, request
 ):
-    action_space = generate_discrete_space(2)
+    observation_space = request.getfixturevalue(observation_space)
     support = torch.linspace(0, 1, 51)
     device = accelerator.device if accelerator else "cpu"
     actor_network = RainbowQNetwork(
         observation_space=observation_space,
-        action_space=action_space,
+        action_space=discrete_space,
         support=support,
         device=device,
     )
@@ -159,13 +114,13 @@ def test_initialize_dqn_with_actor_network_evo_net(
     # Create an instance of the RainbowDQN class
     dqn = RainbowDQN(
         observation_space,
-        action_space,
+        discrete_space,
         actor_network=actor_network,
         accelerator=accelerator,
     )
 
     assert dqn.observation_space == observation_space
-    assert dqn.action_space == action_space
+    assert dqn.action_space == discrete_space
     assert dqn.batch_size == 64
     assert dqn.lr == 0.0001
     assert dqn.learn_step == 5
@@ -187,13 +142,13 @@ def test_initialize_dqn_with_actor_network_evo_net(
         assert isinstance(dqn.optimizer.optimizer, optim.Adam)
 
 
-def test_initialize_dqn_with_incorrect_actor_net_type():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_initialize_dqn_with_incorrect_actor_net_type(
+    vector_space, discrete_space, request
+):
     actor_network = "dummy"
 
     with pytest.raises(TypeError) as a:
-        dqn = RainbowDQN(observation_space, action_space, actor_network=actor_network)
+        dqn = RainbowDQN(vector_space, discrete_space, actor_network=actor_network)
         assert dqn
         assert (
             str(a.value)
@@ -206,25 +161,25 @@ def test_initialize_dqn_with_incorrect_actor_net_type():
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (generate_random_box_space(shape=(4,)), "simple_mlp", torch.randn(1, 4)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
         (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
+            "image_space",
             "simple_cnn",
-            torch.randn(1, 3, 64, 64),
+            torch.randn(1, 3, 32, 32),
         ),
     ],
 )
 def test_initialize_dqn_with_make_evolvable(
-    observation_space, actor_network, input_tensor, request
+    observation_space, discrete_space, actor_network, input_tensor, request
 ):
-    action_space = generate_discrete_space(2)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
-    dqn = RainbowDQN(observation_space, action_space, actor_network=actor_network)
+    dqn = RainbowDQN(observation_space, discrete_space, actor_network=actor_network)
 
     assert dqn.observation_space == observation_space
-    assert dqn.action_space == action_space
+    assert dqn.action_space == discrete_space
     assert dqn.batch_size == 64
     assert dqn.lr == 0.0001
     assert dqn.learn_step == 5
@@ -244,19 +199,19 @@ def test_initialize_dqn_with_make_evolvable(
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_discrete_space(4),
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        generate_multidiscrete_space(2, 2),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
+        "vector_space",
+        "discrete_space",
+        "image_space",
+        "multidiscrete_space",
+        "dict_space",
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_returns_expected_action(accelerator, observation_space):
-    action_space = generate_discrete_space(2)
-
-    dqn = RainbowDQN(observation_space, action_space, accelerator=accelerator)
+def test_returns_expected_action(
+    accelerator, observation_space, discrete_space, request
+):
+    observation_space = request.getfixturevalue(observation_space)
+    dqn = RainbowDQN(observation_space, discrete_space, accelerator=accelerator)
     state = get_sample_from_space(observation_space)
 
     action_mask = None
@@ -264,7 +219,7 @@ def test_returns_expected_action(accelerator, observation_space):
     action = dqn.get_action(state, action_mask)[0]
 
     assert action.is_integer()
-    assert action >= 0 and action < action_space.n
+    assert action >= 0 and action < discrete_space.n
 
     action_mask = np.array([0, 1])
 
@@ -274,12 +229,10 @@ def test_returns_expected_action(accelerator, observation_space):
     assert action == 1
 
 
-def test_returns_expected_action_mask_vectorized():
+def test_returns_expected_action_mask_vectorized(vector_space, discrete_space):
     accelerator = Accelerator()
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
 
-    dqn = RainbowDQN(observation_space, action_space, accelerator=accelerator)
+    dqn = RainbowDQN(vector_space, discrete_space, accelerator=accelerator)
     state = np.array([[1, 2, 4, 5], [2, 3, 5, 1]])
 
     action_mask = np.array([[0, 1], [1, 0]])
@@ -292,23 +245,25 @@ def test_returns_expected_action_mask_vectorized():
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_discrete_space(4),
-        generate_random_box_space(shape=(4,)),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
+        "discrete_space",
+        "vector_space",
+        "dict_space",
+        "multidiscrete_space",
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 # learns from experiences and updates network parameters
-def test_learns_from_experiences(accelerator, observation_space):
+def test_learns_from_experiences(
+    accelerator, observation_space, discrete_space, request
+):
+    observation_space = request.getfixturevalue(observation_space)
     torch.autograd.set_detect_anomaly(True)
-    action_space = generate_discrete_space(2)
     batch_size = 64
 
     # Create an instance of the DQN class
     dqn = RainbowDQN(
         observation_space,
-        action_space,
+        discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
     )
@@ -316,7 +271,7 @@ def test_learns_from_experiences(accelerator, observation_space):
     # Create a batch of experiences
     device = accelerator.device if accelerator else "cpu"
     experiences = get_experiences_batch(
-        observation_space, action_space, batch_size, device
+        observation_space, discrete_space, batch_size, device
     )
 
     # Copy state dict before learning - should be different to after updating weights
@@ -342,15 +297,15 @@ def test_learns_from_experiences(accelerator, observation_space):
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("combined", [True, False])
 # learns from experiences and updates network parameters
-def test_learns_from_experiences_n_step(accelerator, combined):
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_learns_from_experiences_n_step(
+    accelerator, combined, vector_space, discrete_space
+):
     batch_size = 64
 
     # Create an instance of the DQN class
     dqn = RainbowDQN(
-        observation_space,
-        action_space,
+        vector_space,
+        discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
         combined_reward=combined,
@@ -358,16 +313,16 @@ def test_learns_from_experiences_n_step(accelerator, combined):
 
     # Create a batch of experiences
     # Create a batch of experiences
-    states = torch.randn(batch_size, observation_space.shape[0])
-    actions = torch.randint(0, action_space.n, (batch_size, 1))
+    states = torch.randn(batch_size, vector_space.shape[0])
+    actions = torch.randint(0, discrete_space.n, (batch_size, 1))
     rewards = torch.randn((batch_size, 1))
-    next_states = torch.randn(batch_size, observation_space.shape[0])
+    next_states = torch.randn(batch_size, vector_space.shape[0])
     dones = torch.randint(0, 2, (batch_size, 1))
     idxs = np.arange(batch_size)
-    n_states = torch.randn(batch_size, observation_space.shape[0])
-    n_actions = torch.randint(0, action_space.n, (batch_size, 1))
+    n_states = torch.randn(batch_size, vector_space.shape[0])
+    n_actions = torch.randint(0, discrete_space.n, (batch_size, 1))
     n_rewards = torch.randn((batch_size, 1))
-    n_next_states = torch.randn(batch_size, observation_space.shape[0])
+    n_next_states = torch.randn(batch_size, vector_space.shape[0])
     n_dones = torch.randint(0, 2, (batch_size, 1))
 
     experiences = TensorDict(
@@ -418,25 +373,25 @@ def test_learns_from_experiences_n_step(accelerator, combined):
 # learns from experiences and updates network parameters
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("combined", [True, False])
-def test_learns_from_experiences_per(accelerator, combined):
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_learns_from_experiences_per(
+    accelerator, combined, vector_space, discrete_space
+):
     batch_size = 64
 
     # Create an instance of the DQN class
     dqn = RainbowDQN(
-        observation_space,
-        action_space,
+        vector_space,
+        discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
         combined_reward=combined,
     )
 
     # Create a batch of experiences
-    states = torch.randn(batch_size, observation_space.shape[0])
-    actions = torch.randint(0, action_space.n, (batch_size, 1))
+    states = torch.randn(batch_size, vector_space.shape[0])
+    actions = torch.randint(0, discrete_space.n, (batch_size, 1))
     rewards = torch.randn((batch_size, 1))
-    next_states = torch.randn(batch_size, observation_space.shape[0])
+    next_states = torch.randn(batch_size, vector_space.shape[0])
     dones = torch.randint(0, 2, (batch_size, 1))
     weights = torch.rand(batch_size)
     idxs = torch.from_numpy(np.arange(batch_size))
@@ -479,32 +434,32 @@ def test_learns_from_experiences_per(accelerator, combined):
 # learns from experiences and updates network parameters
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("combined", [True, False])
-def test_learns_from_experiences_per_n_step(accelerator, combined):
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_learns_from_experiences_per_n_step(
+    accelerator, combined, vector_space, discrete_space
+):
     batch_size = 64
 
     # Create an instance of the DQN class
     dqn = RainbowDQN(
-        observation_space,
-        action_space,
+        vector_space,
+        discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
         combined_reward=combined,
     )
 
     # Create a batch of experiences
-    states = torch.randn(batch_size, observation_space.shape[0])
-    actions = torch.randint(0, action_space.n, (batch_size, 1))
+    states = torch.randn(batch_size, vector_space.shape[0])
+    actions = torch.randint(0, discrete_space.n, (batch_size, 1))
     rewards = torch.randn((batch_size, 1))
-    next_states = torch.randn(batch_size, observation_space.shape[0])
+    next_states = torch.randn(batch_size, vector_space.shape[0])
     dones = torch.randint(0, 2, (batch_size, 1))
     weights = torch.rand(batch_size)
     idxs = torch.from_numpy(np.arange(batch_size))
-    n_states = torch.randn(batch_size, observation_space.shape[0])
-    n_actions = torch.randint(0, action_space.n, (batch_size, 1))
+    n_states = torch.randn(batch_size, vector_space.shape[0])
+    n_actions = torch.randint(0, discrete_space.n, (batch_size, 1))
     n_rewards = torch.randn((batch_size, 1))
-    n_next_states = torch.randn(batch_size, observation_space.shape[0])
+    n_next_states = torch.randn(batch_size, vector_space.shape[0])
     n_dones = torch.randint(0, 2, (batch_size, 1))
 
     experiences = TensorDict(
@@ -555,9 +510,7 @@ def test_learns_from_experiences_per_n_step(accelerator, combined):
 
 
 # Updates target network parameters with soft update
-def test_soft_update():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_soft_update(vector_space, discrete_space):
     net_config = {"encoder_config": {"hidden_size": [64, 64]}}
     batch_size = 64
     lr = 1e-4
@@ -571,8 +524,8 @@ def test_soft_update():
     wrap = True
 
     dqn = RainbowDQN(
-        observation_space,
-        action_space,
+        vector_space,
+        discrete_space,
         net_config=net_config,
         batch_size=batch_size,
         lr=lr,
@@ -606,15 +559,15 @@ def test_soft_update():
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
+        "vector_space",
+        "image_space",
     ],
 )
-def test_algorithm_test_loop(num_envs, observation_space):
-    action_space = generate_discrete_space(2)
+def test_algorithm_test_loop(num_envs, observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
     vect = num_envs > 1
     env = DummyEnv(state_size=observation_space.shape, vect=vect, num_envs=num_envs)
-    agent = RainbowDQN(observation_space=observation_space, action_space=action_space)
+    agent = RainbowDQN(observation_space=observation_space, action_space=discrete_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
@@ -623,16 +576,15 @@ def test_algorithm_test_loop(num_envs, observation_space):
 @pytest.mark.parametrize(
     "observation_space",
     [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
+        "vector_space",
+        "image_space",
+        "dict_space",
+        "multidiscrete_space",
     ],
 )
-def test_clone_returns_identical_agent(observation_space):
-    action_space = generate_discrete_space(2)
-
-    dqn = DummyRainbowDQN(observation_space, action_space)
+def test_clone_returns_identical_agent(observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
+    dqn = DummyRainbowDQN(observation_space, discrete_space)
     dqn.fitness = [200, 200, 200]
     dqn.scores = [94, 94, 94]
     dqn.steps = [2500]
@@ -664,7 +616,7 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.tensor_test == dqn.tensor_test
 
     accelerator = Accelerator()
-    dqn = RainbowDQN(observation_space, action_space, accelerator=accelerator)
+    dqn = RainbowDQN(observation_space, discrete_space, accelerator=accelerator)
     clone_agent = dqn.clone()
 
     assert clone_agent.observation_space == dqn.observation_space
@@ -690,7 +642,7 @@ def test_clone_returns_identical_agent(observation_space):
 
     accelerator = Accelerator()
     dqn = RainbowDQN(
-        observation_space, action_space, accelerator=accelerator, wrap=False
+        observation_space, discrete_space, accelerator=accelerator, wrap=False
     )
     clone_agent = dqn.clone(wrap=False)
 
@@ -717,23 +669,18 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.scores == dqn.scores
 
 
-def test_clone_new_index():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
-
-    dqn = RainbowDQN(observation_space, action_space)
+def test_clone_new_index(vector_space, discrete_space):
+    dqn = RainbowDQN(vector_space, discrete_space)
     clone_agent = dqn.clone(index=100)
 
     assert clone_agent.index == 100
 
 
-def test_clone_after_learning():
-    observation_space = generate_random_box_space(shape=(4,))
-    action_space = generate_discrete_space(2)
+def test_clone_after_learning(vector_space, discrete_space):
     batch_size = 8
-    rainbow_dqn = RainbowDQN(observation_space, action_space, batch_size=batch_size)
+    rainbow_dqn = RainbowDQN(vector_space, discrete_space, batch_size=batch_size)
 
-    experiences = get_experiences_batch(observation_space, action_space, batch_size)
+    experiences = get_experiences_batch(vector_space, discrete_space, batch_size)
     rainbow_dqn.learn(experiences)
     clone_agent = rainbow_dqn.clone()
 
@@ -763,252 +710,12 @@ def test_clone_after_learning():
 
 
 # The method successfully unwraps the actor and actor_target models when an accelerator is present.
-def test_unwrap_models():
+def test_unwrap_models(vector_space, discrete_space):
     dqn = RainbowDQN(
-        observation_space=generate_random_box_space(shape=(4,)),
-        action_space=generate_discrete_space(2),
+        observation_space=vector_space,
+        action_space=discrete_space,
         accelerator=Accelerator(),
     )
     dqn.unwrap_models()
     assert isinstance(dqn.actor, nn.Module)
     assert isinstance(dqn.actor_target, nn.Module)
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    tmpdir, observation_space, encoder_cls
-):
-    # Initialize the DQN agent
-    dqn = RainbowDQN(
-        observation_space=observation_space,
-        action_space=generate_discrete_space(2),
-    )
-    initial_actor_state_dict = dqn.actor.state_dict()
-    init_optim_state_dict = dqn.optimizer.state_dict()
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    # Load checkpoint
-    dqn.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(dqn.actor.encoder, encoder_cls)
-    assert isinstance(dqn.actor_target.encoder, encoder_cls)
-    assert dqn.lr == 1e-4
-    assert_state_dicts_equal(dqn.actor.state_dict(), dqn.actor_target.state_dict())
-    assert_state_dicts_equal(initial_actor_state_dict, dqn.actor.state_dict())
-    assert_state_dicts_equal(init_optim_state_dict, dqn.optimizer.state_dict())
-    assert dqn.batch_size == 64
-    assert dqn.learn_step == 5
-    assert dqn.gamma == 0.99
-    assert dqn.tau == 1e-3
-    assert dqn.mut is None
-    assert dqn.index == 0
-    assert dqn.scores == []
-    assert dqn.fitness == []
-    assert dqn.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future.
-@pytest.mark.parametrize(
-    "actor_network, input_tensor",
-    [
-        ("simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_cnn_network(
-    actor_network, input_tensor, request, tmpdir
-):
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the DQN agent
-    dqn = RainbowDQN(
-        observation_space=generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
-        action_space=generate_discrete_space(2),
-        actor_network=actor_network,
-    )
-
-    initial_actor_state_dict = dqn.actor.state_dict()
-    init_optim_state_dict = dqn.optimizer.state_dict()
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    # Load checkpoint
-    dqn.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(dqn.actor, nn.Module)
-    assert isinstance(dqn.actor_target, nn.Module)
-    assert dqn.lr == 1e-4
-    assert_state_dicts_equal(dqn.actor.state_dict(), dqn.actor_target.state_dict())
-    assert_state_dicts_equal(initial_actor_state_dict, dqn.actor.state_dict())
-    assert_state_dicts_equal(init_optim_state_dict, dqn.optimizer.state_dict())
-    assert dqn.batch_size == 64
-    assert dqn.learn_step == 5
-    assert dqn.gamma == 0.99
-    assert dqn.tau == 1e-3
-    assert dqn.mut is None
-    assert dqn.index == 0
-    assert dqn.scores == []
-    assert dqn.fitness == []
-    assert dqn.steps == [0]
-
-
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-# The saved checkpoint file contains the correct data and format.
-def test_load_from_pretrained(observation_space, encoder_cls, accelerator, tmpdir):
-    # Initialize the DQN agent
-    dqn = RainbowDQN(
-        observation_space=observation_space,
-        action_space=generate_discrete_space(2),
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_dqn = RainbowDQN.load(checkpoint_path, device="cpu", accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_dqn.observation_space == dqn.observation_space
-    assert new_dqn.action_space == dqn.action_space
-    assert isinstance(new_dqn.actor.encoder, encoder_cls)
-    assert isinstance(new_dqn.actor_target.encoder, encoder_cls)
-    assert new_dqn.lr == dqn.lr
-    assert_state_dicts_equal(
-        new_dqn.actor.to("cpu").state_dict(), dqn.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_dqn.actor_target.to("cpu").state_dict(), dqn.actor_target.state_dict()
-    )
-    assert new_dqn.batch_size == dqn.batch_size
-    assert new_dqn.learn_step == dqn.learn_step
-    assert new_dqn.gamma == dqn.gamma
-    assert new_dqn.tau == dqn.tau
-    assert new_dqn.mut == dqn.mut
-    assert new_dqn.index == dqn.index
-    assert new_dqn.scores == dqn.scores
-    assert new_dqn.fitness == dqn.fitness
-    assert new_dqn.steps == dqn.steps
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future.
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (generate_random_box_space(shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
-            "simple_cnn",
-            torch.randn(1, 3, 64, 64),
-        ),
-    ],
-)
-def test_load_from_pretrained_networks(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = generate_discrete_space(2)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the DQN agent
-    dqn = RainbowDQN(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    dqn.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_dqn = RainbowDQN.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_dqn.observation_space == dqn.observation_space
-    assert new_dqn.action_space == dqn.action_space
-    assert isinstance(new_dqn.actor, nn.Module)
-    assert isinstance(new_dqn.actor_target, nn.Module)
-    assert new_dqn.lr == dqn.lr
-    assert_state_dicts_equal(
-        new_dqn.actor.to("cpu").state_dict(), dqn.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_dqn.actor_target.to("cpu").state_dict(), dqn.actor_target.state_dict()
-    )
-    assert new_dqn.batch_size == dqn.batch_size
-    assert new_dqn.learn_step == dqn.learn_step
-    assert new_dqn.gamma == dqn.gamma
-    assert new_dqn.tau == dqn.tau
-    assert new_dqn.mut == dqn.mut
-    assert new_dqn.index == dqn.index
-    assert new_dqn.scores == dqn.scores
-    assert new_dqn.fitness == dqn.fitness
-    assert new_dqn.steps == dqn.steps

--- a/tests/test_algorithms/test_grpo.py
+++ b/tests/test_algorithms/test_grpo.py
@@ -186,7 +186,7 @@ def create_module(input_size, max_tokens, vocab_size, device):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def accelerator(request):
     gc.collect()
     torch.cuda.empty_cache()
@@ -200,7 +200,7 @@ def accelerator(request):
         accelerator.free_memory()
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def grpo(request, accelerator, monkeypatch):
     gc.collect()
     torch.cuda.empty_cache()

--- a/tests/test_algorithms/test_ippo.py
+++ b/tests/test_algorithms/test_ippo.py
@@ -1,9 +1,6 @@
 import copy
-import gc
-from pathlib import Path
 from unittest.mock import MagicMock
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -17,7 +14,7 @@ from pettingzoo import ParallelEnv
 from torch._dynamo import OptimizedModule
 
 from agilerl.algorithms.ippo import IPPO
-from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput, ModuleDict
+from agilerl.modules import EvolvableMLP, ModuleDict
 from agilerl.modules.custom_components import GumbelSoftmax
 from agilerl.networks.actors import StochasticActor
 from agilerl.networks.value_networks import ValueNetwork
@@ -27,18 +24,8 @@ from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_not_equal_state_dict,
     assert_state_dicts_equal,
-    gen_multi_agent_dict_or_tuple_spaces,
-    generate_multi_agent_box_spaces,
-    generate_multi_agent_discrete_spaces,
-    generate_multi_agent_multidiscrete_spaces,
     get_sample_from_space,
 )
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
 
 
 class DummyMultiEnv(ParallelEnv):
@@ -83,13 +70,13 @@ class MultiAgentCNNActor(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = nn.Conv2d(
-            in_channels=4, out_channels=16, kernel_size=(3, 3), stride=4
+            in_channels=3, out_channels=16, kernel_size=(3, 3), stride=4
         )
         self.conv2 = nn.Conv2d(
             in_channels=16, out_channels=32, kernel_size=(3, 3), stride=2
         )
         self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
-        self.fc1 = nn.Linear(15200, 256)
+        self.fc1 = nn.Linear(288, 256)
         self.fc2 = nn.Linear(256, 2)
         self.relu = nn.ReLU()
         self.output_activation = GumbelSoftmax()
@@ -107,13 +94,13 @@ class MultiAgentCNNCritic(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = nn.Conv2d(
-            in_channels=4, out_channels=16, kernel_size=(3, 3), stride=4
+            in_channels=3, out_channels=16, kernel_size=(3, 3), stride=4
         )
         self.conv2 = nn.Conv2d(
             in_channels=16, out_channels=32, kernel_size=(3, 3), stride=2
         )
         self.pool = nn.MaxPool2d(kernel_size=2, stride=2)
-        self.fc1 = nn.Linear(15200, 256)
+        self.fc1 = nn.Linear(288, 256)
         self.fc2 = nn.Linear(256, 1)
         self.relu = nn.ReLU()
 
@@ -161,65 +148,49 @@ class DummyValueNetwork(ValueNetwork):
         return DummyNoSync()
 
 
-@pytest.fixture
-def mlp_actor(observation_spaces, action_spaces):
-    net = nn.Sequential(
+@pytest.fixture(scope="function")
+def mlp_actor(observation_spaces, action_spaces, request):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
+    return nn.Sequential(
         nn.Linear(observation_spaces[0].shape[0], 64),
         nn.ReLU(),
         nn.Linear(64, action_spaces[0].n),
         nn.Softmax(dim=-1),
     )
-    yield net
-    del net
-    gc.collect()
-    torch.cuda.empty_cache()
 
 
-@pytest.fixture
-def mlp_critic(observation_spaces):
-    net = nn.Sequential(
+@pytest.fixture(scope="function")
+def mlp_critic(observation_spaces, request):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    return nn.Sequential(
         nn.Linear(observation_spaces[0].shape[0], 64),
         nn.ReLU(),
         nn.Linear(64, 1),
     )
-    yield net
-    del net
-    gc.collect()
-    torch.cuda.empty_cache()
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def cnn_actor():
-    net = MultiAgentCNNActor()
-    yield net
-    del net
-    gc.collect()
-    torch.cuda.empty_cache()
+    return MultiAgentCNNActor()
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def cnn_critic():
-    net = MultiAgentCNNCritic()
-    yield net
-    del net
-    gc.collect()
-    torch.cuda.empty_cache()
+    return MultiAgentCNNCritic()
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mocked_accelerator():
     MagicMock(spec=Accelerator)
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def accelerated_experiences(
-    batch_size, observation_spaces, action_spaces, agent_ids, device
+    batch_size, observation_spaces, action_spaces, agent_ids, device, request
 ):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     one_hot = all(isinstance(space, Discrete) for space in observation_spaces)
     discrete_actions = all(isinstance(space, Discrete) for space in action_spaces)
     state_size = (
@@ -261,8 +232,12 @@ def accelerated_experiences(
     return states, actions, log_probs, rewards, dones, values, next_state, next_done
 
 
-@pytest.fixture
-def experiences(batch_size, observation_spaces, action_spaces, agent_ids, device):
+@pytest.fixture(scope="function")
+def experiences(
+    batch_size, observation_spaces, action_spaces, agent_ids, device, request
+):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     one_hot = all(isinstance(space, Discrete) for space in observation_spaces)
     discrete_actions = all(isinstance(space, Discrete) for space in action_spaces)
     state_size = (
@@ -304,10 +279,12 @@ def experiences(batch_size, observation_spaces, action_spaces, agent_ids, device
     return states, actions, log_probs, rewards, dones, values, next_state, next_done
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def vectorized_experiences(
-    batch_size, vect_dim, observation_spaces, action_spaces, agent_ids, device
+    batch_size, vect_dim, observation_spaces, action_spaces, agent_ids, device, request
 ):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     one_hot = all(isinstance(space, Discrete) for space in observation_spaces)
     discrete_actions = all(isinstance(space, Discrete) for space in action_spaces)
     state_size = (
@@ -368,26 +345,35 @@ def vectorized_experiences(
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_box_spaces(3, (6,)),
-        generate_multi_agent_box_spaces(3, (3, 32, 32)),
+        "ma_vector_space",
+        "ma_image_space",
     ],
 )
 @pytest.mark.parametrize("vectorized", [False, True])
-def test_loop(device, sum_score, compile_mode, observation_spaces, vectorized):
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
-
+def test_loop(
+    device,
+    sum_score,
+    compile_mode,
+    observation_spaces,
+    vectorized,
+    ma_discrete_space,
+    request,
+):
+    observation_spaces = request.getfixturevalue(observation_spaces)
     if vectorized:
         env = make_multi_agent_vect_envs(
             DummyMultiEnv,
             2,
-            **dict(observation_spaces=observation_spaces, action_spaces=action_spaces),
+            **dict(
+                observation_spaces=observation_spaces, action_spaces=ma_discrete_space
+            ),
         )
     else:
-        env = DummyMultiEnv(observation_spaces, action_spaces)
+        env = DummyMultiEnv(observation_spaces, ma_discrete_space)
 
     ippo = IPPO(
         observation_spaces,
-        action_spaces,
+        ma_discrete_space,
         agent_ids=["agent_0", "agent_1", "other_agent_0"],
         device=device,
         torch_compiler=compile_mode,
@@ -403,20 +389,19 @@ def test_loop(device, sum_score, compile_mode, observation_spaces, vectorized):
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_box_spaces(3, (6,)),
-        generate_multi_agent_box_spaces(3, (3, 32, 32)),
-        gen_multi_agent_dict_or_tuple_spaces(3, 2, 2, dict_space=True),
-        gen_multi_agent_dict_or_tuple_spaces(3, 2, 2, dict_space=False),
+        "ma_vector_space",
+        "ma_image_space",
+        "ma_dict_space",
     ],
 )
 @pytest.mark.parametrize("compile_mode", [None, "default"])
 @pytest.mark.parametrize("accelerator_flag", [False, True])
 @pytest.mark.parametrize("wrap", [True, False])
 def test_ippo_clone_returns_identical_agent(
-    accelerator_flag, wrap, compile_mode, observation_spaces
+    accelerator_flag, wrap, compile_mode, observation_spaces, ma_discrete_space, request
 ):
     # Clones the agent and returns an identical copy.
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+    observation_spaces = request.getfixturevalue(observation_spaces)
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     index = 0
     batch_size = 64
@@ -439,7 +424,7 @@ def test_ippo_clone_returns_identical_agent(
 
     ippo = IPPO(
         observation_spaces,
-        action_spaces,
+        ma_discrete_space,
         agent_ids,
         index=index,
         batch_size=batch_size,
@@ -503,14 +488,12 @@ def test_ippo_clone_returns_identical_agent(
 
 
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_clone_new_index(compile_mode):
-    observation_spaces = generate_multi_agent_box_spaces(3, (4,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+def test_clone_new_index(compile_mode, ma_vector_space, ma_discrete_space):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
 
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        ma_vector_space,
+        ma_discrete_space,
         agent_ids,
         torch_compiler=compile_mode,
     )
@@ -520,15 +503,13 @@ def test_clone_new_index(compile_mode):
 
 
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_clone_after_learning(compile_mode):
-    observation_spaces = generate_multi_agent_box_spaces(3, (4,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+def test_clone_after_learning(compile_mode, ma_vector_space, ma_discrete_space):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     batch_size = 8
 
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        ma_vector_space,
+        ma_discrete_space,
         agent_ids,
         batch_size=batch_size,
         torch_compiler=compile_mode,
@@ -536,11 +517,11 @@ def test_clone_after_learning(compile_mode):
     )
 
     states = {
-        agent_id: np.random.randn(batch_size, observation_spaces[idx].shape[0])
+        agent_id: np.random.randn(batch_size, ma_vector_space[idx].shape[0])
         for idx, agent_id in enumerate(agent_ids)
     }
     actions = {
-        agent_id: np.random.randint(0, action_spaces[idx].n, (batch_size,))
+        agent_id: np.random.randint(0, ma_discrete_space[idx].n, (batch_size,))
         for idx, agent_id in enumerate(agent_ids)
     }
     log_probs = {agent_id: np.random.randn(batch_size, 1) for agent_id in agent_ids}
@@ -548,7 +529,7 @@ def test_clone_after_learning(compile_mode):
     dones = {agent_id: torch.zeros(batch_size, 1) for agent_id in agent_ids}
     values = {agent_id: np.random.randn(batch_size, 1) for agent_id in agent_ids}
     next_state = {
-        agent_id: np.random.randn(observation_spaces[idx].shape[0])
+        agent_id: np.random.randn(ma_vector_space[idx].shape[0])
         for idx, agent_id in enumerate(agent_ids)
     }
     next_done = {agent: np.random.randint(0, 2, (1,)) for agent in agent_ids}
@@ -598,243 +579,16 @@ def test_clone_after_learning(compile_mode):
         assert str(clone_critic_opt) == str(critic_opt)
 
 
-@pytest.mark.parametrize(
-    "observation_spaces, encoder_cls",
-    [
-        (generate_multi_agent_box_spaces(1, (6,)), EvolvableMLP),
-        (generate_multi_agent_box_spaces(1, (3, 32, 32)), EvolvableCNN),
-        (
-            gen_multi_agent_dict_or_tuple_spaces(1, 2, 2, dict_space=True),
-            EvolvableMultiInput,
-        ),
-        # (
-        #     gen_multi_agent_dict_or_tuple_spaces(1, 2, 2, dict_space=False),
-        #     EvolvableMultiInput,
-        # ),
-    ],
-)
-@pytest.mark.parametrize(
-    "device", ["cpu", "cuda" if torch.cuda.is_available() else "cpu"]
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_save_load_checkpoint_correct_data_and_format(
-    tmpdir, device, accelerator, compile_mode, observation_spaces, encoder_cls
-):
-    # Initialize the ippo agent
-    ippo = IPPO(
-        observation_spaces=observation_spaces,
-        action_spaces=generate_multi_agent_discrete_spaces(1, 2),
-        agent_ids=["agent_0"],
-        torch_compiler=compile_mode,
-        device=device,
-        accelerator=accelerator,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ippo.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actors_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actors_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critics_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critics_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_optimizers_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "critic_optimizers_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "gae_lambda" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    # Load checkpoint
-    loaded_ippo = IPPO(
-        observation_spaces=observation_spaces,
-        action_spaces=generate_multi_agent_discrete_spaces(1, 2),
-        agent_ids=["agent_0"],
-        torch_compiler=compile_mode,
-        device=device,
-        accelerator=accelerator,
-    )
-    loaded_ippo.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    for agent_id in ippo.observation_space.keys():
-        loaded_actor = loaded_ippo.actors[agent_id]
-        loaded_critic = loaded_ippo.critics[agent_id]
-        actor = ippo.actors[agent_id]
-        critic = ippo.critics[agent_id]
-        if compile_mode is not None and accelerator is None:
-            assert isinstance(loaded_actor, OptimizedModule)
-            assert isinstance(loaded_critic, OptimizedModule)
-        else:
-            assert isinstance(loaded_actor.encoder, encoder_cls)
-            assert isinstance(loaded_critic.encoder, encoder_cls)
-
-        assert_state_dicts_equal(loaded_actor.state_dict(), actor.state_dict())
-        assert_state_dicts_equal(loaded_critic.state_dict(), critic.state_dict())
-
-    assert ippo.batch_size == 64
-    assert ippo.lr == 1e-4
-    assert ippo.learn_step == 2048
-    assert ippo.gamma == 0.99
-    assert ippo.gae_lambda == 0.95
-    assert ippo.mut is None
-    assert ippo.index == 0
-    assert ippo.scores == []
-    assert ippo.fitness == []
-    assert ippo.steps == [0]
-
-
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "device", ["cpu", "cuda" if torch.cuda.is_available() else "cpu"]
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-@pytest.mark.parametrize("compile_mode", [None, "default"])
-@pytest.mark.parametrize(
-    "observation_spaces, action_spaces",
-    [
-        (
-            generate_multi_agent_box_spaces(1, (6,)),
-            generate_multi_agent_discrete_spaces(1, 2),
-        )
-    ],
-)
-def test_ippo_save_load_checkpoint_correct_data_and_format_make_evo(
-    tmpdir,
-    observation_spaces,
-    action_spaces,
-    mlp_actor,
-    mlp_critic,
-    device,
-    compile_mode,
-    accelerator,
-):
-    evo_actors = ModuleDict(
-        {
-            "agent_0": MakeEvolvable(
-                network=mlp_actor, input_tensor=torch.randn(1, 6), device=device
-            )
-        }
-    )
-    evo_critics = ModuleDict(
-        {
-            "agent_0": MakeEvolvable(
-                network=mlp_critic, input_tensor=torch.randn(1, 6), device=device
-            )
-        }
-    )
-    ippo = IPPO(
-        observation_spaces=observation_spaces,
-        action_spaces=action_spaces,
-        agent_ids=["agent_0"],
-        actor_networks=evo_actors,
-        critic_networks=evo_critics,
-        device=device,
-        torch_compiler=compile_mode,
-        accelerator=accelerator,
-    )
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ippo.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actors_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actors_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critics_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critics_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_optimizers_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "critic_optimizers_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "gae_lambda" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    # Load checkpoint
-    loaded_ippo = IPPO(
-        observation_spaces=generate_multi_agent_box_spaces(
-            1, (3, 32, 32), low=0, high=255
-        ),
-        action_spaces=generate_multi_agent_discrete_spaces(1, 2),
-        agent_ids=["agent_0"],
-        device=device,
-        torch_compiler=compile_mode,
-        accelerator=accelerator,
-        net_config={
-            "encoder_config": {
-                "channel_size": [16],
-                "kernel_size": [3],
-                "stride_size": [1],
-                "init_layers": False,
-            },
-            "head_config": {"hidden_size": [32], "init_layers": False},
-        },
-    )
-    loaded_ippo.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    for agent_id in ippo.observation_space.keys():
-        actor = ippo.actors[agent_id]
-        loaded_actor = loaded_ippo.actors[agent_id]
-        assert_state_dicts_equal(loaded_actor.state_dict(), actor.state_dict())
-
-        critic = ippo.critics[agent_id]
-        loaded_critic = loaded_ippo.critics[agent_id]
-        assert_state_dicts_equal(loaded_critic.state_dict(), critic.state_dict())
-
-        if compile_mode is not None and accelerator is None:
-            assert isinstance(loaded_actor, OptimizedModule)
-            assert isinstance(loaded_critic, OptimizedModule)
-        else:
-            assert isinstance(loaded_actor, MakeEvolvable)
-            assert isinstance(loaded_critic, MakeEvolvable)
-
-    assert ippo.batch_size == 64
-    assert ippo.lr == 1e-4
-    assert ippo.learn_step == 2048
-    assert ippo.gamma == 0.99
-    assert ippo.gae_lambda == 0.95
-    assert ippo.mut is None
-    assert ippo.index == 0
-    assert ippo.scores == []
-    assert ippo.fitness == []
-    assert ippo.steps == [0]
-
-
-@pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_ippo_unwrap_models(compile_mode):
-    observation_spaces = generate_multi_agent_box_spaces(3, (6,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+def test_ippo_unwrap_models(compile_mode, ma_vector_space, ma_discrete_space):
     accelerator = Accelerator()
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_discrete_space,
+        agent_ids=agent_ids,
         accelerator=accelerator,
         torch_compiler=compile_mode,
-        net_config={
-            "encoder_config": {"hidden_size": [16, 16], "init_layers": False},
-            "head_config": {"hidden_size": [16], "init_layers": False},
-        },
     )
     ippo.unwrap_models()
     for shared_id in ippo.shared_agent_ids:
@@ -844,230 +598,26 @@ def test_ippo_unwrap_models(compile_mode):
         assert isinstance(critic, nn.Module)
 
 
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_spaces, encoder_cls",
-    [
-        (generate_multi_agent_box_spaces(3, (4,)), EvolvableMLP),
-        (generate_multi_agent_box_spaces(3, (3, 32, 32)), EvolvableCNN),
-        (
-            gen_multi_agent_dict_or_tuple_spaces(3, 2, 2, dict_space=True),
-            EvolvableMultiInput,
-        ),
-        # (
-        #     gen_multi_agent_dict_or_tuple_spaces(3, 2, 2, dict_space=False),
-        #     EvolvableMultiInput,
-        # ),
-    ],
-)
-@pytest.mark.parametrize(
-    "device", ["cpu", "cuda" if torch.cuda.is_available() else "cpu"]
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_load_from_pretrained(
-    device, accelerator, tmpdir, compile_mode, observation_spaces, encoder_cls
-):
-    # Initialize the ippo agent
-    ippo = IPPO(
-        observation_spaces=observation_spaces,
-        action_spaces=generate_multi_agent_discrete_spaces(3, 2),
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
-        torch_compiler=compile_mode,
-        accelerator=accelerator,
-        device=device,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ippo.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_ippo = IPPO.load(checkpoint_path, device=device, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_ippo.observation_spaces == ippo.observation_spaces
-    assert new_ippo.action_spaces == ippo.action_spaces
-    assert new_ippo.n_agents == ippo.n_agents
-    assert new_ippo.agent_ids == ippo.agent_ids
-    assert new_ippo.lr == ippo.lr
-
-    for shared_id in ippo.shared_agent_ids:
-        actor = ippo.actors[shared_id]
-        new_actor = new_ippo.actors[shared_id]
-        assert_state_dicts_equal(new_actor.state_dict(), actor.state_dict())
-
-        critic = ippo.critics[shared_id]
-        new_critic = new_ippo.critics[shared_id]
-        assert_state_dicts_equal(new_critic.state_dict(), critic.state_dict())
-
-        if compile_mode is not None and accelerator is None:
-            assert isinstance(new_actor, OptimizedModule)
-            assert isinstance(new_critic, OptimizedModule)
-        else:
-            assert isinstance(new_actor.encoder, encoder_cls)
-            assert isinstance(new_critic.encoder, encoder_cls)
-
-    assert new_ippo.batch_size == ippo.batch_size
-    assert new_ippo.learn_step == ippo.learn_step
-    assert new_ippo.gamma == ippo.gamma
-    assert new_ippo.gae_lambda == ippo.gae_lambda
-    assert new_ippo.mut == ippo.mut
-    assert new_ippo.index == ippo.index
-    assert new_ippo.scores == ippo.scores
-    assert new_ippo.fitness == ippo.fitness
-    assert new_ippo.steps == ippo.steps
-
-
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "device", ["cpu", "cuda" if torch.cuda.is_available() else "cpu"]
-)
-@pytest.mark.parametrize(
-    "observation_spaces, action_spaces, arch, input_tensor, critic_input_tensor, compile_mode",
-    [
-        (
-            generate_multi_agent_box_spaces(3, (4,)),
-            generate_multi_agent_discrete_spaces(3, 2),
-            "mlp",
-            torch.randn(1, 4),
-            torch.randn(1, 4),
-            None,
-        ),
-        (
-            generate_multi_agent_box_spaces(3, (4, 210, 160), low=0, high=255),
-            generate_multi_agent_discrete_spaces(3, 2),
-            "cnn",
-            torch.randn(1, 4, 210, 160),
-            torch.randn(1, 4, 210, 160),
-            None,
-        ),
-        (
-            generate_multi_agent_box_spaces(3, (4,)),
-            generate_multi_agent_discrete_spaces(3, 2),
-            "mlp",
-            torch.randn(1, 4),
-            torch.randn(1, 4),
-            "default",
-        ),
-        (
-            generate_multi_agent_box_spaces(3, (4, 210, 160), low=0, high=255),
-            generate_multi_agent_discrete_spaces(3, 2),
-            "cnn",
-            torch.randn(1, 4, 210, 160),
-            torch.randn(1, 4, 210, 160),
-            "default",
-        ),
-    ],
-)
-# The saved checkpoint file contains the correct data and format.
-def test_load_from_pretrained_networks(
-    mlp_actor,
-    mlp_critic,
-    cnn_actor,
-    cnn_critic,
+@pytest.mark.parametrize("batch_size", [16])
+@pytest.mark.parametrize("agent_ids", [["agent_0", "agent_1", "other_agent_0"]])
+@pytest.mark.parametrize("observation_spaces", ["ma_vector_space"])
+@pytest.mark.parametrize("action_spaces", ["ma_discrete_space"])
+def test_ippo_learns_from_experiences_distributed(
     observation_spaces,
     action_spaces,
-    arch,
-    input_tensor,
-    critic_input_tensor,
-    tmpdir,
+    agent_ids,
+    accelerated_experiences,
     compile_mode,
-    device,
+    batch_size,
+    request,
 ):
-    if arch == "mlp":
-        actor_network = mlp_actor
-        critic_network = mlp_critic
-    elif arch == "cnn":
-        actor_network = cnn_actor
-        critic_network = cnn_critic
-
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-    critic_network = MakeEvolvable(
-        critic_network,
-        critic_input_tensor,
-    )
-
-    actor_networks = ModuleDict(
-        {
-            "agent": actor_network,
-            "other_agent": copy.deepcopy(actor_network),
-        }
-    )
-
-    critic_networks = ModuleDict(
-        {
-            "agent": critic_network,
-            "other_agent": copy.deepcopy(critic_network),
-        }
-    )
-
-    # Initialize the ippo agent
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
+    accelerator = Accelerator(device_placement=False)
     ippo = IPPO(
         observation_spaces=observation_spaces,
         action_spaces=action_spaces,
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
-        actor_networks=actor_networks,
-        critic_networks=critic_networks,
-        torch_compiler=compile_mode,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ippo.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_ippo = IPPO.load(checkpoint_path, device=device)
-
-    # Check if properties and weights are loaded correctly
-    assert new_ippo.observation_spaces == ippo.observation_spaces
-    assert new_ippo.action_spaces == ippo.action_spaces
-    assert new_ippo.n_agents == ippo.n_agents
-    assert new_ippo.agent_ids == ippo.agent_ids
-    assert new_ippo.lr == ippo.lr
-
-    for shared_id in ippo.shared_agent_ids:
-        actor = ippo.actors[shared_id]
-        new_actor = new_ippo.actors[shared_id]
-        assert_state_dicts_equal(new_actor.state_dict(), actor.state_dict())
-
-        critic = ippo.critics[shared_id]
-        new_critic = new_ippo.critics[shared_id]
-        assert_state_dicts_equal(new_critic.state_dict(), critic.state_dict())
-
-    assert new_ippo.batch_size == ippo.batch_size
-    assert new_ippo.learn_step == ippo.learn_step
-    assert new_ippo.gamma == ippo.gamma
-    assert new_ippo.gae_lambda == ippo.gae_lambda
-    assert new_ippo.mut == ippo.mut
-    assert new_ippo.index == ippo.index
-    assert new_ippo.scores == ippo.scores
-    assert new_ippo.fitness == ippo.fitness
-    assert new_ippo.steps == ippo.steps
-
-
-@pytest.mark.parametrize("batch_size", [64])
-@pytest.mark.parametrize("agent_ids", [["agent_0", "agent_1", "other_agent_0"]])
-@pytest.mark.parametrize("compile_mode", [None, "default"])
-@pytest.mark.parametrize("action_spaces", [generate_multi_agent_discrete_spaces(3, 2)])
-@pytest.mark.parametrize(
-    "observation_spaces",
-    [
-        generate_multi_agent_box_spaces(3, (6,)),
-    ],
-)
-def test_ippo_learns_from_experiences_distributed(
-    observation_spaces,
-    accelerated_experiences,
-    batch_size,
-    action_spaces,
-    agent_ids,
-    compile_mode,
-):
-    accelerator = Accelerator(device_placement=False)
-    ippo = IPPO(
-        observation_spaces,
-        action_spaces,
         agent_ids=agent_ids,
         accelerator=accelerator,
         torch_compiler=compile_mode,
@@ -1115,28 +665,31 @@ def test_ippo_learns_from_experiences_distributed(
 
 
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-@pytest.mark.parametrize("agent_ids", [["agent_0", "agent_1", "other_agent_0"]])
-@pytest.mark.parametrize("batch_size", [64])
-@pytest.mark.parametrize("action_spaces", [generate_multi_agent_discrete_spaces(3, 2)])
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_box_spaces(3, (3, 32, 32)),
-        generate_multi_agent_box_spaces(3, (6,)),
+        "ma_image_space",
+        "ma_vector_space",
     ],
 )
+@pytest.mark.parametrize("agent_ids", [["agent_0", "agent_1", "other_agent_0"]])
+@pytest.mark.parametrize("batch_size", [16])
+@pytest.mark.parametrize("action_spaces", ["ma_discrete_space"])
 def test_ippo_learns_from_experiences(
     observation_spaces,
+    agent_ids,
+    action_spaces,
     experiences,
     batch_size,
-    action_spaces,
-    agent_ids,
     device,
     compile_mode,
+    request,
 ):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=observation_spaces,
+        action_spaces=action_spaces,
         agent_ids=agent_ids,
         device=device,
         torch_compiler=compile_mode,
@@ -1177,37 +730,39 @@ def test_ippo_learns_from_experiences(
         assert_not_equal_state_dict(old_critic_state_dict, updated_critic.state_dict())
 
 
-@pytest.mark.parametrize("agent_ids", [["agent_0", "agent_1", "other_agent_0"]])
-@pytest.mark.parametrize("batch_size", [32])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
 @pytest.mark.parametrize("vect_dim", [1, 8])
+@pytest.mark.parametrize("batch_size", [16])
+@pytest.mark.parametrize("agent_ids", [["agent_0", "agent_1", "other_agent_0"]])
 @pytest.mark.parametrize(
     "action_spaces",
     [
-        generate_multi_agent_discrete_spaces(3, 2),
-        generate_multi_agent_box_spaces(3, (6,)),
+        "ma_discrete_space",
+        "ma_vector_space",
     ],
 )
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_box_spaces(3, (3, 32, 32)),  # cnn
-        generate_multi_agent_box_spaces(3, (6,)),  # mlp
+        "ma_image_space",
+        "ma_vector_space",
     ],
 )
 def test_ippo_learns_from_vectorized_experiences(
+    agent_ids,
     observation_spaces,
+    action_spaces,
     vectorized_experiences,
     batch_size,
-    action_spaces,
-    agent_ids,
     device,
     compile_mode,
+    request,
 ):
-    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=observation_spaces,
+        action_spaces=action_spaces,
         agent_ids=agent_ids,
         device=device,
         torch_compiler=compile_mode,
@@ -1250,46 +805,28 @@ def test_ippo_learns_from_vectorized_experiences(
         assert_not_equal_state_dict(old_critic_state_dict, updated_critic.state_dict())
 
 
-@pytest.mark.parametrize(
-    "observation_spaces, batch_size, vect_dim, action_spaces, agent_ids, compile_mode",
-    [
-        (
-            generate_multi_agent_box_spaces(3, (3,)),
-            4,
-            3,
-            generate_multi_agent_box_spaces(3, (3,)),
-            ["agent_0", "agent_1", "other_agent_0"],
-            None,
-        ),
-    ],
-)
 def test_ippo_learns_from_hardcoded_vectorized_experiences_mlp(
-    observation_spaces,
-    batch_size,
-    vect_dim,
-    action_spaces,
-    agent_ids,
+    ma_vector_space,
     device,
-    compile_mode,
 ):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     states = {
         agent: np.array(
             [
-                [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
-                [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
-                [[7, 7, 7], [8, 8, 8], [9, 9, 9]],
+                [[1, 1, 1, 1, 1, 1], [2, 2, 2, 2, 2, 2], [3, 3, 3, 3, 3, 3]],
+                [[4, 4, 4, 4, 4, 4], [5, 5, 5, 5, 5, 5], [6, 6, 6, 6, 6, 6]],
+                [[7, 7, 7, 7, 7, 7], [8, 8, 8, 8, 8, 8], [9, 9, 9, 9, 9, 9]],
             ]
         )
         * i
         for i, agent in enumerate(agent_ids)
     }
-
     actions = {
         agent: np.array(
             [
-                [[1, 1, 1], [2, 2, 2], [3, 3, 3]],
-                [[4, 4, 4], [5, 5, 5], [6, 6, 6]],
-                [[7, 7, 7], [8, 8, 8], [9, 9, 9]],
+                [[1, 1, 1, 1, 1, 1], [2, 2, 2, 2, 2, 2], [3, 3, 3, 3, 3, 3]],
+                [[4, 4, 4, 4, 4, 4], [5, 5, 5, 5, 5, 5], [6, 6, 6, 6, 6, 6]],
+                [[7, 7, 7, 7, 7, 7], [8, 8, 8, 8, 8, 8], [9, 9, 9, 9, 9, 9]],
             ]
         )
         * i
@@ -1312,7 +849,10 @@ def test_ippo_learns_from_hardcoded_vectorized_experiences_mlp(
         for i, agent in enumerate(agent_ids)
     }
     next_state = {
-        agent: np.array([[4, 4, 4], [7, 7, 7], [10, 10, 10]]) * i
+        agent: np.array(
+            [[4, 4, 4, 4, 4, 4], [7, 7, 7, 7, 7, 7], [10, 10, 10, 10, 10, 10]]
+        )
+        * i
         for i, agent in enumerate(agent_ids)
     }
     next_done = {agent: np.array([[0, 1, 0]]) for i, agent in enumerate(agent_ids)}
@@ -1327,14 +867,13 @@ def test_ippo_learns_from_hardcoded_vectorized_experiences_mlp(
         next_state,
         next_done,
     )
-    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_vector_space,
         agent_ids=agent_ids,
         device=device,
-        torch_compiler=compile_mode,
-        batch_size=batch_size,
+        torch_compiler=None,
+        batch_size=32,
     )
 
     actors = ippo.actors
@@ -1386,21 +925,17 @@ def no_sync(self):
 @pytest.mark.parametrize(
     "action_spaces",
     [
-        generate_multi_agent_discrete_spaces(3, 2),
-        generate_multi_agent_box_spaces(3, (2,)),
+        "ma_discrete_space",
+        "ma_vector_space",
     ],
 )
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-@pytest.mark.parametrize(
-    "observation_spaces", [generate_multi_agent_box_spaces(3, (6,))]
-)
 def test_ippo_get_action_agent_masking(
-    observation_spaces, action_spaces, device, compile_mode
+    ma_vector_space, action_spaces, device, compile_mode, request
 ):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
-    state = {
-        agent: np.random.randn(*observation_spaces[0].shape) for agent in agent_ids
-    }
+    state = {agent: np.random.randn(*ma_vector_space[0].shape) for agent in agent_ids}
+    action_spaces = request.getfixturevalue(action_spaces)
     discrete_actions = all(
         isinstance(space, spaces.Discrete) for space in action_spaces
     )
@@ -1412,15 +947,15 @@ def test_ippo_get_action_agent_masking(
         }
     else:
         info = {
-            "agent_0": {"env_defined_actions": np.array([0, 1])},
+            "agent_0": {"env_defined_actions": np.array([0, 1, 0, 1, 0, 1])},
             "agent_1": {"env_defined_actions": None},
             "other_agent_0": {"env_defined_actions": None},
         }
 
     # Define the ippo agent
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=ma_vector_space,
+        action_spaces=action_spaces,
         agent_ids=agent_ids,
         device=device,
         torch_compiler=compile_mode,
@@ -1432,29 +967,27 @@ def test_ippo_get_action_agent_masking(
     if discrete_actions:
         assert np.array_equal(actions["agent_0"], np.array([[1]])), actions["agent_0"]
     else:
-        assert np.array_equal(actions["agent_0"], np.array([[0, 1]])), actions[
-            "agent_0"
-        ]
+        assert np.array_equal(
+            actions["agent_0"], np.array([[0, 1, 0, 1, 0, 1]])
+        ), actions["agent_0"]
 
 
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_discrete_spaces(3, 4),
-        generate_multi_agent_box_spaces(3, (4,)),
-        generate_multi_agent_box_spaces(3, (4, 32, 32), low=0, high=255),
-        generate_multi_agent_multidiscrete_spaces(3, 2),
-        gen_multi_agent_dict_or_tuple_spaces(3, 1, 1, dict_space=True),
-        gen_multi_agent_dict_or_tuple_spaces(3, 1, 1, dict_space=False),
+        "ma_discrete_space",
+        "ma_vector_space",
+        "ma_image_space",
+        "ma_dict_space",
     ],
 )
 @pytest.mark.parametrize(
     "action_spaces",
     [
-        generate_multi_agent_discrete_spaces(3, 2),
-        generate_multi_agent_box_spaces(3, (2,), low=-1, high=1),
-        [spaces.MultiBinary(2) for _ in range(3)],
-        generate_multi_agent_multidiscrete_spaces(3, 2),
+        "ma_discrete_space",
+        "ma_vector_space",
+        "ma_multidiscrete_space",
+        "ma_multibinary_space",
     ],
 )
 @pytest.mark.parametrize("action_batch_size", [None, 16])
@@ -1467,8 +1000,11 @@ def test_ippo_get_action(
     compile_mode,
     accelerator,
     action_batch_size,
+    request,
 ):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
 
     state = {}
     for agent_id, obs_space in zip(agent_ids, observation_spaces):
@@ -1486,8 +1022,8 @@ def test_ippo_get_action(
 
     info = None
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=observation_spaces,
+        action_spaces=action_spaces,
         agent_ids=agent_ids,
         device=device,
         torch_compiler=compile_mode,
@@ -1512,24 +1048,25 @@ def test_ippo_get_action(
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_box_spaces(3, (6,)),
-        generate_multi_agent_box_spaces(3, (3, 32, 32), low=0, high=255),
+        "ma_vector_space",
+        "ma_image_space",
     ],
 )
 @pytest.mark.parametrize(
     "action_spaces",
     [
-        generate_multi_agent_box_spaces(3, (2,), low=-1, high=1),
-        generate_multi_agent_discrete_spaces(3, 2),
+        "ma_vector_space",
+        "ma_discrete_space",
     ],
 )
-@pytest.mark.parametrize("training", [1, 0])
-@pytest.mark.parametrize("compile_mode", [None])
+@pytest.mark.parametrize("compile_mode", [None, "default"])
 def test_ippo_get_action_vectorized(
-    training, observation_spaces, action_spaces, device, compile_mode
+    observation_spaces, action_spaces, device, compile_mode, request
 ):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     vect_dim = 2
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     if all(isinstance(space, spaces.Discrete) for space in observation_spaces):
         state = {
             agent: np.random.randint(0, observation_spaces[idx].n, (vect_dim, 1))
@@ -1546,8 +1083,8 @@ def test_ippo_get_action_vectorized(
         info = {agent: {} for agent in agent_ids}
 
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=observation_spaces,
+        action_spaces=action_spaces,
         agent_ids=agent_ids,
         device=device,
         torch_compiler=compile_mode,
@@ -1567,24 +1104,20 @@ def test_ippo_get_action_vectorized(
         assert agent_id in state_values
 
 
-def test_ippo_get_action_action_masking_exception(device):
+def test_ippo_get_action_action_masking_exception(
+    ma_vector_space, ma_discrete_space, device
+):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
-    observation_spaces = generate_multi_agent_box_spaces(3, (6,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 4)
     state = {
         agent: {
-            "observation": np.random.randn(*observation_spaces[idx].shape),
+            "observation": np.random.randn(*ma_vector_space[idx].shape),
             "action_mask": [0, 1, 0, 1],
         }
         for idx, agent in enumerate(agent_ids)
     }
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
-        net_config={
-            "encoder_config": {"hidden_size": [64, 64], "init_layers": False},
-            "head_config": {"hidden_size": [32], "init_layers": False},
-        },
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_discrete_space,
         agent_ids=agent_ids,
         device=device,
     )
@@ -1592,23 +1125,21 @@ def test_ippo_get_action_action_masking_exception(device):
         actions, log_probs, dist_entropy, state_values = ippo.get_action(obs=state)
 
 
-def test_ippo_get_action_action_masking(device):
+def test_ippo_get_action_action_masking(ma_vector_space, ma_discrete_space, device):
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
-    observation_spaces = generate_multi_agent_box_spaces(3, (6,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 4)
     state = {
-        agent: np.random.randn(*observation_spaces[idx].shape).astype(np.float32)
+        agent: np.random.randn(*ma_vector_space[idx].shape).astype(np.float32)
         for idx, agent in enumerate(agent_ids)
     }
     info = {
         agent: {
-            "action_mask": [0, 1, 0, 1],
+            "action_mask": [0, 1],
         }
         for agent in agent_ids
     }
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_discrete_space,
         agent_ids=agent_ids,
         device=device,
     )
@@ -1623,10 +1154,10 @@ def test_ippo_get_action_action_masking(device):
 @pytest.mark.parametrize(
     "mode", (None, 0, False, "default", "reduce-overhead", "max-autotune")
 )
-def test_ippo_init_torch_compiler_no_error(mode):
+def test_ippo_init_torch_compiler_no_error(ma_vector_space, ma_discrete_space, mode):
     ippo = IPPO(
-        observation_spaces=generate_multi_agent_box_spaces(3, (1,)),
-        action_spaces=generate_multi_agent_discrete_spaces(3, 1),
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_discrete_space,
         agent_ids=["agent_0", "agent_1", "other_agent_0"],
         device="cuda" if torch.cuda.is_available() else "cpu",
         torch_compiler=mode,
@@ -1646,15 +1177,17 @@ def test_ippo_init_torch_compiler_no_error(mode):
 
 
 @pytest.mark.parametrize("mode", (1, True, "max-autotune-no-cudagraphs"))
-def test_ippo_init_torch_compiler_error(mode):
+def test_ippo_init_torch_compiler_error(
+    mode, ma_vector_space, ma_discrete_space, device
+):
     err_string = (
         "Choose between torch compiler modes: "
         "default, reduce-overhead, max-autotune or None"
     )
     with pytest.raises(AssertionError, match=err_string):
         IPPO(
-            observation_spaces=generate_multi_agent_box_spaces(3, (1,)),
-            action_spaces=generate_multi_agent_discrete_spaces(3, 1),
+            observation_spaces=ma_vector_space,
+            action_spaces=ma_discrete_space,
             agent_ids=["agent_0", "agent_1", "other_agent_0"],
             device="cuda" if torch.cuda.is_available() else "cpu",
             torch_compiler=mode,
@@ -1664,22 +1197,24 @@ def test_ippo_init_torch_compiler_error(mode):
 @pytest.mark.parametrize(
     "observation_spaces",
     [
-        generate_multi_agent_box_spaces(3, (4,)),
-        generate_multi_agent_box_spaces(3, (3, 32, 32), low=0, high=255),
+        "ma_vector_space",
+        "ma_image_space",
     ],
 )
 @pytest.mark.parametrize("accelerator_flag", [False, True])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
 def test_initialize_ippo_with_net_config(
-    accelerator_flag, observation_spaces, device, compile_mode
+    accelerator_flag,
+    observation_spaces,
+    ma_discrete_space,
+    device,
+    compile_mode,
+    request,
 ):
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+    observation_spaces = request.getfixturevalue(observation_spaces)
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     batch_size = 64
-    if accelerator_flag:
-        accelerator = Accelerator()
-    else:
-        accelerator = None
+    accelerator = Accelerator() if accelerator_flag else None
 
     net_config = {
         "encoder_config": get_default_encoder_config(observation_spaces[0]),
@@ -1687,7 +1222,7 @@ def test_initialize_ippo_with_net_config(
     }
     ippo = IPPO(
         observation_spaces=observation_spaces,
-        action_spaces=action_spaces,
+        action_spaces=ma_discrete_space,
         agent_ids=agent_ids,
         net_config=net_config,
         accelerator=accelerator,
@@ -1697,7 +1232,7 @@ def test_initialize_ippo_with_net_config(
     )
 
     assert ippo.observation_spaces == observation_spaces
-    assert ippo.action_spaces == action_spaces
+    assert ippo.action_spaces == ma_discrete_space
     assert ippo.n_agents == len(agent_ids)
     assert ippo.agent_ids == agent_ids
     assert ippo.batch_size == batch_size
@@ -1734,12 +1269,10 @@ def test_initialize_ippo_with_net_config(
 
 
 # TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_spaces", [generate_multi_agent_box_spaces(3, (6,))]
-)
-@pytest.mark.parametrize("action_spaces", [generate_multi_agent_discrete_spaces(3, 2)])
 @pytest.mark.parametrize("accelerator_flag", [False, True])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
+@pytest.mark.parametrize("observation_spaces", ["ma_vector_space"])
+@pytest.mark.parametrize("action_spaces", ["ma_discrete_space"])
 def test_initialize_ippo_with_mlp_networks(
     mlp_actor,
     mlp_critic,
@@ -1748,7 +1281,10 @@ def test_initialize_ippo_with_mlp_networks(
     accelerator_flag,
     device,
     compile_mode,
+    request,
 ):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     accelerator = Accelerator() if accelerator_flag else None
     evo_actors = ModuleDict(
         {
@@ -1770,10 +1306,11 @@ def test_initialize_ippo_with_mlp_networks(
             ),
         }
     )
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     ippo = IPPO(
         observation_spaces=observation_spaces,
         action_spaces=action_spaces,
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
+        agent_ids=agent_ids,
         actor_networks=evo_actors,
         critic_networks=evo_critics,
         device=device,
@@ -1794,7 +1331,7 @@ def test_initialize_ippo_with_mlp_networks(
     assert ippo.observation_spaces == observation_spaces
     assert ippo.action_spaces == action_spaces
     assert ippo.n_agents == 3
-    assert ippo.agent_ids == ["agent_0", "agent_1", "other_agent_0"]
+    assert ippo.agent_ids == agent_ids
     assert ippo.scores == []
     assert ippo.fitness == []
     assert ippo.steps == [0]
@@ -1819,17 +1356,18 @@ def test_initialize_ippo_with_mlp_networks(
     assert isinstance(ippo.criterion, nn.MSELoss)
 
 
-@pytest.mark.parametrize(
-    "observation_spaces", [generate_multi_agent_box_spaces(3, (6,))]
-)
-@pytest.mark.parametrize("action_spaces", [generate_multi_agent_discrete_spaces(3, 2)])
+@pytest.mark.parametrize("observation_spaces", ["ma_vector_space"])
+@pytest.mark.parametrize("action_spaces", ["ma_discrete_space"])
 def test_initialize_ippo_with_mlp_networks_gumbel_softmax(
     mlp_actor,
     mlp_critic,
     observation_spaces,
     action_spaces,
     device,
+    request,
 ):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     net_config = {
         "encoder_config": {
             "hidden_size": [64, 64],
@@ -1847,10 +1385,11 @@ def test_initialize_ippo_with_mlp_networks_gumbel_softmax(
             "init_layers": False,
         },
     }
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     ippo = IPPO(
         observation_spaces=observation_spaces,
         action_spaces=action_spaces,
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
+        agent_ids=agent_ids,
         net_config=net_config,
         device=device,
         torch_compiler="reduce-overhead",
@@ -1859,18 +1398,13 @@ def test_initialize_ippo_with_mlp_networks_gumbel_softmax(
 
 
 # TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_spaces",
-    [generate_multi_agent_box_spaces(3, (4, 210, 160), low=0, high=255)],
-)
-@pytest.mark.parametrize("action_spaces", [generate_multi_agent_discrete_spaces(3, 2)])
 @pytest.mark.parametrize("accelerator_flag", [False, True])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
 def test_initialize_ippo_with_cnn_networks(
     cnn_actor,
     cnn_critic,
-    observation_spaces,
-    action_spaces,
+    ma_image_space,
+    ma_discrete_space,
     accelerator_flag,
     device,
     compile_mode,
@@ -1883,12 +1417,12 @@ def test_initialize_ippo_with_cnn_networks(
         {
             "agent": MakeEvolvable(
                 network=cnn_actor,
-                input_tensor=torch.randn(1, 4, 210, 160),
+                input_tensor=torch.randn(1, *ma_image_space[0].shape),
                 device=device,
             ),
             "other_agent": MakeEvolvable(
                 network=cnn_actor,
-                input_tensor=torch.randn(1, 4, 210, 160),
+                input_tensor=torch.randn(1, *ma_image_space[0].shape),
                 device=device,
             ),
         }
@@ -1897,20 +1431,21 @@ def test_initialize_ippo_with_cnn_networks(
         {
             "agent": MakeEvolvable(
                 network=cnn_critic,
-                input_tensor=torch.randn(1, 4, 210, 160),
+                input_tensor=torch.randn(1, *ma_image_space[0].shape),
                 device=device,
             ),
             "other_agent": MakeEvolvable(
                 network=cnn_critic,
-                input_tensor=torch.randn(1, 4, 210, 160),
+                input_tensor=torch.randn(1, *ma_image_space[0].shape),
                 device=device,
             ),
         }
     )
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     ippo = IPPO(
-        observation_spaces=observation_spaces,
-        action_spaces=action_spaces,
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
+        observation_spaces=ma_image_space,
+        action_spaces=ma_discrete_space,
+        agent_ids=agent_ids,
         actor_networks=evo_actors,
         critic_networks=evo_critics,
         device=device,
@@ -1928,10 +1463,10 @@ def test_initialize_ippo_with_cnn_networks(
             isinstance(critic, MakeEvolvable) for critic in ippo.critics.values()
         )
 
-    assert ippo.observation_spaces == observation_spaces
-    assert ippo.action_spaces == action_spaces
+    assert ippo.observation_spaces == ma_image_space
+    assert ippo.action_spaces == ma_discrete_space
     assert ippo.n_agents == 3
-    assert ippo.agent_ids == ["agent_0", "agent_1", "other_agent_0"]
+    assert ippo.agent_ids == agent_ids
     assert ippo.scores == []
     assert ippo.fitness == []
     assert ippo.steps == [0]
@@ -1959,16 +1494,22 @@ def test_initialize_ippo_with_cnn_networks(
 @pytest.mark.parametrize(
     "observation_spaces, net",
     [
-        (generate_multi_agent_box_spaces(3, (4, 210, 160), low=0, high=255), "cnn"),
-        (generate_multi_agent_box_spaces(3, (4,)), "mlp"),
+        ("ma_image_space", "cnn"),
+        ("ma_vector_space", "mlp"),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
 def test_initialize_ippo_with_evo_networks(
-    observation_spaces, net, device, compile_mode, accelerator
+    observation_spaces,
+    ma_discrete_space,
+    net,
+    device,
+    compile_mode,
+    accelerator,
+    request,
 ):
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+    observation_spaces = request.getfixturevalue(observation_spaces)
     net_config = get_default_encoder_config(observation_spaces[0])
 
     head_config = {
@@ -1990,10 +1531,10 @@ def test_initialize_ippo_with_evo_networks(
     evo_actors = ModuleDict(
         {
             "agent": StochasticActor(
-                observation_spaces[0], action_spaces[0], device=device, **net_config
+                observation_spaces[0], ma_discrete_space[0], device=device, **net_config
             ),
             "other_agent": StochasticActor(
-                observation_spaces[1], action_spaces[1], device=device, **net_config
+                observation_spaces[2], ma_discrete_space[2], device=device, **net_config
             ),
         }
     )
@@ -2011,11 +1552,11 @@ def test_initialize_ippo_with_evo_networks(
             ),
         }
     )
-
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     ippo = IPPO(
         observation_spaces=observation_spaces,
-        action_spaces=action_spaces,
-        agent_ids=["agent_0", "agent_1", "other_agent_0"],
+        action_spaces=ma_discrete_space,
+        agent_ids=agent_ids,
         actor_networks=evo_actors,
         critic_networks=evo_critics,
         device=device,
@@ -2049,9 +1590,9 @@ def test_initialize_ippo_with_evo_networks(
     )
 
     assert ippo.observation_spaces == observation_spaces
-    assert ippo.action_spaces == action_spaces
+    assert ippo.action_spaces == ma_discrete_space
     assert ippo.n_agents == 3
-    assert ippo.agent_ids == ["agent_0", "agent_1", "other_agent_0"]
+    assert ippo.agent_ids == agent_ids
     assert ippo.scores == []
     assert ippo.fitness == []
     assert ippo.steps == [0]
@@ -2059,17 +1600,18 @@ def test_initialize_ippo_with_evo_networks(
 
 
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_initialize_ippo_with_incorrect_evo_networks(compile_mode):
-    observation_spaces = generate_multi_agent_box_spaces(3, (4,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+def test_initialize_ippo_with_incorrect_evo_networks(
+    compile_mode, ma_vector_space, ma_discrete_space
+):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     evo_actors = []
     evo_critics = []
 
     with pytest.raises(AssertionError):
         ippo = IPPO(
-            observation_spaces=observation_spaces,
-            action_spaces=action_spaces,
-            agent_ids=["agent_0", "agent_1", "other_agent_0"],
+            observation_spaces=ma_vector_space,
+            action_spaces=ma_discrete_space,
+            agent_ids=agent_ids,
             actor_networks=evo_actors,
             critic_networks=evo_critics,
             torch_compiler=compile_mode,
@@ -2081,23 +1623,24 @@ def test_initialize_ippo_with_incorrect_evo_networks(compile_mode):
     "observation_spaces, action_spaces, actors, critics",
     [
         (
-            generate_multi_agent_box_spaces(3, (4,)),
-            generate_multi_agent_discrete_spaces(3, 2),
+            "ma_vector_space",
+            "ma_discrete_space",
             [EvolvableMLP(4, 2, [32]) for _ in range(2)],
             [1 for _ in range(2)],
         ),
         (
-            generate_multi_agent_box_spaces(3, (4,)),
-            generate_multi_agent_discrete_spaces(3, 2),
+            "ma_vector_space",
+            "ma_discrete_space",
             [1 for _ in range(2)],
             [EvolvableMLP(4, 2, [32]) for _ in range(2)],
         ),
     ],
 )
 def test_initialize_ippo_with_incorrect_networks(
-    observation_spaces, action_spaces, actors, critics
+    observation_spaces, action_spaces, actors, critics, request
 ):
-
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     with pytest.raises(TypeError):
         ippo = IPPO(
             observation_spaces=observation_spaces,
@@ -2109,14 +1652,14 @@ def test_initialize_ippo_with_incorrect_networks(
         assert ippo
 
 
-@pytest.mark.parametrize(
-    "observation_spaces", [generate_multi_agent_box_spaces(3, (6,))]
-)
-@pytest.mark.parametrize("action_spaces", [generate_multi_agent_discrete_spaces(3, 2)])
 @pytest.mark.parametrize("compile_mode", [None, "default"])
+@pytest.mark.parametrize("observation_spaces", ["ma_vector_space"])
+@pytest.mark.parametrize("action_spaces", ["ma_discrete_space"])
 def test_ippo_init_warning(
-    mlp_actor, observation_spaces, action_spaces, device, compile_mode
+    mlp_actor, observation_spaces, action_spaces, device, compile_mode, request
 ):
+    observation_spaces = request.getfixturevalue(observation_spaces)
+    action_spaces = request.getfixturevalue(action_spaces)
     warning_string = "Actor and critic network lists must both be supplied to use custom networks. Defaulting to net config."
     evo_actors = [
         MakeEvolvable(network=mlp_actor, input_tensor=torch.randn(1, 6), device=device)
@@ -2133,18 +1676,16 @@ def test_ippo_init_warning(
         )
 
 
-def test_grouped_outputs_functions():
+def test_grouped_outputs_functions(ma_vector_space, ma_discrete_space):
     """Test that the assemble_grouped_outputs and disassemble_grouped_outputs
     functions work as expected and are inverses of each other."""
 
     # Initialize agent with grouped agents
-    observation_spaces = generate_multi_agent_box_spaces(3, (6,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
     compile_mode = None
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     agent = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_discrete_space,
         agent_ids=agent_ids,
         device="cpu",
         torch_compiler=compile_mode,
@@ -2199,18 +1740,16 @@ def test_grouped_outputs_functions():
 
 
 @pytest.mark.parametrize("compile_mode", [None, "default"])
-def test_get_action_distributed(compile_mode):
-    observation_spaces = generate_multi_agent_box_spaces(3, (6,))
-    action_spaces = generate_multi_agent_discrete_spaces(3, 2)
+def test_get_action_distributed(compile_mode, ma_vector_space, ma_discrete_space):
     accelerator = Accelerator()
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     state = {
-        agent: np.random.randn(*observation_spaces[idx].shape).astype(np.float32)
+        agent: np.random.randn(*ma_vector_space[idx].shape).astype(np.float32)
         for idx, agent in enumerate(agent_ids)
     }
     ippo = IPPO(
-        observation_spaces,
-        action_spaces,
+        observation_spaces=ma_vector_space,
+        action_spaces=ma_discrete_space,
         agent_ids=agent_ids,
         accelerator=accelerator,
         torch_compiler=compile_mode,

--- a/tests/test_algorithms/test_neural_ts.py
+++ b/tests/test_algorithms/test_neural_ts.py
@@ -1,7 +1,5 @@
 import copy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -15,18 +13,7 @@ from tensordict import TensorDict
 from agilerl.algorithms.neural_ts_bandit import NeuralTS
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.wrappers.make_evolvable import MakeEvolvable
-from tests.helper_functions import (
-    assert_not_equal_state_dict,
-    assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_random_box_space,
-)
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
+from tests.helper_functions import assert_not_equal_state_dict, assert_state_dicts_equal
 
 
 class DummyNeuralTS(NeuralTS):
@@ -66,48 +53,19 @@ class DummyBanditEnv:
         )
 
 
-@pytest.fixture
-def simple_mlp():
-    network = nn.Sequential(
-        nn.Linear(4, 64),
-        nn.ReLU(),
-        nn.Linear(64, 1),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_cnn():
-    network = nn.Sequential(
-        nn.Conv2d(
-            3, 4, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 3 (for RGB images), Output channels: 16
-        nn.ReLU(),
-        nn.Conv2d(
-            4, 4, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 16, Output channels: 32
-        nn.ReLU(),
-        nn.Flatten(),  # Flatten the 2D feature map to a 1D vector
-        nn.Linear(32 * 4 * 4 * 32, 8),  # Fully connected layer with 128 output features
-        nn.ReLU(),
-        nn.Linear(8, 1),
-    )
-    return network
-
-
 # initialize NeuralTS with valid parameters
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 64, 64)), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_bandit(observation_space, encoder_cls, accelerator):
+def test_initialize_bandit(observation_space, encoder_cls, accelerator, request):
     action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     device = accelerator.device if accelerator else "cpu"
     bandit = NeuralTS(observation_space, action_space, accelerator=accelerator)
 
@@ -137,21 +95,21 @@ def test_initialize_bandit(observation_space, encoder_cls, accelerator):
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (spaces.Box(0, 1, shape=(3, 64, 64)), "simple_cnn", torch.randn(1, 3, 64, 64)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
+        ("image_space", "simple_cnn", torch.randn(1, 3, 32, 32)),
     ],
 )
 def test_initialize_bandit_with_make_evo(
-    observation_space, actor_network, input_tensor, request
+    observation_space, discrete_space, actor_network, input_tensor, request
 ):
-    action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
-    bandit = NeuralTS(observation_space, action_space, actor_network=actor_network)
+    bandit = NeuralTS(observation_space, discrete_space, actor_network=actor_network)
 
     assert bandit.observation_space == observation_space
-    assert bandit.action_space == action_space
+    assert bandit.action_space == discrete_space
     assert bandit.batch_size == 64
     assert bandit.lr == 0.003
     assert bandit.learn_step == 2
@@ -169,19 +127,17 @@ def test_initialize_bandit_with_make_evo(
     assert isinstance(bandit.criterion, nn.MSELoss)
 
 
-def test_initialize_bandit_with_evo_nets():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
+def test_initialize_bandit_with_evo_nets(vector_space, discrete_space, request):
     actor_network = EvolvableMLP(
-        num_inputs=observation_space.shape[0],
+        num_inputs=vector_space.shape[0],
         num_outputs=1,
         hidden_size=[64, 64],
         layer_norm=False,
     )
 
-    bandit = NeuralTS(observation_space, action_space, actor_network=actor_network)
-    assert bandit.observation_space == observation_space
-    assert bandit.action_space == action_space
+    bandit = NeuralTS(vector_space, discrete_space, actor_network=actor_network)
+    assert bandit.observation_space == vector_space
+    assert bandit.action_space == discrete_space
     assert bandit.batch_size == 64
     assert bandit.lr == 0.003
     assert bandit.learn_step == 2
@@ -199,13 +155,13 @@ def test_initialize_bandit_with_evo_nets():
     assert isinstance(bandit.criterion, nn.MSELoss)
 
 
-def test_initialize_neuralts_with_incorrect_actor_net_type():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
+def test_initialize_neuralts_with_incorrect_actor_net_type(
+    vector_space, discrete_space
+):
     actor_network = "dummy"
 
     with pytest.raises(TypeError) as a:
-        bandit = NeuralTS(observation_space, action_space, actor_network=actor_network)
+        bandit = NeuralTS(vector_space, discrete_space, actor_network=actor_network)
         assert bandit
         assert (
             str(a.value)
@@ -214,11 +170,8 @@ def test_initialize_neuralts_with_incorrect_actor_net_type():
 
 
 # Returns the expected action when given a state observation and epsilon=0 or 1.
-def test_returns_expected_action():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
-
-    bandit = NeuralTS(observation_space, action_space)
+def test_returns_expected_action(vector_space, discrete_space):
+    bandit = NeuralTS(vector_space, discrete_space)
     state = np.array([1, 2, 3, 4])
 
     action_mask = None
@@ -226,16 +179,13 @@ def test_returns_expected_action():
     action = bandit.get_action(state, action_mask)
 
     assert action.is_integer()
-    assert action >= 0 and action < action_space.n
+    assert action >= 0 and action < discrete_space.n
 
 
 # Returns the expected action when given a state observation and action mask.
-def test_returns_expected_action_mask():
+def test_returns_expected_action_mask(vector_space, discrete_space):
     accelerator = Accelerator()
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
-
-    bandit = NeuralTS(observation_space, action_space, accelerator=accelerator)
+    bandit = NeuralTS(vector_space, discrete_space, accelerator=accelerator)
     state = np.array([1, 2, 3, 4])
 
     action_mask = np.array([0, 1])
@@ -247,22 +197,18 @@ def test_returns_expected_action_mask():
 
 
 # learns from experiences and updates network parameters
-@pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32)),
-    ],
-)
+@pytest.mark.parametrize("observation_space", ["vector_space", "image_space"])
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_learns_from_experiences(observation_space, accelerator):
-    action_space = spaces.Discrete(2)
+def test_learns_from_experiences(
+    observation_space, discrete_space, accelerator, request
+):
+    observation_space = request.getfixturevalue(observation_space)
     batch_size = 64
 
     # Create an instance of the NeuralTS class
     bandit = NeuralTS(
         observation_space,
-        action_space,
+        discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
     )
@@ -291,37 +237,24 @@ def test_learns_from_experiences(observation_space, accelerator):
 
 
 # Runs algorithm test loop
-@pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32)),
-    ],
-)
-def test_algorithm_test_loop(observation_space):
-    action_space = spaces.Discrete(2)
+@pytest.mark.parametrize("observation_space", ["vector_space", "image_space"])
+def test_algorithm_test_loop(observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
 
-    env = DummyBanditEnv(state_size=observation_space.shape, arms=action_space.n)
+    env = DummyBanditEnv(state_size=observation_space.shape, arms=discrete_space.n)
 
-    agent = NeuralTS(observation_space=observation_space, action_space=action_space)
+    agent = NeuralTS(observation_space=observation_space, action_space=discrete_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
 
 # Clones the agent and returns an identical agent.
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32)),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
-def test_clone_returns_identical_agent(observation_space):
-    action_space = spaces.Discrete(2)
-
-    bandit = DummyNeuralTS(observation_space, action_space)
+def test_clone_returns_identical_agent(observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
+    bandit = DummyNeuralTS(observation_space, discrete_space)
     bandit.tensor_attribute = torch.randn(1)
     bandit.numpy_attribute = np.random.rand(1)
     clone_agent = bandit.clone()
@@ -348,7 +281,7 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.numpy_test == bandit.numpy_test
 
     accelerator = Accelerator()
-    bandit = NeuralTS(observation_space, action_space, accelerator=accelerator)
+    bandit = NeuralTS(observation_space, discrete_space, accelerator=accelerator)
     clone_agent = bandit.clone()
 
     assert clone_agent.observation_space == bandit.observation_space
@@ -370,7 +303,7 @@ def test_clone_returns_identical_agent(observation_space):
 
     accelerator = Accelerator()
     bandit = NeuralTS(
-        observation_space, action_space, accelerator=accelerator, wrap=False
+        observation_space, discrete_space, accelerator=accelerator, wrap=False
     )
     clone_agent = bandit.clone(wrap=False)
 
@@ -396,20 +329,22 @@ def test_clone_returns_identical_agent(observation_space):
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (spaces.Box(0, 1, shape=(3, 64, 64)), "simple_cnn", torch.randn(1, 3, 64, 64)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
+        ("image_space", "simple_cnn", torch.randn(1, 3, 32, 32)),
     ],
 )
-def test_clone_with_make_evo(observation_space, actor_network, input_tensor, request):
-    action_space = spaces.Discrete(2)
+def test_clone_with_make_evo(
+    observation_space, discrete_space, actor_network, input_tensor, request
+):
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
-    bandit = NeuralTS(observation_space, action_space, actor_network=actor_network)
+    bandit = NeuralTS(observation_space, discrete_space, actor_network=actor_network)
     clone_agent = bandit.clone()
 
     assert clone_agent.observation_space == bandit.observation_space
-    assert clone_agent.action_space == bandit.action_space
+    assert clone_agent.action_space == discrete_space
     assert clone_agent.batch_size == bandit.batch_size
     assert clone_agent.lr == bandit.lr
     assert clone_agent.learn_step == bandit.learn_step
@@ -426,32 +361,26 @@ def test_clone_with_make_evo(observation_space, actor_network, input_tensor, req
     assert clone_agent.scores == bandit.scores
 
 
-def test_clone_new_index():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
-
-    bandit = NeuralTS(observation_space, action_space)
+def test_clone_new_index(vector_space, discrete_space):
+    bandit = NeuralTS(vector_space, discrete_space)
     clone_agent = bandit.clone(index=100)
-
     assert clone_agent.index == 100
 
 
-def test_clone_after_learning():
-    action_space = spaces.Discrete(2)
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_clone_after_learning(vector_space, discrete_space):
     batch_size = 4
-    states = torch.randn(batch_size, observation_space.shape[0])
+    states = torch.randn(batch_size, vector_space.shape[0])
     rewards = torch.rand(batch_size, 1)
     experiences = TensorDict(
         {"obs": states, "reward": rewards},
         batch_size=[batch_size],
     )
-    bandit = NeuralTS(observation_space, action_space, batch_size=batch_size)
+    bandit = NeuralTS(vector_space, discrete_space, batch_size=batch_size)
     bandit.learn(experiences)
     clone_agent = bandit.clone()
 
     assert clone_agent.observation_space == bandit.observation_space
-    assert clone_agent.action_space == bandit.action_space
+    assert clone_agent.action_space == discrete_space
     assert clone_agent.batch_size == bandit.batch_size
     assert clone_agent.lr == bandit.lr
     assert clone_agent.learn_step == bandit.learn_step
@@ -469,269 +398,11 @@ def test_clone_after_learning():
 
 
 # The method successfully unwraps the actor model when an accelerator is present.
-def test_unwrap_models():
+def test_unwrap_models(vector_space, discrete_space):
     bandit = NeuralTS(
-        observation_space=spaces.Box(0, 1, shape=(4,)),
-        action_space=spaces.Discrete(2),
+        observation_space=vector_space,
+        action_space=discrete_space,
         accelerator=Accelerator(),
     )
     bandit.unwrap_models()
     assert isinstance(bandit.actor, nn.Module)
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32)), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    observation_space, encoder_cls, tmpdir
-):
-    # Initialize the NeuralTS agent
-    bandit = NeuralTS(
-        observation_space=observation_space, action_space=spaces.Discrete(2)
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    bandit = NeuralTS(
-        observation_space=spaces.Box(0, 1, shape=(4,)), action_space=spaces.Discrete(2)
-    )
-    # Load checkpoint
-    bandit.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(bandit.actor.encoder, encoder_cls)
-    assert bandit.lr == 3e-3
-    assert bandit.batch_size == 64
-    assert bandit.learn_step == 2
-    assert bandit.gamma == 1.0
-    assert bandit.lamb == 1.0
-    assert bandit.reg == 0.000625
-    assert bandit.mut is None
-    assert bandit.index == 0
-    assert bandit.scores == []
-    assert bandit.fitness == []
-    assert bandit.steps == [0]
-
-    assert bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: Will be deprecated in the future
-@pytest.mark.parametrize(
-    "actor_network, input_tensor",
-    [
-        ("simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_cnn_network(
-    actor_network, input_tensor, request, tmpdir
-):
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the NeuralTS agent
-    bandit = NeuralTS(
-        observation_space=spaces.Box(0, 1, shape=(3, 64, 64)),
-        action_space=spaces.Discrete(2),
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    bandit = NeuralTS(
-        observation_space=spaces.Box(0, 1, shape=(4,)), action_space=spaces.Discrete(2)
-    )
-    # Load checkpoint
-    bandit.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(bandit.actor, nn.Module)
-    assert bandit.lr == 3e-3
-    assert bandit.batch_size == 64
-    assert bandit.learn_step == 2
-    assert bandit.gamma == 1.0
-    assert bandit.lamb == 1.0
-    assert bandit.reg == 0.000625
-    assert bandit.mut is None
-    assert bandit.index == 0
-    assert bandit.scores == []
-    assert bandit.fitness == []
-    assert bandit.steps == [0]
-
-    assert bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32)), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_load_from_pretrained(observation_space, encoder_cls, accelerator, tmpdir):
-    # Initialize the NeuralTS agent
-    bandit = NeuralTS(
-        observation_space=observation_space, action_space=spaces.Discrete(2)
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_bandit = NeuralTS.load(checkpoint_path, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_bandit.observation_space == bandit.observation_space
-    assert new_bandit.action_space == bandit.action_space
-    assert isinstance(new_bandit.actor.encoder, encoder_cls)
-    assert new_bandit.lr == bandit.lr
-    assert_state_dicts_equal(
-        copy.deepcopy(new_bandit.actor).to("cpu").state_dict(),
-        bandit.actor.state_dict(),
-    )
-    assert new_bandit.batch_size == bandit.batch_size
-    assert new_bandit.learn_step == bandit.learn_step
-    assert new_bandit.gamma == bandit.gamma
-    assert new_bandit.lamb == bandit.lamb
-    assert new_bandit.reg == bandit.reg
-    assert new_bandit.mut == bandit.mut
-    assert new_bandit.index == bandit.index
-    assert new_bandit.scores == bandit.scores
-    assert new_bandit.fitness == bandit.fitness
-    assert new_bandit.steps == bandit.steps
-
-    assert new_bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        new_bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in new_bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: Will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (spaces.Box(0, 1, shape=(3, 64, 64)), "simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_load_from_pretrained_networks(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = spaces.Discrete(2)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the NeuralTS agent
-    bandit = NeuralTS(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_bandit = NeuralTS.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_bandit.observation_space == bandit.observation_space
-    assert new_bandit.action_space == bandit.action_space
-    assert isinstance(new_bandit.actor, nn.Module)
-    assert new_bandit.lr == bandit.lr
-    assert_state_dicts_equal(
-        new_bandit.actor.to("cpu").state_dict(), bandit.actor.state_dict()
-    )
-    assert new_bandit.batch_size == bandit.batch_size
-    assert new_bandit.learn_step == bandit.learn_step
-    assert new_bandit.gamma == bandit.gamma
-    assert bandit.lamb == 1.0
-    assert bandit.reg == 0.000625
-    assert new_bandit.mut == bandit.mut
-    assert new_bandit.index == bandit.index
-    assert new_bandit.scores == bandit.scores
-    assert new_bandit.fitness == bandit.fitness
-    assert new_bandit.steps == bandit.steps
-
-    assert new_bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        new_bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in new_bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )

--- a/tests/test_algorithms/test_neural_ucb.py
+++ b/tests/test_algorithms/test_neural_ucb.py
@@ -1,7 +1,5 @@
 import copy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -15,17 +13,7 @@ from tensordict import TensorDict
 from agilerl.algorithms.neural_ucb_bandit import NeuralUCB
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.wrappers.make_evolvable import MakeEvolvable
-from tests.helper_functions import (
-    assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_random_box_space,
-)
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
+from tests.helper_functions import assert_state_dicts_equal
 
 
 class DummyNeuralUCB(NeuralUCB):
@@ -65,47 +53,18 @@ class DummyBanditEnv:
         )
 
 
-@pytest.fixture
-def simple_mlp():
-    network = nn.Sequential(
-        nn.Linear(4, 64),
-        nn.ReLU(),
-        nn.Linear(64, 1),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_cnn():
-    network = nn.Sequential(
-        nn.Conv2d(
-            3, 4, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 3 (for RGB images), Output channels: 16
-        nn.ReLU(),
-        nn.Conv2d(
-            4, 4, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 16, Output channels: 32
-        nn.ReLU(),
-        nn.Flatten(),  # Flatten the 2D feature map to a 1D vector
-        nn.Linear(32 * 4 * 4 * 32, 8),  # Fully connected layer with 128 output features
-        nn.ReLU(),
-        nn.Linear(8, 1),
-    )
-    return network
-
-
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 64, 64)), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_bandit(observation_space, encoder_cls, accelerator):
+def test_initialize_bandit(observation_space, encoder_cls, accelerator, request):
     action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     device = accelerator.device if accelerator else "cpu"
     bandit = NeuralUCB(observation_space, action_space, accelerator=accelerator)
 
@@ -135,21 +94,21 @@ def test_initialize_bandit(observation_space, encoder_cls, accelerator):
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (spaces.Box(0, 1, shape=(3, 64, 64)), "simple_cnn", torch.randn(1, 3, 64, 64)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
+        ("image_space", "simple_cnn", torch.randn(1, 3, 32, 32)),
     ],
 )
 def test_initialize_bandit_with_actor_network(
-    observation_space, actor_network, input_tensor, request
+    observation_space, discrete_space, actor_network, input_tensor, request
 ):
-    action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
-    bandit = NeuralUCB(observation_space, action_space, actor_network=actor_network)
+    bandit = NeuralUCB(observation_space, discrete_space, actor_network=actor_network)
 
     assert bandit.observation_space == observation_space
-    assert bandit.action_space == action_space
+    assert bandit.action_space == discrete_space
     assert bandit.batch_size == 64
     assert bandit.lr == 0.001
     assert bandit.learn_step == 2
@@ -167,13 +126,11 @@ def test_initialize_bandit_with_actor_network(
     assert isinstance(bandit.criterion, nn.MSELoss)
 
 
-def test_initialize_bandit_with_incorrect_actor_network():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
-    actor_network = nn.Sequential(nn.Linear(observation_space.shape[0], action_space.n))
+def test_initialize_bandit_with_incorrect_actor_network(vector_space, discrete_space):
+    actor_network = nn.Sequential(nn.Linear(vector_space.shape[0], discrete_space.n))
 
     with pytest.raises(TypeError) as e:
-        bandit = NeuralUCB(observation_space, action_space, actor_network=actor_network)
+        bandit = NeuralUCB(vector_space, discrete_space, actor_network=actor_network)
 
         assert bandit
         assert (
@@ -182,19 +139,15 @@ def test_initialize_bandit_with_incorrect_actor_network():
         )
 
 
-def test_initialize_bandit_with_evo_nets():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
+def test_initialize_bandit_with_evo_nets(vector_space, discrete_space):
     actor_network = EvolvableMLP(
-        num_inputs=observation_space.shape[0],
+        num_inputs=vector_space.shape[0],
         num_outputs=1,
         hidden_size=[64, 64],
         layer_norm=False,
     )
 
-    bandit = NeuralUCB(observation_space, action_space, actor_network=actor_network)
-    assert bandit.observation_space == observation_space
-    assert bandit.action_space == action_space
+    bandit = NeuralUCB(vector_space, discrete_space, actor_network=actor_network)
     assert bandit.batch_size == 64
     assert bandit.lr == 0.001
     assert bandit.learn_step == 2
@@ -212,13 +165,12 @@ def test_initialize_bandit_with_evo_nets():
     assert isinstance(bandit.criterion, nn.MSELoss)
 
 
-def test_initialize_neuralucb_with_incorrect_actor_net_type():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
+def test_initialize_neuralucb_with_incorrect_actor_net_type(
+    vector_space, discrete_space
+):
     actor_network = "dummy"
-
     with pytest.raises(TypeError) as a:
-        bandit = NeuralUCB(observation_space, action_space, actor_network=actor_network)
+        bandit = NeuralUCB(vector_space, discrete_space, actor_network=actor_network)
         assert bandit
         assert (
             str(a.value)
@@ -227,11 +179,8 @@ def test_initialize_neuralucb_with_incorrect_actor_net_type():
 
 
 # Returns the expected action when given a state observation and epsilon=0 or 1.
-def test_returns_expected_action():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
-
-    bandit = NeuralUCB(observation_space, action_space)
+def test_returns_expected_action(vector_space, discrete_space):
+    bandit = NeuralUCB(vector_space, discrete_space)
     state = np.array([1, 2, 3, 4])
 
     action_mask = None
@@ -239,16 +188,14 @@ def test_returns_expected_action():
     action = bandit.get_action(state, action_mask)
 
     assert action.is_integer()
-    assert action >= 0 and action < action_space.n
+    assert action >= 0 and action < discrete_space.n
 
 
 # Returns the expected action when given a state observation and action mask.
-def test_returns_expected_action_mask():
+def test_returns_expected_action_mask(vector_space, discrete_space):
     accelerator = Accelerator()
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
 
-    bandit = NeuralUCB(observation_space, action_space, accelerator=accelerator)
+    bandit = NeuralUCB(vector_space, discrete_space, accelerator=accelerator)
     state = np.array([1, 2, 3, 4])
 
     action_mask = np.array([0, 1])
@@ -260,22 +207,18 @@ def test_returns_expected_action_mask():
 
 
 # learns from experiences and updates network parameters
-@pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32)),
-    ],
-)
+@pytest.mark.parametrize("observation_space", ["vector_space", "image_space"])
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_learns_from_experiences(observation_space, accelerator):
-    action_space = spaces.Discrete(2)
+def test_learns_from_experiences(
+    observation_space, discrete_space, accelerator, request
+):
+    observation_space = request.getfixturevalue(observation_space)
     batch_size = 64
 
     # Create an instance of the NeuralTS class
     bandit = NeuralUCB(
         observation_space,
-        action_space,
+        discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
     )
@@ -304,36 +247,24 @@ def test_learns_from_experiences(observation_space, accelerator):
 
 
 # Runs algorithm test loop
-@pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32)),
-    ],
-)
-def test_algorithm_test_loop(observation_space):
-    action_space = spaces.Discrete(2)
+@pytest.mark.parametrize("observation_space", ["vector_space", "image_space"])
+def test_algorithm_test_loop(observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
 
-    env = DummyBanditEnv(state_size=observation_space.shape, arms=action_space.n)
+    env = DummyBanditEnv(state_size=observation_space.shape, arms=discrete_space.n)
 
-    agent = NeuralUCB(observation_space=observation_space, action_space=action_space)
+    agent = NeuralUCB(observation_space=observation_space, action_space=discrete_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
 
 # Clones the agent and returns an identical agent.
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32)),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
-def test_clone_returns_identical_agent(observation_space):
-    action_space = spaces.Discrete(2)
-    bandit = DummyNeuralUCB(observation_space, action_space)
+def test_clone_returns_identical_agent(observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
+    bandit = DummyNeuralUCB(observation_space, discrete_space)
     bandit.tensor_attribute = torch.randn(1)
     bandit.numpy_attribute = np.random.rand(1)
     clone_agent = bandit.clone()
@@ -360,7 +291,7 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.numpy_test == bandit.numpy_test
 
     accelerator = Accelerator()
-    bandit = NeuralUCB(observation_space, action_space, accelerator=accelerator)
+    bandit = NeuralUCB(observation_space, discrete_space, accelerator=accelerator)
     clone_agent = bandit.clone()
 
     assert clone_agent.observation_space == bandit.observation_space
@@ -382,7 +313,7 @@ def test_clone_returns_identical_agent(observation_space):
 
     accelerator = Accelerator()
     bandit = NeuralUCB(
-        observation_space, action_space, accelerator=accelerator, wrap=False
+        observation_space, discrete_space, accelerator=accelerator, wrap=False
     )
     clone_agent = bandit.clone(wrap=False)
 
@@ -404,32 +335,26 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.scores == bandit.scores
 
 
-def test_clone_new_index():
-    observation_space = spaces.Box(0, 1, shape=(4,))
-    action_space = spaces.Discrete(2)
-
-    bandit = NeuralUCB(observation_space, action_space)
+def test_clone_new_index(vector_space, discrete_space):
+    bandit = NeuralUCB(vector_space, discrete_space)
     clone_agent = bandit.clone(index=100)
-
     assert clone_agent.index == 100
 
 
-def test_clone_after_learning():
-    action_space = spaces.Discrete(2)
-    observation_space = spaces.Box(0, 1, shape=(4,))
+def test_clone_after_learning(vector_space, discrete_space):
     batch_size = 4
-    states = torch.randn(batch_size, observation_space.shape[0])
+    states = torch.randn(batch_size, vector_space.shape[0])
     rewards = torch.rand(batch_size, 1)
     experiences = TensorDict(
         {"obs": states, "reward": rewards},
         batch_size=[batch_size],
     )
-    bandit = NeuralUCB(observation_space, action_space, batch_size=batch_size)
+    bandit = NeuralUCB(vector_space, discrete_space, batch_size=batch_size)
     bandit.learn(experiences)
     clone_agent = bandit.clone()
 
     assert clone_agent.observation_space == bandit.observation_space
-    assert clone_agent.action_space == bandit.action_space
+    assert clone_agent.action_space == discrete_space
     assert clone_agent.batch_size == bandit.batch_size
     assert clone_agent.lr == bandit.lr
     assert clone_agent.learn_step == bandit.learn_step
@@ -450,20 +375,22 @@ def test_clone_after_learning():
 @pytest.mark.parametrize(
     "observation_space, actor_network, input_tensor",
     [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-        (spaces.Box(0, 1, shape=(3, 64, 64)), "simple_cnn", torch.randn(1, 3, 64, 64)),
+        ("vector_space", "simple_mlp", torch.randn(1, 4)),
+        ("image_space", "simple_cnn", torch.randn(1, 3, 32, 32)),
     ],
 )
-def test_clone_with_make_evo(observation_space, actor_network, input_tensor, request):
-    action_space = spaces.Discrete(2)
+def test_clone_with_make_evo(
+    observation_space, discrete_space, actor_network, input_tensor, request
+):
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
-    bandit = NeuralUCB(observation_space, action_space, actor_network=actor_network)
+    bandit = NeuralUCB(observation_space, discrete_space, actor_network=actor_network)
     clone_agent = bandit.clone()
 
     assert clone_agent.observation_space == bandit.observation_space
-    assert clone_agent.action_space == bandit.action_space
+    assert clone_agent.action_space == discrete_space
     assert clone_agent.batch_size == bandit.batch_size
     assert clone_agent.lr == bandit.lr
     assert clone_agent.learn_step == bandit.learn_step
@@ -481,268 +408,11 @@ def test_clone_with_make_evo(observation_space, actor_network, input_tensor, req
 
 
 # The method successfully unwraps the actor model when an accelerator is present.
-def test_unwrap_models():
+def test_unwrap_models(vector_space, discrete_space):
     bandit = NeuralUCB(
-        observation_space=spaces.Box(0, 1, shape=(4,)),
-        action_space=spaces.Discrete(2),
+        observation_space=vector_space,
+        action_space=discrete_space,
         accelerator=Accelerator(),
     )
     bandit.unwrap_models()
     assert isinstance(bandit.actor, nn.Module)
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32)), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    observation_space, encoder_cls, tmpdir
-):
-    # Initialize the NeuralUCB agent
-    bandit = NeuralUCB(
-        observation_space=observation_space, action_space=spaces.Discrete(2)
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    bandit = NeuralUCB(
-        observation_space=spaces.Box(0, 1, shape=(4,)), action_space=spaces.Discrete(2)
-    )
-    # Load checkpoint
-    bandit.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(bandit.actor.encoder, encoder_cls)
-    assert bandit.lr == 1e-3
-    assert bandit.batch_size == 64
-    assert bandit.learn_step == 2
-    assert bandit.gamma == 1.0
-    assert bandit.lamb == 1.0
-    assert bandit.reg == 0.000625
-    assert bandit.mut is None
-    assert bandit.index == 0
-    assert bandit.scores == []
-    assert bandit.fitness == []
-    assert bandit.steps == [0]
-
-    assert bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: Will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_network(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the NeuralUCB agent
-    bandit = NeuralUCB(
-        observation_space=observation_space,
-        action_space=spaces.Discrete(2),
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    bandit = NeuralUCB(
-        observation_space=observation_space, action_space=spaces.Discrete(2)
-    )
-    # Load checkpoint
-    bandit.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(bandit.actor, nn.Module)
-    assert bandit.lr == 1e-3
-    assert bandit.batch_size == 64
-    assert bandit.learn_step == 2
-    assert bandit.gamma == 1.0
-    assert bandit.lamb == 1.0
-    assert bandit.reg == 0.000625
-    assert bandit.mut is None
-    assert bandit.index == 0
-    assert bandit.scores == []
-    assert bandit.fitness == []
-    assert bandit.steps == [0]
-
-    assert bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32)), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_load_from_pretrained(observation_space, encoder_cls, accelerator, tmpdir):
-    # Initialize the NeuralUCB agent
-    bandit = NeuralUCB(
-        observation_space=observation_space, action_space=spaces.Discrete(2)
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_bandit = NeuralUCB.load(checkpoint_path, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_bandit.observation_space == bandit.observation_space
-    assert new_bandit.action_space == bandit.action_space
-    assert isinstance(new_bandit.actor.encoder, encoder_cls)
-    assert new_bandit.lr == bandit.lr
-    assert_state_dicts_equal(
-        copy.deepcopy(new_bandit.actor).to("cpu").state_dict(),
-        bandit.actor.state_dict(),
-    )
-    assert new_bandit.batch_size == bandit.batch_size
-    assert new_bandit.learn_step == bandit.learn_step
-    assert new_bandit.gamma == bandit.gamma
-    assert new_bandit.lamb == bandit.lamb
-    assert new_bandit.reg == bandit.reg
-    assert new_bandit.mut == bandit.mut
-    assert new_bandit.index == bandit.index
-    assert new_bandit.scores == bandit.scores
-    assert new_bandit.fitness == bandit.fitness
-    assert new_bandit.steps == bandit.steps
-
-    assert new_bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        new_bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in new_bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )
-
-
-# TODO: Will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (spaces.Box(0, 1, shape=(4,)), "simple_mlp", torch.randn(1, 4)),
-    ],
-)
-# The saved checkpoint file contains the correct data and format.
-def test_load_from_pretrained_networks(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = spaces.Discrete(2)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the NeuralUCB agent
-    bandit = NeuralUCB(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    bandit.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_bandit = NeuralUCB.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_bandit.observation_space == bandit.observation_space
-    assert new_bandit.action_space == bandit.action_space
-    assert isinstance(new_bandit.actor, nn.Module)
-    assert new_bandit.lr == bandit.lr
-    assert_state_dicts_equal(
-        new_bandit.actor.to("cpu").state_dict(), bandit.actor.state_dict()
-    )
-    assert new_bandit.batch_size == bandit.batch_size
-    assert new_bandit.learn_step == bandit.learn_step
-    assert new_bandit.gamma == bandit.gamma
-    assert bandit.lamb == 1.0
-    assert bandit.reg == 0.000625
-    assert new_bandit.mut == bandit.mut
-    assert new_bandit.index == bandit.index
-    assert new_bandit.scores == bandit.scores
-    assert new_bandit.fitness == bandit.fitness
-    assert new_bandit.steps == bandit.steps
-
-    assert new_bandit.numel == sum(
-        w.numel() for w in bandit.exp_layer.parameters() if w.requires_grad
-    )
-    assert torch.equal(
-        new_bandit.theta_0,
-        torch.cat(
-            [w.flatten() for w in new_bandit.exp_layer.parameters() if w.requires_grad]
-        ),
-    )

--- a/tests/test_algorithms/test_ppo.py
+++ b/tests/test_algorithms/test_ppo.py
@@ -1,7 +1,5 @@
 import copy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -14,20 +12,9 @@ from gymnasium import spaces
 from agilerl.algorithms.ppo import PPO
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.wrappers.make_evolvable import MakeEvolvable
-from tests.helper_functions import (
-    assert_not_equal_state_dict,
-    assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_discrete_space,
-    generate_multidiscrete_space,
-    generate_random_box_space,
-)
+from tests.helper_functions import assert_not_equal_state_dict, assert_state_dicts_equal
 
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
+# Cleanup fixture moved to conftest.py for better performance
 
 
 class DummyPPO(PPO):
@@ -59,68 +46,6 @@ class DummyEnv:
             np.random.randint(0, 2, self.n_envs),
             {},
         )
-
-
-@pytest.fixture
-def simple_mlp():
-    network = nn.Sequential(
-        nn.Linear(4, 20),
-        nn.ReLU(),
-        nn.Linear(20, 10),
-        nn.ReLU(),
-        nn.Linear(10, 1),
-        nn.Tanh(),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_mlp_critic():
-    network = nn.Sequential(
-        nn.Linear(6, 20),
-        nn.ReLU(),
-        nn.Linear(20, 10),
-        nn.ReLU(),
-        nn.Linear(10, 1),
-        nn.Tanh(),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_cnn():
-    network = nn.Sequential(
-        nn.Conv2d(
-            3, 16, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 3 (for RGB images), Output channels: 16
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Conv2d(
-            16, 32, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 16, Output channels: 32
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Flatten(),  # Flatten the 2D feature map to a 1D vector
-        nn.Linear(32 * 16 * 16, 128),  # Fully connected layer with 128 output features
-        nn.ReLU(),
-        nn.Linear(128, 1),  # Output layer with num_classes output features
-    )
-    return network
-
-
-@pytest.fixture
-def vector_space():
-    return generate_random_box_space(shape=(4,), low=0, high=1)
-
-
-@pytest.fixture
-def image_space():
-    return generate_random_box_space(shape=(3, 32, 32), low=0, high=255)
-
-
-@pytest.fixture
-def action_space():
-    return generate_random_box_space(shape=(2,), low=0, high=1)
 
 
 class SimpleCNN(nn.Module):
@@ -155,27 +80,32 @@ class SimpleCNN(nn.Module):
         return x
 
 
+@pytest.fixture(scope="function")
+def build_ppo(observation_space, action_space, accelerator, request):
+    observation_space = request.getfixturevalue(observation_space)
+    action_space = request.getfixturevalue(action_space)
+    return PPO(observation_space, action_space, accelerator=accelerator)
+
+
 # Initializes all necessary attributes with default values
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
     ],
 )
 @pytest.mark.parametrize(
     "action_space",
-    [
-        generate_random_box_space(shape=(2,), low=-1, high=1),
-        generate_discrete_space(2),
-        generate_multidiscrete_space(2, 3),
-        spaces.MultiBinary(2),
-    ],
+    ["vector_space", "discrete_space", "multidiscrete_space", "multibinary_space"],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_ppo(observation_space, action_space, encoder_cls, accelerator):
+def test_initialize_ppo(
+    observation_space, action_space, encoder_cls, accelerator, request
+):
+    observation_space = request.getfixturevalue(observation_space)
+    action_space = request.getfixturevalue(action_space)
     ppo = PPO(observation_space, action_space, accelerator=accelerator)
     assert ppo.algo == "PPO"
     assert ppo.observation_space == observation_space
@@ -211,7 +141,7 @@ def test_initialize_ppo(observation_space, action_space, encoder_cls, accelerato
     [
         (
             "vector_space",
-            "action_space",
+            "discrete_space",
             "simple_mlp",
             "simple_mlp_critic",
             torch.randn(1, 4),
@@ -229,7 +159,7 @@ def test_initialize_ppo_with_make_evo(
     request,
 ):
     obs_space = request.getfixturevalue(obs_space)
-    action_space = generate_discrete_space(2)
+    action_space = request.getfixturevalue(action_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
     critic_network = request.getfixturevalue(critic_network)
@@ -265,15 +195,13 @@ def test_initialize_ppo_with_make_evo(
     assert isinstance(ppo.optimizer.optimizer, optim.Adam)
 
 
-def test_initialize_ppo_with_incorrect_actor_net():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_discrete_space(2)
+def test_initialize_ppo_with_incorrect_actor_net(vector_space, discrete_space):
     actor_network = "dummy"
     critic_network = "dummy"
     with pytest.raises(TypeError):
         ppo = PPO(
-            observation_space,
-            action_space,
+            vector_space,
+            discrete_space,
             actor_network=actor_network,
             critic_network=critic_network,
         )
@@ -285,7 +213,7 @@ def test_initialize_ppo_with_incorrect_actor_net():
     "observation_space, actor_network, critic_network, input_tensor, input_tensor_critic",
     [
         (
-            generate_random_box_space(shape=(4,), low=0, high=1),
+            "vector_space",
             "simple_mlp",
             "simple_mlp_critic",
             torch.randn(1, 4),
@@ -295,54 +223,38 @@ def test_initialize_ppo_with_incorrect_actor_net():
 )
 def test_initialize_ppo_with_actor_network_no_critic(
     observation_space,
+    discrete_space,
     actor_network,
     critic_network,
     input_tensor,
     input_tensor_critic,
     request,
 ):
-    action_space = generate_discrete_space(2)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
+    observation_space = request.getfixturevalue(observation_space)
     with pytest.raises(TypeError):
         ppo = PPO(
             observation_space,
-            action_space,
+            discrete_space,
             actor_network=actor_network,
             critic_network=critic_network,
         )
         assert ppo
 
 
-@pytest.fixture
-def build_ppo(observation_space, action_space, accelerator):
-    ppo = PPO(observation_space, action_space, accelerator=accelerator)
-    yield ppo
-    del ppo
-
-
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,), low=0, high=1),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=1),
-        generate_discrete_space(4),
-        generate_dict_or_tuple_space(2, 3, dict_space=False),
-        generate_dict_or_tuple_space(2, 3, dict_space=True),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
 @pytest.mark.parametrize(
     "action_space",
-    [
-        generate_random_box_space(shape=(2,), low=0, high=1),
-        generate_discrete_space(2),
-        spaces.MultiDiscrete([2, 3]),
-        spaces.MultiBinary(2),
-    ],
+    ["vector_space", "discrete_space", "multidiscrete_space", "multibinary_space"],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 # Returns the expected action when given a state observation.
-def test_returns_expected_action(observation_space, action_space, build_ppo):
+def test_returns_expected_action(observation_space, action_space, build_ppo, request):
+    observation_space = request.getfixturevalue(observation_space)
+    action_space = request.getfixturevalue(action_space)
     state = observation_space.sample()
 
     # First with grad=False
@@ -371,7 +283,7 @@ def test_returns_expected_action(observation_space, action_space, build_ppo):
         assert action.shape == (1, *action_space.shape)
 
     # Now with grad=True, and eval_action
-    eval_action = torch.Tensor([[0, 1]]).to(build_ppo.device)
+    eval_action = torch.Tensor([[0, 1, 0, 1]]).to(build_ppo.device)
     action_logprob, dist_entropy, state_values = build_ppo.evaluate_actions(
         state, actions=eval_action
     )
@@ -381,10 +293,8 @@ def test_returns_expected_action(observation_space, action_space, build_ppo):
     assert isinstance(state_values, torch.Tensor)
 
 
-def test_ppo_optimizer_parameters():
-    observation_space = spaces.Box(low=0, high=1, shape=(4,), dtype=np.float32)
-    action_space = spaces.Discrete(2)
-    ppo = PPO(observation_space, action_space)
+def test_ppo_optimizer_parameters(vector_space, discrete_space):
+    ppo = PPO(vector_space, discrete_space)
 
     # Store initial parameters
     initial_params = {
@@ -412,35 +322,32 @@ def test_ppo_optimizer_parameters():
     assert not not_updated, f"The following parameters weren't updated:\n{not_updated}"
 
 
-@pytest.mark.parametrize(
-    "observation_space", [generate_random_box_space(shape=(4,), low=0, high=1)]
-)
-@pytest.mark.parametrize("action_space", [generate_discrete_space(2)])
+@pytest.mark.parametrize("observation_space", ["vector_space"])
+@pytest.mark.parametrize("action_space", ["discrete_space"])
 @pytest.mark.parametrize("accelerator", [None])
-def test_returns_expected_action_mask_vectorized(build_ppo):
-    state = np.array([[1, 2, 4, 5], [2, 3, 5, 1]])
-    action_mask = np.array([[0, 1], [1, 0]])
+def test_returns_expected_action_mask_vectorized(
+    build_ppo, observation_space, action_space, request
+):
+    observation_space = request.getfixturevalue(observation_space)
+    action_space = request.getfixturevalue(action_space)
+    state = np.stack([observation_space.sample(), observation_space.sample()])
+    action_mask = np.stack([np.array([0, 1]), np.array([1, 0])])
     action, _, _, _ = build_ppo.get_action(state, action_mask=action_mask)
     assert np.array_equal(action, [1, 0]), action
 
 
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,), low=0, high=1),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=1),
-        generate_discrete_space(4),
-        generate_dict_or_tuple_space(2, 3, dict_space=False),
-        generate_dict_or_tuple_space(2, 3, dict_space=True),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_learns_from_experiences(observation_space, accelerator):
+def test_learns_from_experiences(
+    observation_space, discrete_space, accelerator, request
+):
     batch_size = 45
-    action_space = spaces.Discrete(2)
+    observation_space = request.getfixturevalue(observation_space)
     ppo = PPO(
         observation_space=observation_space,
-        action_space=action_space,
+        action_space=discrete_space,
         batch_size=batch_size,
         accelerator=accelerator,
     )
@@ -483,7 +390,7 @@ def test_learns_from_experiences(observation_space, accelerator):
         )
 
     # Create a batch of experiences
-    actions = torch.randint(0, action_space.n, (num_steps,)).float()
+    actions = torch.randint(0, discrete_space.n, (num_steps,)).float()
     log_probs = torch.randn(num_steps)
     rewards = torch.randn(num_steps)
     dones = torch.randint(0, 2, (num_steps,))
@@ -510,39 +417,27 @@ def test_learns_from_experiences(observation_space, accelerator):
 
 
 # Runs algorithm test loop
-@pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,), low=0, high=1),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=1),
-    ],
-)
+@pytest.mark.parametrize("observation_space", ["vector_space", "image_space"])
 @pytest.mark.parametrize("num_envs", [1, 3])
-def test_algorithm_test_loop(observation_space, num_envs):
-    action_space = generate_discrete_space(2)
+def test_algorithm_test_loop(observation_space, discrete_space, num_envs, request):
+    observation_space = request.getfixturevalue(observation_space)
 
     # Create a vectorised environment & test loop
     vect = num_envs > 1
     env = DummyEnv(state_size=observation_space.shape, vect=vect, num_envs=num_envs)
-    agent = PPO(observation_space=observation_space, action_space=action_space)
+    agent = PPO(observation_space=observation_space, action_space=discrete_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
 
 # Clones the agent and returns an identical agent.
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,), low=0, high=1),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=1),
-        generate_dict_or_tuple_space(2, 3, dict_space=False),
-        generate_dict_or_tuple_space(2, 3, dict_space=True),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
-def test_clone_returns_identical_agent(observation_space):
-    action_space = generate_discrete_space(2)
+def test_clone_returns_identical_agent(observation_space, discrete_space, request):
+    observation_space = request.getfixturevalue(observation_space)
 
-    ppo = DummyPPO(observation_space, action_space)
+    ppo = DummyPPO(observation_space, discrete_space)
     ppo.fitness = [200, 200, 200]
     ppo.scores = [94, 94, 94]
     ppo.steps = [2500]
@@ -577,7 +472,7 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.tensor_test == ppo.tensor_test
 
     accelerator = Accelerator()
-    ppo = PPO(observation_space, action_space, accelerator=accelerator)
+    ppo = PPO(observation_space, discrete_space, accelerator=accelerator)
     clone_agent = ppo.clone()
 
     assert clone_agent.observation_space == ppo.observation_space
@@ -608,7 +503,7 @@ def test_clone_returns_identical_agent(observation_space):
     accelerator = Accelerator()
     ppo = PPO(
         observation_space,
-        action_space,
+        discrete_space,
         accelerator=accelerator,
         wrap=False,
     )
@@ -640,26 +535,20 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.scores == ppo.scores
 
 
-def test_clone_new_index():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_discrete_space(2)
-
-    ppo = PPO(observation_space, action_space)
+def test_clone_new_index(vector_space, discrete_space):
+    ppo = PPO(vector_space, discrete_space)
     clone_agent = ppo.clone(index=100)
-
     assert clone_agent.index == 100
 
 
-def test_clone_after_learning():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_clone_after_learning(vector_space):
     max_env_steps = 20
     num_vec_envs = 2
-    ppo = PPO(observation_space, action_space)
-    states = np.random.randn(max_env_steps, num_vec_envs, observation_space.shape[0])
+    ppo = PPO(vector_space, copy.deepcopy(vector_space))
 
-    next_states = np.random.randn(num_vec_envs, observation_space.shape[0])
-    actions = np.random.rand(max_env_steps, num_vec_envs, action_space.shape[0])
+    states = np.random.randn(max_env_steps, num_vec_envs, vector_space.shape[0])
+    next_states = np.random.randn(num_vec_envs, vector_space.shape[0])
+    actions = np.random.rand(max_env_steps, num_vec_envs, vector_space.shape[0])
     log_probs = -np.random.rand(max_env_steps, num_vec_envs)
     rewards = np.random.randint(0, 100, (max_env_steps, num_vec_envs))
     dones = np.zeros((max_env_steps, num_vec_envs))
@@ -701,276 +590,3 @@ def test_clone_after_learning():
     assert clone_agent.fitness == ppo.fitness
     assert clone_agent.steps == ppo.steps
     assert clone_agent.scores == ppo.scores
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,), low=0, high=1), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=1), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 3, dict_space=False), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 3, dict_space=True), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    observation_space, encoder_cls, tmpdir
-):
-    # Initialize the ppo agent
-    ppo = PPO(
-        observation_space=observation_space,
-        action_space=generate_random_box_space(shape=(2,)),
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ppo.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "gamma" in checkpoint
-    assert "gae_lambda" in checkpoint
-    assert "mut" in checkpoint
-    assert "action_std_init" in checkpoint
-    assert "clip_coef" in checkpoint
-    assert "ent_coef" in checkpoint
-    assert "vf_coef" in checkpoint
-    assert "max_grad_norm" in checkpoint
-    assert "target_kl" in checkpoint
-    assert "update_epochs" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    ppo = PPO(
-        observation_space=observation_space,
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
-    )
-    # Load checkpoint
-    ppo.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(ppo.actor.encoder, encoder_cls)
-    assert isinstance(ppo.critic.encoder, encoder_cls)
-    assert ppo.lr == 1e-4
-    assert ppo.batch_size == 64
-    assert ppo.gamma == 0.99
-    assert ppo.mut is None
-    assert ppo.action_std_init == 0.0
-    assert ppo.clip_coef == 0.2
-    assert ppo.ent_coef == 0.01
-    assert ppo.vf_coef == 0.5
-    assert ppo.max_grad_norm == 0.5
-    assert ppo.target_kl is None
-    assert ppo.update_epochs == 4
-    assert ppo.index == 0
-    assert ppo.scores == []
-    assert ppo.fitness == []
-    assert ppo.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "actor_network, input_tensor",
-    [
-        ("simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_cnn_network(
-    actor_network, input_tensor, request, tmpdir
-):
-    observation_space = generate_random_box_space(
-        shape=input_tensor.shape[1:], low=0, high=1
-    )
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
-
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-    critic_network = SimpleCNN()
-    critic_network = MakeEvolvable(
-        critic_network,
-        input_tensor,
-        torch.randn(1, action_space.shape[0]),
-    )
-
-    # Initialize the ppo agent
-    ppo = PPO(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-        critic_network=critic_network,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ppo.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_state_dict" in checkpoint["network_info"]["modules"]
-    assert "optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr" in checkpoint
-    assert "gamma" in checkpoint
-    assert "gae_lambda" in checkpoint
-    assert "mut" in checkpoint
-    assert "action_std_init" in checkpoint
-    assert "clip_coef" in checkpoint
-    assert "ent_coef" in checkpoint
-    assert "vf_coef" in checkpoint
-    assert "max_grad_norm" in checkpoint
-    assert "target_kl" in checkpoint
-    assert "update_epochs" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    ppo = PPO(
-        observation_space=generate_random_box_space(shape=(4,), low=0, high=1),
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
-        actor_network=actor_network,
-        critic_network=critic_network,
-    )
-    # Load checkpoint
-    ppo.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(ppo.actor, nn.Module)
-    assert isinstance(ppo.critic, nn.Module)
-    assert ppo.lr == 1e-4
-    assert ppo.batch_size == 64
-    assert ppo.gamma == 0.99
-    assert ppo.mut is None
-    assert ppo.action_std_init == 0.0
-    assert ppo.clip_coef == 0.2
-    assert ppo.ent_coef == 0.01
-    assert ppo.vf_coef == 0.5
-    assert ppo.max_grad_norm == 0.5
-    assert ppo.target_kl is None
-    assert ppo.update_epochs == 4
-    assert ppo.index == 0
-    assert ppo.scores == []
-    assert ppo.fitness == []
-    assert ppo.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.]
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,), low=0, high=1), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=1), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 3, dict_space=False), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 3, dict_space=True), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_load_from_pretrained(observation_space, encoder_cls, accelerator, tmpdir):
-    # Initialize the ppo agent
-    ppo = PPO(
-        observation_space=observation_space,
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
-        accelerator=accelerator,
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ppo.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_ppo = PPO.load(checkpoint_path, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_ppo.observation_space == ppo.observation_space
-    assert new_ppo.action_space == ppo.action_space
-    assert isinstance(new_ppo.actor.encoder, encoder_cls)
-    assert isinstance(new_ppo.critic.encoder, encoder_cls)
-    assert new_ppo.lr == ppo.lr
-    assert_state_dicts_equal(new_ppo.actor.state_dict(), ppo.actor.state_dict())
-    assert_state_dicts_equal(new_ppo.critic.state_dict(), ppo.critic.state_dict())
-    assert new_ppo.batch_size == ppo.batch_size
-    assert new_ppo.gamma == ppo.gamma
-    assert new_ppo.mut == ppo.mut
-    assert new_ppo.index == ppo.index
-    assert new_ppo.scores == ppo.scores
-    assert new_ppo.fitness == ppo.fitness
-    assert new_ppo.steps == ppo.steps
-
-
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (
-            generate_random_box_space(shape=(4,), low=0, high=1),
-            "simple_mlp",
-            torch.randn(1, 4),
-        ),
-        (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=1),
-            "simple_cnn",
-            torch.randn(1, 3, 64, 64),
-        ),
-    ],
-)
-# The saved checkpoint file contains the correct data and format.
-def test_load_from_pretrained_networks(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = spaces.Discrete(2)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the ppo agent
-    ppo = PPO(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-        critic_network=copy.deepcopy(actor_network),
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    ppo.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_ppo = PPO.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_ppo.observation_space == ppo.observation_space
-    assert new_ppo.action_space == ppo.action_space
-    assert isinstance(new_ppo.actor, nn.Module)
-    assert isinstance(new_ppo.critic, nn.Module)
-    assert new_ppo.lr == ppo.lr
-    assert_state_dicts_equal(
-        new_ppo.actor.to("cpu").state_dict(), ppo.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_ppo.critic.to("cpu").state_dict(), ppo.critic.state_dict()
-    )
-    assert new_ppo.batch_size == ppo.batch_size
-    assert new_ppo.gamma == ppo.gamma
-    assert new_ppo.mut == ppo.mut
-    assert new_ppo.index == ppo.index
-    assert new_ppo.scores == ppo.scores
-    assert new_ppo.fitness == ppo.fitness
-    assert new_ppo.steps == ppo.steps

--- a/tests/test_algorithms/test_td3.py
+++ b/tests/test_algorithms/test_td3.py
@@ -1,7 +1,5 @@
 import copy
-from pathlib import Path
 
-import dill
 import numpy as np
 import pytest
 import torch
@@ -9,6 +7,7 @@ import torch.nn as nn
 import torch.optim as optim
 from accelerate import Accelerator
 from accelerate.optimizer import AcceleratedOptimizer
+from gymnasium import spaces
 
 from agilerl.algorithms.td3 import TD3
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
@@ -18,19 +17,9 @@ from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_not_equal_state_dict,
     assert_state_dicts_equal,
-    generate_dict_or_tuple_space,
-    generate_discrete_space,
-    generate_multidiscrete_space,
-    generate_random_box_space,
     get_experiences_batch,
     get_sample_from_space,
 )
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    yield  # Run the test first
-    torch.cuda.empty_cache()  # Free up GPU memory
 
 
 class DummyTD3(TD3):
@@ -64,53 +53,6 @@ class DummyEnv:
         )
 
 
-@pytest.fixture
-def simple_mlp():
-    network = nn.Sequential(
-        nn.Linear(4, 20),
-        nn.ReLU(),
-        nn.Linear(20, 10),
-        nn.ReLU(),
-        nn.Linear(10, 1),
-        nn.Tanh(),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_mlp_critic():
-    network = nn.Sequential(
-        nn.Linear(6, 20),
-        nn.ReLU(),
-        nn.Linear(20, 10),
-        nn.ReLU(),
-        nn.Linear(10, 1),
-        nn.Tanh(),
-    )
-    return network
-
-
-@pytest.fixture
-def simple_cnn():
-    network = nn.Sequential(
-        nn.Conv2d(
-            3, 16, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 3 (for RGB images), Output channels: 16
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Conv2d(
-            16, 32, kernel_size=3, stride=1, padding=1
-        ),  # Input channels: 16, Output channels: 32
-        nn.ReLU(),
-        nn.MaxPool2d(kernel_size=2, stride=2),
-        nn.Flatten(),  # Flatten the 2D feature map to a 1D vector
-        nn.Linear(32 * 16 * 16, 128),  # Fully connected layer with 128 output features
-        nn.ReLU(),
-        nn.Linear(128, 2),  # Output layer with num_classes output features
-    )
-    return network
-
-
 class SimpleCNN(nn.Module):
     def __init__(self):
         super().__init__()
@@ -127,7 +69,7 @@ class SimpleCNN(nn.Module):
         self.mp2 = nn.MaxPool2d(kernel_size=2, stride=2)
         self.flat = nn.Flatten()  # Flatten the 2D feature map to a 1D vector
         self.linear1 = nn.Linear(
-            32 * 16 * 16, 128
+            32 * 8 * 8, 128
         )  # Fully connected layer with 128 output features
         self.relu3 = nn.ReLU()
         self.linear2 = nn.Linear(
@@ -148,23 +90,24 @@ class SimpleCNN(nn.Module):
 @pytest.mark.parametrize(
     "observation_space, encoder_cls",
     [
-        (generate_random_box_space(shape=(4,)), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
+        ("vector_space", EvolvableMLP),
+        ("image_space", EvolvableCNN),
+        ("dict_space", EvolvableMultiInput),
     ],
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_initialize_td3(observation_space, encoder_cls, accelerator):
-    action_space = generate_random_box_space(shape=(2,), low=-1, high=1)
+def test_initialize_td3(
+    observation_space, vector_space, encoder_cls, accelerator, request
+):
+    observation_space = request.getfixturevalue(observation_space)
 
     # Initialize TD3 with default parameters
-    td3 = TD3(observation_space, action_space, accelerator=accelerator)
+    td3 = TD3(observation_space, vector_space, accelerator=accelerator)
 
     expected_opt_cls = AcceleratedOptimizer if accelerator else optim.Adam
     expected_device = accelerator.device if accelerator else "cpu"
     assert td3.observation_space == observation_space
-    assert td3.action_space == action_space
+    assert td3.action_space == vector_space
     assert td3.batch_size == 64
     assert td3.lr_actor == 0.0001
     assert td3.lr_critic == 0.001
@@ -196,7 +139,7 @@ def test_initialize_td3(observation_space, encoder_cls, accelerator):
     "observation_space, actor_network, critic_1_network, critic_2_network, input_tensor, input_tensor_critic",
     [
         (
-            generate_random_box_space(shape=(4,), low=0, high=1),
+            "vector_space",
             "simple_mlp",
             "simple_mlp_critic",
             "simple_mlp_critic",
@@ -207,6 +150,7 @@ def test_initialize_td3(observation_space, encoder_cls, accelerator):
 )
 def test_initialize_td3_with_actor_network(
     observation_space,
+    vector_space,
     actor_network,
     critic_1_network,
     critic_2_network,
@@ -214,7 +158,7 @@ def test_initialize_td3_with_actor_network(
     input_tensor_critic,
     request,
 ):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
     critic_1_network = request.getfixturevalue(critic_1_network)
@@ -224,14 +168,14 @@ def test_initialize_td3_with_actor_network(
 
     td3 = TD3(
         observation_space,
-        action_space,
-        expl_noise=np.zeros((1, action_space.shape[0])),
+        vector_space,
+        expl_noise=np.zeros((1, vector_space.shape[0])),
         actor_network=actor_network,
         critic_networks=[critic_1_network, critic_2_network],
     )
 
     assert td3.observation_space == observation_space
-    assert td3.action_space == action_space
+    assert td3.action_space == vector_space
     assert td3.batch_size == 64
     assert td3.lr_actor == 0.0001
     assert td3.lr_critic == 0.001
@@ -257,7 +201,7 @@ def test_initialize_td3_with_actor_network(
     "observation_space, actor_network, critic_1_network, critic_2_network, input_tensor, input_tensor_critic",
     [
         (
-            generate_random_box_space(shape=(4,), low=0, high=1),
+            "vector_space",
             "simple_mlp",
             "simple_mlp_critic",
             "simple_mlp_critic",
@@ -271,6 +215,7 @@ def test_initialize_td3_with_actor_network(
 # TODO: This will be deprecated in the future
 def test_initialize_td3_with_actor_network_no_critics(
     observation_space,
+    vector_space,
     actor_network,
     critic_1_network,
     critic_2_network,
@@ -278,19 +223,19 @@ def test_initialize_td3_with_actor_network_no_critics(
     input_tensor_critic,
     request,
 ):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
 
     td3 = TD3(
         observation_space,
-        action_space,
+        vector_space,
         actor_network=actor_network,
         critic_networks=None,
     )
 
     assert td3.observation_space == observation_space
-    assert td3.action_space == action_space
+    assert td3.action_space == vector_space
     assert td3.batch_size == 64
     assert td3.lr_actor == 0.0001
     assert td3.lr_critic == 0.001
@@ -316,40 +261,40 @@ def test_initialize_td3_with_actor_network_no_critics(
     "observation_space, actor_network, input_tensor",
     [
         (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
+            "image_space",
             "simple_cnn",
-            torch.randn(1, 3, 64, 64),
+            torch.randn(1, 3, 32, 32),
         ),
     ],
 )
 def test_initialize_td3_with_actor_network_cnn(
-    observation_space, actor_network, input_tensor, request
+    observation_space, vector_space, actor_network, input_tensor, request
 ):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+    observation_space = request.getfixturevalue(observation_space)
     actor_network = request.getfixturevalue(actor_network)
     actor_network = MakeEvolvable(actor_network, input_tensor)
     critic_1_network = SimpleCNN()
     critic_1_network = MakeEvolvable(
         critic_1_network,
         input_tensor,
-        torch.randn(1, action_space.shape[0]),
+        torch.randn(1, vector_space.shape[0]),
     )
     critic_2_network = SimpleCNN()
     critic_2_network = MakeEvolvable(
         critic_2_network,
         input_tensor,
-        torch.randn(1, action_space.shape[0]),
+        torch.randn(1, vector_space.shape[0]),
     )
 
     td3 = TD3(
         observation_space,
-        action_space,
+        vector_space,
         actor_network=actor_network,
         critic_networks=[critic_1_network, critic_2_network],
     )
 
     assert td3.observation_space == observation_space
-    assert td3.action_space == action_space
+    assert td3.action_space == vector_space
     assert td3.batch_size == 64
     assert td3.lr_actor == 0.0001
     assert td3.lr_critic == 0.001
@@ -370,18 +315,12 @@ def test_initialize_td3_with_actor_network_cnn(
 
 
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_discrete_space(4),
-        generate_random_box_space(shape=(4,)),
-        generate_multidiscrete_space(2, 2),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
-def test_returns_expected_action_training(observation_space):
+def test_returns_expected_action_training(observation_space, request):
+    observation_space = request.getfixturevalue(observation_space)
+    action_space = spaces.Box(low=-1, high=1, shape=(2,))
     accelerator = Accelerator()
-    action_space = generate_random_box_space(shape=(2,), low=-1, high=1)
 
     td3 = TD3(observation_space, action_space)
     state = get_sample_from_space(observation_space)
@@ -424,12 +363,10 @@ def test_returns_expected_action_training(observation_space):
 
 
 # Returns the expected action from float64 input
-def test_returns_expected_action_float64():
-    observation_space = generate_discrete_space(4)
-    action_space = generate_random_box_space(shape=(2,), low=-1, high=1)
-
-    td3 = TD3(observation_space, action_space)
-    state = np.array([0, 1, 2, 3]).astype(np.float64)
+def test_returns_expected_action_float64(discrete_space):
+    action_space = spaces.Box(low=-1, high=1, shape=(2,))
+    td3 = TD3(discrete_space, action_space)
+    state = np.array([0, 1, 0, 1]).astype(np.float64)
     training = False
     action = td3.get_action(state, training)[0]
 
@@ -438,10 +375,7 @@ def test_returns_expected_action_float64():
         assert isinstance(act, np.float32)
         assert -1 <= act <= 1
 
-    td3 = TD3(
-        observation_space,
-        action_space,
-    )
+    td3 = TD3(discrete_space, action_space)
     state = np.array([1]).astype(np.float64)
     training = True
     action = td3.get_action(state, training)[0]
@@ -451,11 +385,7 @@ def test_returns_expected_action_float64():
         assert isinstance(act, np.float32)
         assert -1 <= act <= 1
 
-    td3 = TD3(
-        observation_space,
-        action_space,
-        O_U_noise=False,
-    )
+    td3 = TD3(discrete_space, action_space, O_U_noise=False)
     state = np.array([1]).astype(np.float64)
     training = True
     action = td3.get_action(state, training)[0]
@@ -468,15 +398,7 @@ def test_returns_expected_action_float64():
 
 # learns from experiences and updates network parameters
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_discrete_space(4),
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        generate_multidiscrete_space(2, 2),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
 @pytest.mark.parametrize(
     "min_action, max_action",
@@ -484,12 +406,13 @@ def test_returns_expected_action_float64():
 )
 @pytest.mark.parametrize("accelerator", [None, Accelerator()])
 def test_learns_from_experiences(
-    observation_space, min_action, max_action, accelerator
+    observation_space, min_action, max_action, accelerator, request
 ):
+    observation_space = request.getfixturevalue(observation_space)
     # Continuous action space
     low = np.array(min_action) if isinstance(min_action, list) else min_action
     high = np.array(max_action) if isinstance(max_action, list) else max_action
-    action_space = generate_random_box_space(shape=(2,), low=low, high=high)
+    action_space = spaces.Box(low=low, high=high, shape=(2,))
 
     # Create an instance of the td3 class
     batch_size = 64
@@ -545,9 +468,7 @@ def test_learns_from_experiences(
 
 
 # Updates target network parameters with soft update
-def test_soft_update():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_soft_update(vector_space):
     net_config = {"encoder_config": {"hidden_size": [64, 64]}}
     batch_size = 64
     lr_actor = 1e-4
@@ -562,8 +483,8 @@ def test_soft_update():
     wrap = True
 
     td3 = TD3(
-        observation_space,
-        action_space,
+        vector_space,
+        copy.deepcopy(vector_space),
         net_config=net_config,
         batch_size=batch_size,
         lr_actor=lr_actor,
@@ -622,37 +543,25 @@ def test_soft_update():
 
 
 # Runs algorithm test loop
-@pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,)),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-    ],
-)
+@pytest.mark.parametrize("observation_space", ["vector_space", "image_space"])
 @pytest.mark.parametrize("num_envs", [1, 3])
-def test_algorithm_test_loop(observation_space, num_envs):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_algorithm_test_loop(observation_space, vector_space, num_envs, request):
+    observation_space = request.getfixturevalue(observation_space)
     vect = num_envs > 1
     env = DummyEnv(state_size=observation_space.shape, vect=vect, num_envs=num_envs)
-    agent = TD3(observation_space=observation_space, action_space=action_space)
+    agent = TD3(observation_space, vector_space)
     mean_score = agent.test(env, max_steps=10)
     assert isinstance(mean_score, float)
 
 
 # Clones the agent and returns an identical agent.
 @pytest.mark.parametrize(
-    "observation_space",
-    [
-        generate_random_box_space(shape=(4,), low=0, high=1),
-        generate_random_box_space(shape=(3, 32, 32), low=0, high=255),
-        generate_dict_or_tuple_space(2, 2, dict_space=True),
-        generate_dict_or_tuple_space(2, 2, dict_space=False),
-    ],
+    "observation_space", ["vector_space", "image_space", "dict_space"]
 )
-def test_clone_returns_identical_agent(observation_space):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_clone_returns_identical_agent(observation_space, vector_space, request):
+    observation_space = request.getfixturevalue(observation_space)
 
-    td3 = DummyTD3(observation_space, action_space)
+    td3 = DummyTD3(observation_space, vector_space)
     td3.fitness = [200, 200, 200]
     td3.scores = [94, 94, 94]
     td3.steps = [2500]
@@ -702,7 +611,7 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.tensor_test == td3.tensor_test
 
     accelerator = Accelerator()
-    td3 = TD3(observation_space, action_space, accelerator=accelerator)
+    td3 = TD3(observation_space, vector_space, accelerator=accelerator)
     clone_agent = td3.clone()
 
     assert clone_agent.observation_space == td3.observation_space
@@ -746,7 +655,7 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.scores == td3.scores
 
     accelerator = Accelerator()
-    td3 = TD3(observation_space, action_space, accelerator=accelerator, wrap=False)
+    td3 = TD3(observation_space, vector_space, accelerator=accelerator, wrap=False)
     clone_agent = td3.clone(wrap=False)
 
     assert clone_agent.observation_space == td3.observation_space
@@ -790,25 +699,20 @@ def test_clone_returns_identical_agent(observation_space):
     assert clone_agent.scores == td3.scores
 
 
-def test_clone_new_index():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
-
-    td3 = TD3(observation_space, action_space)
+def test_clone_new_index(vector_space):
+    td3 = TD3(vector_space, copy.deepcopy(vector_space))
     clone_agent = td3.clone(index=100)
 
     assert clone_agent.index == 100
 
 
-def test_clone_after_learning():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_clone_after_learning(vector_space):
     batch_size = 8
-    td3 = TD3(observation_space, action_space)
+    td3 = TD3(vector_space, copy.deepcopy(vector_space))
 
     # Get experiences and learn
     experiences = get_experiences_batch(
-        observation_space, action_space, batch_size, device=td3.device
+        vector_space, vector_space, batch_size, device=td3.device
     )
     td3.learn(experiences)
 
@@ -857,10 +761,10 @@ def test_clone_after_learning():
 
 
 # The method successfully unwraps the actor and actor_target models when an accelerator is present.
-def test_unwrap_models():
+def test_unwrap_models(vector_space):
     td3 = TD3(
-        observation_space=generate_random_box_space(shape=(4,), low=0, high=1),
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
+        vector_space,
+        copy.deepcopy(vector_space),
         accelerator=Accelerator(),
     )
     td3.unwrap_models()
@@ -872,227 +776,32 @@ def test_unwrap_models():
     assert isinstance(td3.critic_target_2, nn.Module)
 
 
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,), low=0, high=1), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format(
-    tmpdir, observation_space, encoder_cls
-):
-    # Initialize the td3 agent
-    td3 = TD3(
-        observation_space=observation_space,
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    td3.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "critic_1_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_1_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_1_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_1_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_1_optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "critic_2_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_2_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_2_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_2_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_2_optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr_actor" in checkpoint
-    assert "lr_critic" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    td3 = TD3(
-        observation_space=observation_space,
-        action_space=generate_random_box_space(shape=(2,), low=-1, high=1),
-    )
-    # Load checkpoint
-    td3.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(td3.actor.encoder, encoder_cls)
-    assert isinstance(td3.actor_target.encoder, encoder_cls)
-    assert isinstance(td3.critic_1.encoder, encoder_cls)
-    assert isinstance(td3.critic_target_1.encoder, encoder_cls)
-    assert isinstance(td3.critic_2.encoder, encoder_cls)
-    assert isinstance(td3.critic_target_2.encoder, encoder_cls)
-    assert td3.lr_actor == 1e-4
-    assert td3.lr_critic == 1e-3
-    assert_state_dicts_equal(td3.actor.state_dict(), td3.actor_target.state_dict())
-    assert_state_dicts_equal(
-        td3.critic_1.state_dict(), td3.critic_target_1.state_dict()
-    )
-    assert_state_dicts_equal(
-        td3.critic_2.state_dict(), td3.critic_target_2.state_dict()
-    )
-    assert td3.batch_size == 64
-    assert td3.learn_step == 5
-    assert td3.gamma == 0.99
-    assert td3.tau == 0.005
-    assert td3.mut is None
-    assert td3.index == 0
-    assert td3.scores == []
-    assert td3.fitness == []
-    assert td3.steps == [0]
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "actor_network, input_tensor",
-    [
-        ("simple_cnn", torch.randn(1, 3, 64, 64)),
-    ],
-)
-def test_save_load_checkpoint_correct_data_and_format_cnn_network(
-    actor_network, input_tensor, request, tmpdir
-):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
-    observation_space = generate_random_box_space(
-        shape=input_tensor.shape[1:], low=0, high=1
-    )
-
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-    critic_1_network = SimpleCNN()
-    critic_1_network = MakeEvolvable(
-        critic_1_network,
-        input_tensor,
-        torch.randn(1, action_space.shape[0]),
-    )
-    critic_2_network = SimpleCNN()
-    critic_2_network = MakeEvolvable(
-        critic_2_network,
-        input_tensor,
-        torch.randn(1, action_space.shape[0]),
-    )
-
-    td3 = TD3(
-        observation_space,
-        action_space,
-        actor_network=actor_network,
-        critic_networks=[critic_1_network, critic_2_network],
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    td3.save_checkpoint(checkpoint_path)
-
-    # Load the saved checkpoint file
-    checkpoint = torch.load(checkpoint_path, pickle_module=dill, weights_only=False)
-
-    # Check if the loaded checkpoint has the correct keys
-    assert "actor_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_init_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_target_state_dict" in checkpoint["network_info"]["modules"]
-    assert "actor_optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "critic_1_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_1_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_1_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_1_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_1_optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "critic_2_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_2_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_2_init_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_target_2_state_dict" in checkpoint["network_info"]["modules"]
-    assert "critic_2_optimizer_state_dict" in checkpoint["network_info"]["optimizers"]
-    assert "batch_size" in checkpoint
-    assert "lr_actor" in checkpoint
-    assert "lr_critic" in checkpoint
-    assert "learn_step" in checkpoint
-    assert "gamma" in checkpoint
-    assert "tau" in checkpoint
-    assert "mut" in checkpoint
-    assert "index" in checkpoint
-    assert "scores" in checkpoint
-    assert "fitness" in checkpoint
-    assert "steps" in checkpoint
-
-    td3 = TD3(
-        observation_space=generate_random_box_space(shape=(4,), low=0, high=1),
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
-        actor_network=actor_network,
-        critic_networks=[critic_1_network, critic_2_network],
-    )
-    # Load checkpoint
-    td3.load_checkpoint(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert isinstance(td3.actor, nn.Module)
-    assert isinstance(td3.actor_target, nn.Module)
-    assert isinstance(td3.critic_1, nn.Module)
-    assert isinstance(td3.critic_target_1, nn.Module)
-    assert isinstance(td3.critic_2, nn.Module)
-    assert isinstance(td3.critic_target_2, nn.Module)
-    assert td3.lr_actor == 1e-4
-    assert td3.lr_critic == 1e-3
-    assert_state_dicts_equal(td3.actor.state_dict(), td3.actor_target.state_dict())
-    assert_state_dicts_equal(
-        td3.critic_1.state_dict(), td3.critic_target_1.state_dict()
-    )
-    assert_state_dicts_equal(
-        td3.critic_2.state_dict(), td3.critic_target_2.state_dict()
-    )
-    assert td3.batch_size == 64
-    assert td3.learn_step == 5
-    assert td3.gamma == 0.99
-    assert td3.tau == 0.005
-    assert td3.mut is None
-    assert td3.index == 0
-    assert td3.scores == []
-    assert td3.fitness == []
-    assert td3.steps == [0]
-
-
 @pytest.mark.parametrize(
     "observation_space, net_type",
     [
-        (generate_random_box_space(shape=(4,), low=0, high=1), "mlp"),
-        (generate_random_box_space(shape=(3, 64, 64), low=0, high=255), "cnn"),
+        ("vector_space", "mlp"),
+        ("image_space", "cnn"),
     ],
 )
-def test_initialize_td3_with_actor_network_evo_net(observation_space, net_type):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_initialize_td3_with_actor_network_evo_net(
+    observation_space, vector_space, net_type, request
+):
+    observation_space = request.getfixturevalue(observation_space)
 
-    actor_network = DeterministicActor(observation_space, action_space)
+    actor_network = DeterministicActor(observation_space, vector_space)
     critic_networks = [
-        ContinuousQNetwork(observation_space, action_space) for _ in range(2)
+        ContinuousQNetwork(observation_space, vector_space) for _ in range(2)
     ]
 
     td3 = TD3(
         observation_space,
-        action_space,
+        vector_space,
         actor_network=actor_network,
         critic_networks=critic_networks,
     )
 
     assert td3.observation_space == observation_space
-    assert td3.action_space == action_space
+    assert td3.action_space == vector_space
     assert td3.batch_size == 64
     assert td3.lr_actor == 0.0001
     assert td3.lr_critic == 0.001
@@ -1112,15 +821,13 @@ def test_initialize_td3_with_actor_network_evo_net(observation_space, net_type):
     assert isinstance(td3.criterion, nn.MSELoss)
 
 
-def test_initialize_td3_with_incorrect_actor_net():
-    observation_space = generate_random_box_space(shape=(4,), low=0, high=1)
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
+def test_initialize_td3_with_incorrect_actor_net(vector_space):
     actor_network = "dummy"
     critic_networks = "dummy"
     with pytest.raises(AssertionError):
         td3 = TD3(
-            observation_space,
-            action_space,
+            vector_space,
+            copy.deepcopy(vector_space),
             actor_network=actor_network,
             critic_networks=critic_networks,
         )
@@ -1152,163 +859,17 @@ def test_initialize_td3_with_incorrect_actor_net():
         ),
     ],
 )
-def test_multi_dim_clamp(min, max, action, expected_result, device):
+def test_multi_dim_clamp(vector_space, min, max, action, expected_result, device):
     if isinstance(min, list):
         min = np.array(min)
     if isinstance(max, list):
         max = np.array(max)
     td3 = TD3(
-        observation_space=generate_random_box_space(shape=(4,), low=0, high=1),
-        action_space=generate_random_box_space(shape=(1,), low=0, high=1),
+        vector_space,
+        copy.deepcopy(vector_space),
         device=device,
     )
     input = torch.tensor(action, dtype=torch.float32).to(device)
     clamped_actions = td3.multi_dim_clamp(min, max, input).type(torch.float32)
     expected_result = torch.tensor(expected_result)
     assert clamped_actions.dtype == expected_result.dtype
-
-
-# The saved checkpoint file contains the correct data and format.
-@pytest.mark.parametrize(
-    "observation_space, encoder_cls",
-    [
-        (generate_random_box_space(shape=(4,), low=0, high=1), EvolvableMLP),
-        (generate_random_box_space(shape=(3, 32, 32), low=0, high=255), EvolvableCNN),
-        (generate_dict_or_tuple_space(2, 2, dict_space=True), EvolvableMultiInput),
-        (generate_dict_or_tuple_space(2, 2, dict_space=False), EvolvableMultiInput),
-    ],
-)
-@pytest.mark.parametrize("accelerator", [None, Accelerator()])
-def test_load_from_pretrained(observation_space, encoder_cls, accelerator, tmpdir):
-    # Initialize the td3 agent
-    td3 = TD3(
-        observation_space=observation_space,
-        action_space=generate_random_box_space(shape=(2,), low=0, high=1),
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    td3.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_td3 = TD3.load(checkpoint_path, accelerator=accelerator)
-
-    # Check if properties and weights are loaded correctly
-    assert new_td3.observation_space == td3.observation_space
-    assert new_td3.action_space == td3.action_space
-    assert isinstance(new_td3.actor.encoder, encoder_cls)
-    assert isinstance(new_td3.actor_target.encoder, encoder_cls)
-    assert isinstance(new_td3.critic_1.encoder, encoder_cls)
-    assert isinstance(new_td3.critic_target_1.encoder, encoder_cls)
-    assert isinstance(new_td3.critic_2.encoder, encoder_cls)
-    assert isinstance(new_td3.critic_target_2.encoder, encoder_cls)
-    assert new_td3.lr_actor == td3.lr_actor
-    assert new_td3.lr_critic == td3.lr_critic
-    assert_state_dicts_equal(
-        new_td3.actor.to("cpu").state_dict(), td3.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.actor_target.to("cpu").state_dict(), td3.actor_target.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_1.to("cpu").state_dict(), td3.critic_1.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_target_1.to("cpu").state_dict(), td3.critic_target_1.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_2.to("cpu").state_dict(), td3.critic_2.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_target_2.to("cpu").state_dict(), td3.critic_target_2.state_dict()
-    )
-    assert new_td3.batch_size == td3.batch_size
-    assert new_td3.learn_step == td3.learn_step
-    assert new_td3.gamma == td3.gamma
-    assert new_td3.tau == td3.tau
-    assert new_td3.policy_freq == td3.policy_freq
-    assert new_td3.mut == td3.mut
-    assert new_td3.index == td3.index
-    assert new_td3.scores == td3.scores
-    assert new_td3.fitness == td3.fitness
-    assert new_td3.steps == td3.steps
-
-
-# The saved checkpoint file contains the correct data and format.
-# TODO: This will be deprecated in the future
-@pytest.mark.parametrize(
-    "observation_space, actor_network, input_tensor",
-    [
-        (
-            generate_random_box_space(shape=(4,), low=0, high=255),
-            "simple_mlp",
-            torch.randn(1, 4),
-        ),
-        (
-            generate_random_box_space(shape=(3, 64, 64), low=0, high=255),
-            "simple_cnn",
-            torch.randn(1, 3, 64, 64),
-        ),
-    ],
-)
-def test_load_from_pretrained_networks(
-    observation_space, actor_network, input_tensor, request, tmpdir
-):
-    action_space = generate_random_box_space(shape=(2,), low=0, high=1)
-    actor_network = request.getfixturevalue(actor_network)
-    actor_network = MakeEvolvable(actor_network, input_tensor)
-
-    # Initialize the td3 agent
-    td3 = TD3(
-        observation_space=observation_space,
-        action_space=action_space,
-        actor_network=actor_network,
-        critic_networks=[copy.deepcopy(actor_network), copy.deepcopy(actor_network)],
-    )
-
-    # Save the checkpoint to a file
-    checkpoint_path = Path(tmpdir) / "checkpoint.pth"
-    td3.save_checkpoint(checkpoint_path)
-
-    # Create new agent object
-    new_td3 = TD3.load(checkpoint_path)
-
-    # Check if properties and weights are loaded correctly
-    assert new_td3.observation_space == td3.observation_space
-    assert new_td3.action_space == td3.action_space
-    assert isinstance(new_td3.actor, nn.Module)
-    assert isinstance(new_td3.actor_target, nn.Module)
-    assert isinstance(new_td3.critic_1, nn.Module)
-    assert isinstance(new_td3.critic_target_1, nn.Module)
-    assert isinstance(new_td3.critic_2, nn.Module)
-    assert isinstance(new_td3.critic_target_2, nn.Module)
-    assert new_td3.lr_actor == td3.lr_actor
-    assert new_td3.lr_critic == td3.lr_critic
-    assert_state_dicts_equal(
-        new_td3.actor.to("cpu").state_dict(), td3.actor.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.actor_target.to("cpu").state_dict(), td3.actor_target.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_1.to("cpu").state_dict(), td3.critic_1.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_target_1.to("cpu").state_dict(), td3.critic_target_1.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_2.to("cpu").state_dict(), td3.critic_2.state_dict()
-    )
-    assert_state_dicts_equal(
-        new_td3.critic_target_2.to("cpu").state_dict(), td3.critic_target_2.state_dict()
-    )
-    assert new_td3.batch_size == td3.batch_size
-    assert new_td3.learn_step == td3.learn_step
-    assert new_td3.gamma == td3.gamma
-    assert new_td3.tau == td3.tau
-    assert new_td3.policy_freq == td3.policy_freq
-    assert new_td3.mut == td3.mut
-    assert new_td3.index == td3.index
-    assert new_td3.scores == td3.scores
-    assert new_td3.fitness == td3.fitness
-    assert new_td3.steps == td3.steps

--- a/tests/test_modules/test_cnn.py
+++ b/tests/test_modules/test_cnn.py
@@ -7,11 +7,8 @@ import torch
 from agilerl.modules.cnn import EvolvableCNN
 from tests.helper_functions import assert_state_dicts_equal
 
-
 ######### Define fixtures #########
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
+# Device fixture moved to conftest.py
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_modules/test_lstm.py
+++ b/tests/test_modules/test_lstm.py
@@ -7,11 +7,8 @@ import torch
 from agilerl.modules.lstm import EvolvableLSTM
 from tests.helper_functions import assert_state_dicts_equal
 
-
 ######### Define fixtures #########
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
+# Device fixture moved to conftest.py
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_modules/test_mlp.py
+++ b/tests/test_modules/test_mlp.py
@@ -8,11 +8,8 @@ from agilerl.modules.custom_components import NoisyLinear
 from agilerl.modules.mlp import EvolvableMLP
 from tests.helper_functions import assert_state_dicts_equal
 
-
 ######### Define fixtures #########
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
+# Device fixture moved to conftest.py
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_modules/test_multi_input.py
+++ b/tests/test_modules/test_multi_input.py
@@ -18,9 +18,7 @@ DictOrTupleSpace = Union[Dict, Tuple]
 
 
 ######### Define fixtures #########
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
+# Device fixture moved to conftest.py
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_modules/test_resnet.py
+++ b/tests/test_modules/test_resnet.py
@@ -4,11 +4,8 @@ import torch
 from agilerl.modules.resnet import EvolvableResNet
 from tests.helper_functions import assert_state_dicts_equal
 
-
 ######### Define fixtures #########
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
+# Device fixture moved to conftest.py
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
The tests needed some refactoring and optimization since there were a lot of redundant tests since the 2.0 changes. This reduces the time taken to run the test suite by approximately 50% (from 2hrs to 1hr more or less). In total this removes about 500 tests that weren't needed. 

- Use session fixtures for spaces, networks, configs -> more memory efficient and better use of `pytest` library.
- Remove redundant tests in `test_mutations.py` e.g. didn't need to parameterize different observation spaces for all types of mutations. 
- Refactor algorithm tests - implement tests for `EvolvableAlgorithm` base methods rather than have them included as tests for algorithms individually (e.g. unwrap, saving , loading). 