### PR TITLE
[fix] issue when passing a custom encoder class to the encoder classes being taken as evolvable_attributes. 

### DIFF
--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -178,7 +178,8 @@ def unwrap_optimizer(
 
 
 def recursive_check_module_attrs(obj: Any, networks_only: bool = False) -> bool:
-    """Recursively check if the object has any attributes that are EvolvableModule objects or Optimizer's.
+    """Recursively check if the object has any attributes that are EvolvableModule objects or Optimizer's,
+    excluding metaclasses.
 
     :param obj: The object to check for EvolvableModule objects or Optimizer's.
     :type obj: Any
@@ -192,6 +193,10 @@ def recursive_check_module_attrs(obj: Any, networks_only: bool = False) -> bool:
     if not networks_only:
         check_types += (OptimizerWrapper,)
 
+    # Exclude metaclasses
+    if isinstance(obj, type):
+        return False
+    
     if isinstance(obj, check_types):
         return True
     elif isinstance(obj, Optimizer):


### PR DESCRIPTION
Fixed and issue when passing a custom encoder class to the encoder classes being taken as evolvable_attributes. It also seems overall more sound to allow classes to be passed as net config.