### PR TITLE
Better error handling for unsupported spaces

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -70,6 +70,7 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     CosineLRScheduleConfig,
+    check_supported_space,
     chkpt_attribute_to_device,
     clone_llm,
     create_warmup_cosine_scheduler,
@@ -1164,12 +1165,8 @@ class RLAlgorithm(EvolvableAlgorithm, ABC):
 
         super().__init__(index, hp_config, device, accelerator, torch_compiler, name)
 
-        assert isinstance(
-            observation_space, spaces.Space
-        ), "Observation space must be an instance of gymnasium.spaces.Space."
-        assert isinstance(
-            action_space, spaces.Space
-        ), "Action space must be an instance of gymnasium.spaces.Space."
+        check_supported_space(observation_space)
+        check_supported_space(action_space)
 
         self.observation_space = observation_space
         self.action_space = action_space
@@ -1283,6 +1280,11 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
             raise ValueError(
                 f"Observation spaces must be a list or dictionary of spaces.Space objects. Got {type(observation_spaces)}."
             )
+
+        for obs_space in self.possible_observation_spaces.values():
+            check_supported_space(obs_space)
+        for action_space in self.possible_action_spaces.values():
+            check_supported_space(action_space)
 
         self.agent_ids = list(self.possible_observation_spaces.keys())
         self.n_agents = len(self.agent_ids)

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -1254,12 +1254,7 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
             assert len(agent_ids) == len(
                 observation_spaces
             ), "Number of agent IDs must match number of observation spaces."
-            assert all(
-                isinstance(_space, spaces.Space) for _space in observation_spaces
-            ), "Observation spaces must be instances of gymnasium.spaces.Space."
-            assert all(
-                isinstance(_space, spaces.Space) for _space in action_spaces
-            ), "Action spaces must be instances of gymnasium.spaces.Space."
+
             self.possible_observation_spaces = spaces.Dict(
                 {
                     agent_id: space

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -45,6 +45,38 @@ from agilerl.typing import (
 PreTrainedModelType = Union[PeftModel, PreTrainedModel]
 
 
+def check_supported_space(observation_space: GymSpaceType) -> None:
+    """Checks if the observation space is supported by AgileRL.
+
+    :param observation_space: The observation space to check.
+    :type observation_space: GymSpaceType
+    """
+    assert isinstance(
+        observation_space, spaces.Space
+    ), "Observation space must be an instance of gymnasium.spaces.Space."
+
+    assert not isinstance(
+        observation_space, (spaces.Graph, spaces.Sequence, spaces.OneOf)
+    ), "AgileRL does not support Graph, Sequence, and OneOf spaces."
+
+    if isinstance(observation_space, spaces.Dict):
+        for subspace in observation_space.spaces.values():
+            assert not isinstance(
+                subspace, (spaces.Tuple, spaces.Dict)
+            ), "AgileRL does not support nested Tuple and Dict spaces in Dict spaces."
+            check_supported_space(subspace)
+    elif isinstance(observation_space, spaces.Tuple):
+        for subspace in observation_space.spaces:
+            assert not isinstance(
+                subspace, (spaces.Tuple, spaces.Dict)
+            ), "AgileRL does not support nested Tuple and Dict spaces in Tuple spaces."
+            check_supported_space(subspace)
+    elif isinstance(observation_space, spaces.MultiDiscrete):
+        assert (
+            len(observation_space.nvec.shape) == 1
+        ), "AgileRL does not support multi-dimensional MultiDiscrete spaces."
+
+
 def get_input_size_from_space(
     observation_space: GymSpaceType,
 ) -> Union[int, Dict[str, int], Tuple[int, ...]]:

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -72,9 +72,10 @@ def check_supported_space(observation_space: GymSpaceType) -> None:
             ), "AgileRL does not support nested Tuple and Dict spaces in Tuple spaces."
             check_supported_space(subspace)
     elif isinstance(observation_space, spaces.MultiDiscrete):
-        assert (
-            len(observation_space.nvec.shape) == 1
-        ), "AgileRL does not support multi-dimensional MultiDiscrete spaces."
+        assert len(observation_space.nvec.shape) == 1, (
+            "AgileRL does not support multi-dimensional MultiDiscrete spaces. Got shape "
+            f"{observation_space.nvec.shape}."
+        )
 
 
 def get_input_size_from_space(

--- a/tests/test_algorithms/test_base.py
+++ b/tests/test_algorithms/test_base.py
@@ -322,7 +322,13 @@ class DummyMARLAlgorithm(MultiAgentRLAlgorithm):
 
 @pytest.mark.parametrize(
     "observation_space",
-    ["dict_space", "discrete_space", "vector_space", "multidiscrete_space"],
+    [
+        "dict_space",
+        "tuple_space",
+        "discrete_space",
+        "vector_space",
+        "multidiscrete_space",
+    ],
 )
 @pytest.mark.parametrize(
     "action_space",


### PR DESCRIPTION
Raise more verbose `AssertionError` for unsupported spaces:
- Nested `Dict` and `Tuple` spaces.
- Multidimensional `MultiDiscrete` spaces.
- `Graph`, `Sequence`, and `OneOf` spaces.
