### PR TITLE
Set min and max latent dims in shared critic from mlp bounds

### DIFF
--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -299,7 +299,7 @@ class MADDPG(MultiAgentRLAlgorithm):
             )
             max_latent_dim = max(
                 [
-                    agent_configs[agent_id].get("max_latent_dim", 128)
+                    agent_configs[agent_id].get("max_latent_dim", 1024)
                     for agent_id in self.agent_ids
                 ],
             )

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -337,7 +337,7 @@ class MATD3(MultiAgentRLAlgorithm):
             )
             max_latent_dim = max(
                 [
-                    agent_configs[agent_id].get("max_latent_dim", 128)
+                    agent_configs[agent_id].get("max_latent_dim", 1024)
                     for agent_id in self.agent_ids
                 ],
             )

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -599,6 +599,8 @@ def format_shared_critic_encoder(encoder_configs: NetConfigType) -> dict[str, An
         if encoder_key == "mlp_config":
             encoder_config[encoder_key] = config
             encoder_config["latent_dim"] = config.get("hidden_size", [32])[-1]
+            encoder_config["min_latent_dim"] = config.get("min_mlp_nodes", 8)
+            encoder_config["max_latent_dim"] = config.get("max_mlp_nodes", 1024)
         else:
             encoder_config["init_dicts"][encoder_key] = config
 

--- a/configs/training/multi_agent/maddpg.yaml
+++ b/configs/training/multi_agent/maddpg.yaml
@@ -71,7 +71,8 @@ MUTATION_PARAMS:
 
 NET_CONFIG:
     latent_dim: 64
-
+    min_latent_dim: 8
+    max_latent_dim: 1024
     encoder_config:
         hidden_size: [64]
         min_mlp_nodes: 64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agilerl"
 
-version = "2.5.0.dev3"
+version = "2.5.0.dev4"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.5.0.dev3"
+version = "2.5.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
- Was setting `latent_dim` from last hidden size of actor encoder but not mutation bounds, so an error was raised if this was above the default bounds.