### PR TITLE
QNetwork, LSTM for Non-Box vector spaces, rainbow consistency in naming

### DIFF
--- a/agilerl/networks/base.py
+++ b/agilerl/networks/base.py
@@ -504,7 +504,7 @@ class EvolvableNetwork(EvolvableModule, metaclass=NetworkMeta):
             assert_correct_lstm_net_config(net_config)
 
             encoder = EvolvableLSTM(
-                input_size=self.observation_space.shape[0],
+                input_size=spaces.flatdim(self.observation_space),
                 num_outputs=self.latent_dim,
                 device=self.device,
                 name=self.encoder_name,

--- a/agilerl/networks/q_networks.py
+++ b/agilerl/networks/q_networks.py
@@ -85,6 +85,8 @@ class QNetwork(EvolvableNetwork):
 
         if head_config is None:
             head_config = asdict(MlpNetConfig(hidden_size=[16], output_activation=None))
+        else:
+            head_config["output_activation"] = None
 
         self.num_actions = spaces.flatdim(action_space)
 


### PR DESCRIPTION
- Forcefully set `output_activation `to None in `QNetwork`.
- Use `spaces.flatdim` to support non-box vector spaces for recurrent policies.
- Standardise naming of states -> obs in `RainbowDQN`