### PR TITLE
Unsupported spaces error handling

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -70,6 +70,7 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     CosineLRScheduleConfig,
+    check_supported_space,
     chkpt_attribute_to_device,
     clone_llm,
     create_warmup_cosine_scheduler,
@@ -1164,12 +1165,8 @@ class RLAlgorithm(EvolvableAlgorithm, ABC):
 
         super().__init__(index, hp_config, device, accelerator, torch_compiler, name)
 
-        assert isinstance(
-            observation_space, spaces.Space
-        ), "Observation space must be an instance of gymnasium.spaces.Space."
-        assert isinstance(
-            action_space, spaces.Space
-        ), "Action space must be an instance of gymnasium.spaces.Space."
+        check_supported_space(observation_space)
+        check_supported_space(action_space)
 
         self.observation_space = observation_space
         self.action_space = action_space
@@ -1283,6 +1280,11 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
             raise ValueError(
                 f"Observation spaces must be a list or dictionary of spaces.Space objects. Got {type(observation_spaces)}."
             )
+
+        for obs_space in self.possible_observation_spaces.values():
+            check_supported_space(obs_space)
+        for action_space in self.possible_action_spaces.values():
+            check_supported_space(action_space)
 
         self.agent_ids = list(self.possible_observation_spaces.keys())
         self.n_agents = len(self.agent_ids)

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -45,6 +45,38 @@ from agilerl.typing import (
 PreTrainedModelType = Union[PeftModel, PreTrainedModel]
 
 
+def check_supported_space(observation_space: GymSpaceType) -> None:
+    """Checks if the observation space is supported by AgileRL.
+
+    :param observation_space: The observation space to check.
+    :type observation_space: GymSpaceType
+    """
+    assert isinstance(
+        observation_space, spaces.Space
+    ), "Observation space must be an instance of gymnasium.spaces.Space."
+
+    assert not isinstance(
+        observation_space, (spaces.Graph, spaces.Sequence, spaces.OneOf)
+    ), "AgileRL does not support Graph, Sequence, and OneOf spaces."
+
+    if isinstance(observation_space, spaces.Dict):
+        for subspace in observation_space.spaces.values():
+            assert not isinstance(
+                subspace, (spaces.Tuple, spaces.Dict)
+            ), "AgileRL does not support nested Tuple and Dict spaces in Dict spaces."
+            check_supported_space(subspace)
+    elif isinstance(observation_space, spaces.Tuple):
+        for subspace in observation_space.spaces:
+            assert not isinstance(
+                subspace, (spaces.Tuple, spaces.Dict)
+            ), "AgileRL does not support nested Tuple and Dict spaces in Tuple spaces."
+            check_supported_space(subspace)
+    elif isinstance(observation_space, spaces.MultiDiscrete):
+        assert (
+            len(observation_space.nvec.shape) == 1
+        ), "AgileRL does not support multi-dimensional MultiDiscrete spaces."
+
+
 def get_input_size_from_space(
     observation_space: GymSpaceType,
 ) -> Union[int, Dict[str, int], Tuple[int, ...]]:


### PR DESCRIPTION
Raise more verbose `AssertionError` for unsupported spaces:
- Nested `Dict` and `Tuple` spaces.
- Multidimensional `MultiDiscrete` spaces.
- `Graph`, `Sequence`, and `OneOf` spaces.
