### PR TITLE
Grpo finetune llm fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
                 - --skip=*.css,*.js,*.map,*.scss,*.svg
                 - --ignore-words-list=magent,pres,roate
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.12.2
+      rev: v0.12.3
       hooks:
           - id: ruff-check
             args:

--- a/agilerl/training/train_llm.py
+++ b/agilerl/training/train_llm.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch.distributed as dist
-import wandb
 from accelerate import Accelerator
 from tqdm import trange
 
+import wandb
 from agilerl.algorithms import GRPO
 from agilerl.algorithms.core.base import RLAlgorithm
 from agilerl.hpo.mutation import Mutations
@@ -152,13 +152,13 @@ Effective learning batch_size: {data_increment} * {init_hp["BATCH_SIZE_PER_GPU"]
         )
 
     total_steps = 0
-    # calling env.reset() supplies the first batch of training data
 
+    # calling env.reset() supplies the first batch of training data
     prompts = env.reset(reset_dataloaders=True)
     for i in range(training_steps):
         agent_metrics_dict = {}
         for agent_idx, agent in enumerate(pop):
-            agent.set_reference_policy(env.num_dataset_passes + 1)
+            agent.set_reference_policy(env.num_dataset_passes)
             completion_ids, action_masks = agent.get_action(prompts)
             completion_lengths = np.mean([x.shape[1] for x in completion_ids])
 

--- a/agilerl/utils/llm_utils.py
+++ b/agilerl/utils/llm_utils.py
@@ -230,6 +230,7 @@ class HuggingFaceGym(gym.Env):
                 apply_chat_template_fn(q, a, tokenizer)
                 for q, a in zip(questions, answers)
             ]
+
             return {
                 "question": questions,
                 "answer": answers,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agilerl"
-version = "2.3.1"
+version = "2.3.2"
 
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = ["Nick Ustaran-Anderegg <dev@agilerl.com>"]


### PR DESCRIPTION
- In `agilerl.training.train_llm.finetune_llm`  removed '+1' from within `agent.set_reference_policy(env.num_dataset_passes)` to prevent unnecessary reference policy reset at the start of training