### PR TITLE
Module backwards compatibility in EvolvableAlgorithm load()

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -77,6 +77,7 @@ from agilerl.utils.algo_utils import (
     chkpt_attribute_to_device,
     clone_llm,
     create_warmup_cosine_scheduler,
+    filter_init_dict,
     get_input_size_from_space,
     get_output_size_from_space,
     isroutine,
@@ -1094,22 +1095,20 @@ class EvolvableAlgorithm(ABC, metaclass=RegistryMeta):
             )
             if isinstance(module_cls, dict):
                 for agent_id, mod_cls in module_cls.items():
-                    d = init_dict[agent_id]
+                    d = filter_init_dict(init_dict[agent_id], mod_cls)
                     d["device"] = device
                     mod: EvolvableModule = mod_cls(**d)
                     loaded_modules[name][agent_id] = mod
             else:
+                init_dict = filter_init_dict(init_dict, module_cls)
                 init_dict["device"] = device
                 module = module_cls(**init_dict)
                 loaded_modules[name] = module
 
         # Reconstruct the algorithm
-        constructor_params = inspect.signature(cls.__init__).parameters.keys()
         checkpoint["accelerator"] = accelerator
         checkpoint["device"] = device
-        class_init_dict = {
-            k: v for k, v in checkpoint.items() if k in constructor_params
-        }
+        class_init_dict = filter_init_dict(checkpoint, cls)
         self = cls(**class_init_dict)
         registry: MutationRegistry = checkpoint["registry"]
         self.registry = registry

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -452,6 +452,21 @@ def chkpt_attribute_to_device(
     return chkpt_dict
 
 
+def filter_init_dict(init_dict: dict[str, Any], cls: type) -> dict[str, Any]:
+    """Filter the init dict to only include parameters that are valid for the given class.
+
+    :param init_dict: Initialization dictionary
+    :type init_dict: dict[str, Any]
+    :param cls: Class to filter the init dict for
+    :type cls: type
+
+    :return: Filtered initialization dictionary
+    :rtype: dict[str, Any]
+    """
+    init_params = inspect.signature(cls.__init__).parameters.keys()
+    return {k: v for k, v in init_dict.items() if k in init_params}
+
+
 def key_in_nested_dict(nested_dict: dict[str, Any], target: str) -> bool:
     """Determine if key is in nested dictionary.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agilerl"
 
-version = "2.5.0.dev2"
+version = "2.5.0.dev3"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.5.0.dev2"
+version = "2.5.0.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
- filter out init arguments that are in checkpoint but not in module cls