### PR TITLE
Add parameter sharing support to MADDPG and MATD3

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -1772,6 +1772,15 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
         """
         return agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
 
+    def get_network_id(self, agent_id: str) -> str:
+        """Get the network ID for an agent, considering parameter sharing groups.
+
+        :param agent_id: The agent ID
+        :type agent_id: str
+        :return: The actor/critic network ID
+        """
+        return self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
+
     def assemble_shared_inputs(self, experience: ExperiencesType) -> ExperiencesType:
         """Preprocesses inputs by constructing dictionaries by shared agents.
 

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -78,6 +78,7 @@ from agilerl.utils.algo_utils import (
     check_supported_space,
     chkpt_attribute_to_device,
     clone_llm,
+    concatenate_tensors,
     create_warmup_cosine_scheduler,
     filter_init_dict,
     get_input_size_from_space,
@@ -1503,26 +1504,57 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
     def preprocess_observation(
         self,
         observation: ObservationType,
+        group_ids: list[str] | None = None,
     ) -> dict[str, TorchObsType]:
         """Preprocesses observations for forward pass through neural network.
 
-        :param observations: Observations of environment
-        :type observations: numpy.ndarray[float] or dict[str, numpy.ndarray[float]]
+        :param observation: Observations of environment
+        :type observation: numpy.ndarray[float] or dict[str, numpy.ndarray[float]]
+        :param group_ids: Optional list of output IDs. When group IDs are provided
+            (e.g., ``["agent", "other_agent"]``), observations are grouped and
+            concatenated per group. Otherwise, observations are returned per
+            agent ID for backwards compatibility.
+        :type group_ids: list[str] | None
 
         :return: Preprocessed observations
         :rtype: torch.Tensor[float] or dict[str, torch.Tensor[float]] or tuple[torch.Tensor[float], ...]
         """
-        preprocessed = {}
+        if group_ids is None:
+            preprocessed = {}
+            for agent_id, agent_obs in observation.items():
+                preprocessed[agent_id] = preprocess_observation(
+                    self.possible_observation_spaces.get(agent_id),
+                    observation=agent_obs,
+                    device=self.device,
+                    normalize_images=self.normalize_images,
+                    placeholder_value=self.placeholder_value,
+                )
+            return preprocessed
+
+        preprocessed: dict[str, list[TorchObsType] | TorchObsType] = {
+            group_id: [] for group_id in group_ids
+        }
         for agent_id, agent_obs in observation.items():
-            preprocessed[agent_id] = preprocess_observation(
-                self.possible_observation_spaces.get(agent_id),
-                observation=agent_obs,
-                device=self.device,
-                normalize_images=self.normalize_images,
-                placeholder_value=self.placeholder_value,
+            output_id = self.get_network_id(agent_id)
+            if output_id not in preprocessed:
+                preprocessed[output_id] = []
+
+            preprocessed[output_id].append(
+                preprocess_observation(
+                    self.observation_space.get(output_id),
+                    observation=agent_obs,
+                    device=self.device,
+                    normalize_images=self.normalize_images,
+                    placeholder_value=self.placeholder_value,
+                )
             )
 
-        return preprocessed
+        for output_id in list(preprocessed.keys()):
+            if not preprocessed[output_id]:
+                continue
+            preprocessed[output_id] = concatenate_tensors(preprocessed[output_id])
+
+        return cast("dict[str, TorchObsType]", preprocessed)
 
     def extract_action_masks(self, infos: InfosDict) -> ArrayDict:
         """Extract action masks from info dictionary.
@@ -1773,11 +1805,12 @@ class MultiAgentRLAlgorithm(EvolvableAlgorithm, ABC):
         return agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
 
     def get_network_id(self, agent_id: str) -> str:
-        """Get the network ID for an agent, considering parameter sharing groups.
+        """Get the actor/critic network ID for an agent.
 
         :param agent_id: The agent ID
         :type agent_id: str
-        :return: The actor/critic network ID
+        :return: The network ID
+        :rtype: str
         """
         return self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
 

--- a/agilerl/algorithms/ippo.py
+++ b/agilerl/algorithms/ippo.py
@@ -29,7 +29,6 @@ from agilerl.typing import (
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
     concatenate_experiences_into_batches,
-    concatenate_tensors,
     get_experiences_samples,
     get_vect_dim,
     key_in_nested_dict,
@@ -438,40 +437,7 @@ class IPPO(MultiAgentRLAlgorithm):
         *args: Any,
         **kwargs: Any,
     ) -> dict[str, TorchObsType]:
-        """Preprocesses observations for forward pass through neural network.
-
-        :param observation: Observations of environment
-        :type observation: numpy.ndarray[float] or dict[str, numpy.ndarray[float]]
-        :param group_ids: List of group IDs
-        :type group_ids: list[str]
-
-        :return: Preprocessed observations
-        :rtype: torch.Tensor[float] or dict[str, torch.Tensor[float]] or tuple[torch.Tensor[float], ...]
-        """
-        if group_ids is None:
-            group_ids = list(observation.keys())
-        preprocessed = {group_id: [] for group_id in group_ids}
-        for agent_id, agent_obs in observation.items():
-            group_id = (
-                self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
-            )
-            preprocessed[group_id].append(
-                preprocess_observation_fn(
-                    self.observation_space.get(group_id),
-                    observation=agent_obs,
-                    device=self.device,
-                    normalize_images=self.normalize_images,
-                ),
-            )
-
-        # Need to concatenate / stack observations for each group of homogeneous agents
-        for group_id in group_ids:
-            if not preprocessed[group_id]:
-                continue
-
-            preprocessed[group_id] = concatenate_tensors(preprocessed[group_id])
-
-        return preprocessed
+        return super().preprocess_observation(observation, group_ids)
 
     def _get_action_and_values(
         self,

--- a/agilerl/algorithms/ippo.py
+++ b/agilerl/algorithms/ippo.py
@@ -430,15 +430,6 @@ class IPPO(MultiAgentRLAlgorithm):
 
         return action_masks
 
-    def preprocess_observation(
-        self,
-        observation: ObservationType,
-        group_ids: list[str] | None = None,
-        *args: Any,
-        **kwargs: Any,
-    ) -> dict[str, TorchObsType]:
-        return super().preprocess_observation(observation, group_ids)
-
     def _get_action_and_values(
         self,
         obs: TorchObsType,

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -1,6 +1,6 @@
 import copy
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from dataclasses import asdict
 from typing import Any
 
@@ -26,9 +26,11 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
+    concatenate_tensors,
     concatenate_spaces,
     format_shared_critic_encoder,
     get_deepest_head_config,
+    get_vect_dim,
     key_in_nested_dict,
     make_safe_deepcopies,
     obs_channels_to_first,
@@ -211,29 +213,30 @@ class MADDPG(MultiAgentRLAlgorithm):
         }
 
         if actor_networks is not None and critic_networks is not None:
+            network_ids = list(self.observation_space.keys())
             if isinstance(actor_networks, list):
                 assert len(actor_networks) == len(
-                    self.agent_ids,
+                    self.observation_space,
                 ), (
-                    "actor_networks must be a list of the same length as the number of agents"
+                    "actor_networks must be a list of the same length as the number of homogeneous agents"
                 )
                 actor_networks = ModuleDict(
                     {
-                        self.agent_ids[i]: actor_networks[i]
-                        for i in range(len(self.agent_ids))
+                        network_ids[idx]: actor_networks[idx]
+                        for idx in range(len(network_ids))
                     },
                 )
             if isinstance(critic_networks, list):
                 assert len(critic_networks) == len(
-                    self.agent_ids,
+                    self.observation_space,
                 ), (
-                    "critic_networks must be a list of the same length as the number of agents"
+                    "critic_networks must be a list of the same length as the number of homogeneous agents"
                 )
 
                 critic_networks = ModuleDict(
                     {
-                        self.agent_ids[i]: critic_networks[i]
-                        for i in range(len(self.agent_ids))
+                        network_ids[idx]: critic_networks[idx]
+                        for idx in range(len(network_ids))
                     },
                 )
 
@@ -257,6 +260,22 @@ class MADDPG(MultiAgentRLAlgorithm):
                 raise TypeError(
                     msg,
                 )
+
+            assert len(actor_networks) == self.n_unique_agents, (
+                f"Length of actor_networks ({len(actor_networks)}) does not match number of unique "
+                f"agents defined in environment ({self.n_unique_agents}: {list(self.observation_space.keys())})"
+            )
+            assert len(critic_networks) == self.n_unique_agents, (
+                f"Length of critic_networks ({len(critic_networks)}) does not match number of unique "
+                f"agents defined in environment ({self.n_unique_agents}: {list(self.observation_space.keys())})"
+            )
+            assert set(actor_networks.keys()) == set(network_ids), (
+                "actor_networks keys must match grouped agent IDs in observation_space."
+            )
+            assert set(critic_networks.keys()) == set(network_ids), (
+                "critic_networks keys must match grouped agent IDs in observation_space."
+            )
+
             self.actors, self.critics = make_safe_deepcopies(
                 actor_networks,
                 critic_networks,
@@ -268,11 +287,12 @@ class MADDPG(MultiAgentRLAlgorithm):
         else:
             agent_configs, encoder_configs = self.build_net_config(
                 net_config,
+                flatten=False,
                 return_encoders=True,
             )
 
             # Iterate over actor configs and modify accordingly
-            for agent_id in self.agent_ids:
+            for agent_id in self.observation_space:
                 agent_config = agent_configs[agent_id]
                 head_config = agent_config.get("head_config", None)
 
@@ -288,23 +308,26 @@ class MADDPG(MultiAgentRLAlgorithm):
             latent_dim = max(
                 [
                     agent_configs[agent_id].get("latent_dim", 32)
-                    for agent_id in self.agent_ids
+                    for agent_id in self.observation_space
                 ],
             )
             min_latent_dim = min(
                 [
                     agent_configs[agent_id].get("min_latent_dim", 8)
-                    for agent_id in self.agent_ids
+                    for agent_id in self.observation_space
                 ],
             )
             max_latent_dim = max(
                 [
                     agent_configs[agent_id].get("max_latent_dim", 1024)
-                    for agent_id in self.agent_ids
+                    for agent_id in self.observation_space
                 ],
             )
             critic_encoder_config = format_shared_critic_encoder(encoder_configs)
-            critic_head_config = get_deepest_head_config(agent_configs, self.agent_ids)
+            critic_head_config = get_deepest_head_config(
+                agent_configs,
+                list(self.observation_space.keys()),
+            )
             critic_net_config = {
                 "encoder_config": critic_encoder_config,
                 "head_config": critic_head_config,
@@ -315,8 +338,8 @@ class MADDPG(MultiAgentRLAlgorithm):
 
             def create_actor(agent_id: str) -> DeterministicActor:
                 actor: DeterministicActor = DeterministicActor(
-                    self.possible_observation_spaces[agent_id],
-                    self.possible_action_spaces[agent_id],
+                    self.observation_space[agent_id],
+                    self.action_space[agent_id],
                     device=self.device,
                     **copy.deepcopy(agent_configs[agent_id]),
                 )
@@ -337,20 +360,26 @@ class MADDPG(MultiAgentRLAlgorithm):
                 )
 
             self.actors = ModuleDict(
-                {agent_id: create_actor(agent_id) for agent_id in self.agent_ids},
+                {
+                    agent_id: create_actor(agent_id)
+                    for agent_id in self.observation_space
+                },
             )
             self.critics = ModuleDict(
-                {agent_id: create_critic() for agent_id in self.agent_ids},
+                {agent_id: create_critic() for agent_id in self.observation_space},
             )
             self.actor_targets = ModuleDict(
-                {agent_id: create_actor(agent_id) for agent_id in self.agent_ids},
+                {
+                    agent_id: create_actor(agent_id)
+                    for agent_id in self.observation_space
+                },
             )
             self.critic_targets = ModuleDict(
-                {agent_id: create_critic() for agent_id in self.agent_ids},
+                {agent_id: create_critic() for agent_id in self.observation_space},
             )
 
         # Initialise target network parameters
-        for agent_id in self.agent_ids:
+        for agent_id in self.observation_space:
             self.actor_targets[agent_id].load_state_dict(
                 self.actors[agent_id].state_dict(),
             )
@@ -449,21 +478,42 @@ class MADDPG(MultiAgentRLAlgorithm):
         ), "AgileRL requires action masks to be defined in the information dictionary."
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
+        vect_dim = get_vect_dim(obs, self.possible_observation_spaces)
+        unique_agents_ids = list(obs.keys())
 
         # Preprocess observations
         preprocessed_states = self.preprocess_observation(obs)
+        grouped_agents = defaultdict(list)
+        for agent_id in unique_agents_ids:
+            group_id = self.get_network_id(agent_id)
+            grouped_agents[group_id].append(agent_id)
 
-        action_dict: dict[str, torch.Tensor] = {}
-        for agent_id, agent_obs in preprocessed_states.items():
-            actor = self.actors[agent_id]
+        grouped_actions: dict[str, np.ndarray] = {}
+        for group_id, group_agent_ids in grouped_agents.items():
+            actor = self.actors[group_id]
             actor.eval()
+            grouped_obs = concatenate_tensors(
+                [preprocessed_states[agent_id] for agent_id in group_agent_ids],
+            )
             if self.accelerator is not None:
                 with actor.no_sync(), torch.no_grad():
-                    actions = actor(agent_obs)
+                    actions = actor(grouped_obs)
             else:
                 with torch.no_grad():
-                    actions = actor(agent_obs)
+                    actions = actor(grouped_obs)
+            grouped_actions[group_id] = actions.cpu().numpy()
 
+        action_dict = {
+            agent_id: torch.as_tensor(action, device=self.device)
+            for agent_id, action in self.disassemble_grouped_outputs(
+                grouped_actions,
+                vect_dim,
+                grouped_agents,
+            ).items()
+        }
+
+        for agent_id, actions in action_dict.items():
+            actor = self.actors[self.get_network_id(agent_id)]
             actor.train()
             if self.training:
                 if isinstance(self.possible_action_spaces[agent_id], spaces.Discrete):
@@ -478,17 +528,19 @@ class MADDPG(MultiAgentRLAlgorithm):
                     torch.as_tensor(max_output, device=actions.device),
                 )
 
-            action_dict[agent_id] = actions.cpu()
+            action_dict[agent_id] = actions.detach().cpu()
 
         # Process actions for environment
         processed_action_dict: ArrayDict = OrderedDict()
         for agent_id in action_dict:
             space = self.possible_action_spaces[agent_id]
+            network_id = self.get_network_id(agent_id)
+            actor = self.actors[network_id]
             if isinstance(space, spaces.Discrete):
                 action = action_dict[agent_id].numpy()
                 mask = (
                     1 - np.array(action_masks[agent_id])
-                    if action_masks[agent_id] is not None
+                    if action_masks.get(agent_id) is not None
                     else None
                 )
                 action: np.ndarray = np.ma.array(action, mask=mask)
@@ -569,7 +621,7 @@ class MADDPG(MultiAgentRLAlgorithm):
             for idx in indices:
                 self.current_noise[agent_id][idx, :] = 0
 
-    def learn(self, experiences: ExperiencesType) -> dict[str, torch.Tensor]:
+    def learn(self, experiences: ExperiencesType) -> dict[str, tuple[float, float]]:
         """Update agent network parameters from the gathered experiences.
 
         :param experience: Tuple of dictionaries containing batched states, actions,
@@ -601,17 +653,21 @@ class MADDPG(MultiAgentRLAlgorithm):
         # Get next actions
         with torch.no_grad():
             next_actions = [
-                self.actor_targets[agent_id](next_states[agent_id])
+                self.actor_targets[self.get_network_id(agent_id)](next_states[agent_id])
                 for agent_id in self.agent_ids
             ]
 
         # Stack actions for critic
-        stacked_actions = torch.cat(list(actions.values()), dim=1)
+        stacked_actions = torch.cat(
+            [actions[agent_id] for agent_id in self.agent_ids],
+            dim=1,
+        )
         stacked_next_actions = torch.cat(next_actions, dim=1)
 
-        loss_dict = {}
+        loss_dict: dict[str, tuple[float, float]] = {}
+        grouped_losses: dict[str, list[tuple[float, float]]] = defaultdict(list)
         for agent_id in self.agent_ids:
-            loss_dict[f"{agent_id}"] = self._learn_individual(
+            losses = self._learn_individual(
                 agent_id,
                 stacked_actions,
                 stacked_next_actions,
@@ -621,8 +677,21 @@ class MADDPG(MultiAgentRLAlgorithm):
                 rewards,
                 dones,
             )
+            if self.has_grouped_agents():
+                grouped_losses[self.get_group_id(agent_id)].append(losses)
+            else:
+                loss_dict[agent_id] = losses
 
-        for agent_id in self.agent_ids:
+        if self.has_grouped_agents():
+            for group_id, group_loss in grouped_losses.items():
+                actor_losses = [loss[0] for loss in group_loss]
+                critic_losses = [loss[1] for loss in group_loss]
+                loss_dict[group_id] = (
+                    float(np.mean(actor_losses)),
+                    float(np.mean(critic_losses)),
+                )
+
+        for agent_id in self.observation_space:
             self.soft_update(self.actors[agent_id], self.actor_targets[agent_id])
             self.soft_update(self.critics[agent_id], self.critic_targets[agent_id])
 
@@ -661,11 +730,13 @@ class MADDPG(MultiAgentRLAlgorithm):
         :return: Tuple containing actor loss and critic loss
         :rtype: tuple[float, float]
         """
-        actor = self.actors[agent_id]
-        critic = self.critics[agent_id]
-        critic_target = self.critic_targets[agent_id]
-        actor_optimizer = self.actor_optimizers[agent_id]
-        critic_optimizer = self.critic_optimizers[agent_id]
+        network_id = self.get_network_id(agent_id)
+
+        actor = self.actors[network_id]
+        critic = self.critics[network_id]
+        critic_target = self.critic_targets[network_id]
+        actor_optimizer = self.actor_optimizers[network_id]
+        critic_optimizer = self.critic_optimizers[network_id]
 
         if self.accelerator is not None:
             with critic.no_sync():
@@ -722,7 +793,10 @@ class MADDPG(MultiAgentRLAlgorithm):
         detached_actions[agent_id] = action
 
         # update actor and targets
-        stacked_detached_actions = torch.cat(list(detached_actions.values()), dim=1)
+        stacked_detached_actions = torch.cat(
+            [detached_actions[agent_key] for agent_key in self.agent_ids],
+            dim=1,
+        )
         if self.accelerator is not None:
             with critic.no_sync():
                 actor_loss = -critic(states, stacked_detached_actions).mean()

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -26,8 +26,8 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
-    concatenate_tensors,
     concatenate_spaces,
+    concatenate_tensors,
     format_shared_critic_encoder,
     get_deepest_head_config,
     get_vect_dim,

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -453,9 +453,6 @@ class MADDPG(MultiAgentRLAlgorithm):
         action_masks = self.extract_action_masks(infos)
         return action_masks, env_defined_actions, agent_masks
 
-    def get_network_id(self, agent_id: str) -> str:
-        return self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
-
     def get_action(
         self,
         obs: dict[str, ObservationType],

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -454,6 +454,9 @@ class MADDPG(MultiAgentRLAlgorithm):
         action_masks = self.extract_action_masks(infos)
         return action_masks, env_defined_actions, agent_masks
 
+    def get_network_id(self, agent_id: str) -> str:
+        return self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
+
     def get_action(
         self,
         obs: dict[str, ObservationType],

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -27,7 +27,6 @@ from agilerl.typing import (
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
     concatenate_spaces,
-    concatenate_tensors,
     format_shared_critic_encoder,
     get_deepest_head_config,
     get_vect_dim,
@@ -482,22 +481,23 @@ class MADDPG(MultiAgentRLAlgorithm):
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
         vect_dim = get_vect_dim(obs, self.possible_observation_spaces)
-        unique_agents_ids = list(obs.keys())
-
-        # Preprocess observations
-        preprocessed_states = self.preprocess_observation(obs)
+        active_agent_ids = list(obs.keys())
         grouped_agents = defaultdict(list)
-        for agent_id in unique_agents_ids:
-            group_id = self.get_network_id(agent_id)
-            grouped_agents[group_id].append(agent_id)
+        for agent_id in active_agent_ids:
+            network_id = self.get_network_id(agent_id)
+            grouped_agents[network_id].append(agent_id)
+
+        # Preprocess and group observations only for currently active groups.
+        preprocessed_states = self.preprocess_observation(
+            obs,
+            group_ids=list(grouped_agents.keys()),
+        )
 
         grouped_actions: dict[str, np.ndarray] = {}
-        for group_id, group_agent_ids in grouped_agents.items():
+        for group_id in grouped_agents:
             actor = self.actors[group_id]
             actor.eval()
-            grouped_obs = concatenate_tensors(
-                [preprocessed_states[agent_id] for agent_id in group_agent_ids],
-            )
+            grouped_obs = preprocessed_states[group_id]
             if self.accelerator is not None:
                 with actor.no_sync(), torch.no_grad():
                     actions = actor(grouped_obs)

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -477,12 +477,16 @@ class MADDPG(MultiAgentRLAlgorithm):
         ), "AgileRL requires action masks to be defined in the information dictionary."
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
-        vect_dim = get_vect_dim(obs, self.possible_observation_spaces)
         active_agent_ids = list(obs.keys())
         grouped_agents = defaultdict(list)
+        agent_batch_sizes = {}
         for agent_id in active_agent_ids:
             network_id = self.get_network_id(agent_id)
             grouped_agents[network_id].append(agent_id)
+            agent_batch_sizes[agent_id] = get_vect_dim(
+                obs[agent_id],
+                self.possible_observation_spaces[agent_id],
+            )
 
         # Preprocess and group observations only for currently active groups.
         preprocessed_states = self.preprocess_observation(
@@ -503,14 +507,17 @@ class MADDPG(MultiAgentRLAlgorithm):
                     actions = actor(grouped_obs)
             grouped_actions[group_id] = actions.cpu().numpy()
 
-        action_dict = {
-            agent_id: torch.as_tensor(action, device=self.device)
-            for agent_id, action in self.disassemble_grouped_outputs(
-                grouped_actions,
-                vect_dim,
-                grouped_agents,
-            ).items()
-        }
+        action_dict = {}
+        for group_id, actions in grouped_actions.items():
+            start = 0
+            for agent_id in grouped_agents[group_id]:
+                batch_size = agent_batch_sizes[agent_id]
+                end = start + batch_size
+                action_dict[agent_id] = torch.as_tensor(
+                    actions[start:end],
+                    device=self.device,
+                )
+                start = end
 
         for agent_id, actions in action_dict.items():
             actor = self.actors[self.get_network_id(agent_id)]

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -26,7 +26,6 @@ from agilerl.typing import (
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
     concatenate_spaces,
-    concatenate_tensors,
     format_shared_critic_encoder,
     get_deepest_head_config,
     get_vect_dim,
@@ -550,22 +549,23 @@ class MATD3(MultiAgentRLAlgorithm):
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
         vect_dim = get_vect_dim(obs, self.possible_observation_spaces)
-        unique_agents_ids = list(obs.keys())
-
-        # Preprocess observations
-        preprocessed_states = self.preprocess_observation(obs)
+        active_agent_ids = list(obs.keys())
         grouped_agents = defaultdict(list)
-        for agent_id in unique_agents_ids:
-            group_id = self.get_network_id(agent_id)
-            grouped_agents[group_id].append(agent_id)
+        for agent_id in active_agent_ids:
+            network_id = self.get_network_id(agent_id)
+            grouped_agents[network_id].append(agent_id)
+
+        # Preprocess and group observations only for currently active groups.
+        preprocessed_states = self.preprocess_observation(
+            obs,
+            group_ids=list(grouped_agents.keys()),
+        )
 
         grouped_actions: dict[str, np.ndarray] = {}
-        for group_id, group_agent_ids in grouped_agents.items():
+        for group_id in grouped_agents:
             actor = self.actors[group_id]
             actor.eval()
-            grouped_obs = concatenate_tensors(
-                [preprocessed_states[agent_id] for agent_id in group_agent_ids],
-            )
+            grouped_obs = preprocessed_states[group_id]
             if self.accelerator is not None:
                 with actor.no_sync(), torch.no_grad():
                     actions = actor(grouped_obs)

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -25,8 +25,8 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
-    concatenate_tensors,
     concatenate_spaces,
+    concatenate_tensors,
     format_shared_critic_encoder,
     get_deepest_head_config,
     get_vect_dim,
@@ -757,12 +757,12 @@ class MATD3(MultiAgentRLAlgorithm):
             for group_id, group_loss in grouped_losses.items():
                 actor_losses = [loss[0] for loss in group_loss if loss[0] is not None]
                 critic_losses = [loss[1] for loss in group_loss]
-                mean_actor_loss = (
-                    float(np.mean(actor_losses)) if actor_losses else None
-                )
+                mean_actor_loss = float(np.mean(actor_losses)) if actor_losses else None
                 loss_dict[group_id] = (mean_actor_loss, float(np.mean(critic_losses)))
 
-        if all(counter % self.policy_freq == 0 for counter in self.learn_counter.values()):
+        if all(
+            counter % self.policy_freq == 0 for counter in self.learn_counter.values()
+        ):
             for agent_id in self.observation_space:
                 self.soft_update(self.actors[agent_id], self.actor_targets[agent_id])
                 self.soft_update(

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -545,12 +545,16 @@ class MATD3(MultiAgentRLAlgorithm):
         ), "AgileRL requires action masks to be defined in the information dictionary."
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
-        vect_dim = get_vect_dim(obs, self.possible_observation_spaces)
         active_agent_ids = list(obs.keys())
         grouped_agents = defaultdict(list)
+        agent_batch_sizes = {}
         for agent_id in active_agent_ids:
             network_id = self.get_network_id(agent_id)
             grouped_agents[network_id].append(agent_id)
+            agent_batch_sizes[agent_id] = get_vect_dim(
+                obs[agent_id],
+                self.possible_observation_spaces[agent_id],
+            )
 
         # Preprocess and group observations only for currently active groups.
         preprocessed_states = self.preprocess_observation(
@@ -571,14 +575,17 @@ class MATD3(MultiAgentRLAlgorithm):
                     actions = actor(grouped_obs)
             grouped_actions[group_id] = actions.cpu().numpy()
 
-        action_dict = {
-            agent_id: torch.as_tensor(action, device=self.device)
-            for agent_id, action in self.disassemble_grouped_outputs(
-                grouped_actions,
-                vect_dim,
-                grouped_agents,
-            ).items()
-        }
+        action_dict = {}
+        for group_id, actions in grouped_actions.items():
+            start = 0
+            for agent_id in grouped_agents[group_id]:
+                batch_size = agent_batch_sizes[agent_id]
+                end = start + batch_size
+                action_dict[agent_id] = torch.as_tensor(
+                    actions[start:end],
+                    device=self.device,
+                )
+                start = end
 
         for agent_id, actions in action_dict.items():
             actor = self.actors[self.get_network_id(agent_id)]

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -521,6 +521,9 @@ class MATD3(MultiAgentRLAlgorithm):
         action_masks = self.extract_action_masks(infos)
         return action_masks, env_defined_actions, agent_masks
 
+    def get_network_id(self, agent_id: str) -> str:
+        return self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
+
     def get_action(
         self,
         obs: dict[str, ObservationType],

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -520,9 +520,6 @@ class MATD3(MultiAgentRLAlgorithm):
         action_masks = self.extract_action_masks(infos)
         return action_masks, env_defined_actions, agent_masks
 
-    def get_network_id(self, agent_id: str) -> str:
-        return self.get_group_id(agent_id) if self.has_grouped_agents() else agent_id
-
     def get_action(
         self,
         obs: dict[str, ObservationType],

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -1,6 +1,6 @@
 import copy
 import warnings
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from dataclasses import asdict
 from typing import Any
 
@@ -25,9 +25,11 @@ from agilerl.typing import (
 )
 from agilerl.utils.algo_utils import (
     apply_env_defined_actions,
+    concatenate_tensors,
     concatenate_spaces,
     format_shared_critic_encoder,
     get_deepest_head_config,
+    get_vect_dim,
     key_in_nested_dict,
     make_safe_deepcopies,
     obs_channels_to_first,
@@ -179,7 +181,7 @@ class MATD3(MultiAgentRLAlgorithm):
         self.tau = tau
         self.mut = mut
         self.policy_freq = policy_freq
-        self.learn_counter = dict.fromkeys(self.agent_ids, 0)
+        self.learn_counter = dict.fromkeys(self.observation_space.keys(), 0)
         self.O_U_noise = O_U_noise
         self.vect_noise_dim = vect_noise_dim
         self.theta = theta
@@ -219,41 +221,45 @@ class MATD3(MultiAgentRLAlgorithm):
                 critic_networks,
                 list,
             ), "critic_networks must be a list containing the two critics in MATD3."
+            assert len(critic_networks) == 2, (
+                "critic_networks must contain exactly two critic sets in MATD3."
+            )
+            network_ids = list(self.observation_space.keys())
 
             if isinstance(actor_networks, list):
                 assert len(actor_networks) == len(
-                    self.agent_ids,
+                    self.observation_space,
                 ), (
-                    "actor_networks must be a list of the same length as the number of agents"
+                    "actor_networks must be a list of the same length as the number of homogeneous agents"
                 )
                 actor_networks = ModuleDict(
                     {
-                        self.agent_ids[i]: actor_networks[i]
-                        for i in range(len(self.agent_ids))
+                        network_ids[idx]: actor_networks[idx]
+                        for idx in range(len(network_ids))
                     },
                 )
             if isinstance(critic_networks[0], list):
                 assert len(critic_networks[0]) == len(
-                    self.agent_ids,
+                    self.observation_space,
                 ), (
-                    "critic_networks at index 0 must be a list of the same length as the number of agents"
+                    "critic_networks at index 0 must be a list of the same length as the number of homogeneous agents"
                 )
                 assert len(critic_networks[1]) == len(
-                    self.agent_ids,
+                    self.observation_space,
                 ), (
-                    "critic_networks at index 1 must be a list of the same length as the number of agents"
+                    "critic_networks at index 1 must be a list of the same length as the number of homogeneous agents"
                 )
 
                 critic_networks[0] = ModuleDict(
                     {
-                        self.agent_ids[i]: critic_networks[0][i]
-                        for i in range(len(self.agent_ids))
+                        network_ids[idx]: critic_networks[0][idx]
+                        for idx in range(len(network_ids))
                     },
                 )
                 critic_networks[1] = ModuleDict(
                     {
-                        self.agent_ids[i]: critic_networks[1][i]
-                        for i in range(len(self.agent_ids))
+                        network_ids[idx]: critic_networks[1][idx]
+                        for idx in range(len(network_ids))
                     },
                 )
 
@@ -289,6 +295,29 @@ class MATD3(MultiAgentRLAlgorithm):
                 raise TypeError(
                     msg,
                 )
+
+            assert len(actor_networks) == self.n_unique_agents, (
+                f"Length of actor_networks ({len(actor_networks)}) does not match number of unique "
+                f"agents defined in environment ({self.n_unique_agents}: {list(self.observation_space.keys())})"
+            )
+            assert len(critic_networks[0]) == self.n_unique_agents, (
+                f"Length of critic_networks at index 0 ({len(critic_networks[0])}) does not match number of unique "
+                f"agents defined in environment ({self.n_unique_agents}: {list(self.observation_space.keys())})"
+            )
+            assert len(critic_networks[1]) == self.n_unique_agents, (
+                f"Length of critic_networks at index 1 ({len(critic_networks[1])}) does not match number of unique "
+                f"agents defined in environment ({self.n_unique_agents}: {list(self.observation_space.keys())})"
+            )
+            assert set(actor_networks.keys()) == set(network_ids), (
+                "actor_networks keys must match grouped agent IDs in observation_space."
+            )
+            assert set(critic_networks[0].keys()) == set(network_ids), (
+                "critic_networks[0] keys must match grouped agent IDs in observation_space."
+            )
+            assert set(critic_networks[1].keys()) == set(network_ids), (
+                "critic_networks[1] keys must match grouped agent IDs in observation_space."
+            )
+
             self.actors, self.critics_1, self.critics_2 = make_safe_deepcopies(
                 actor_networks,
                 critic_networks[0],
@@ -304,11 +333,12 @@ class MATD3(MultiAgentRLAlgorithm):
         else:
             agent_configs, encoder_configs = self.build_net_config(
                 net_config,
+                flatten=False,
                 return_encoders=True,
             )
 
             # Iterate over actor configs and modify accordingly
-            for agent_id in self.agent_ids:
+            for agent_id in self.observation_space:
                 agent_config = agent_configs[agent_id]
                 head_config = agent_config.get("head_config", None)
 
@@ -324,23 +354,26 @@ class MATD3(MultiAgentRLAlgorithm):
             latent_dim = max(
                 [
                     agent_configs[agent_id].get("latent_dim", 32)
-                    for agent_id in self.agent_ids
+                    for agent_id in self.observation_space
                 ],
             )
             min_latent_dim = min(
                 [
                     agent_configs[agent_id].get("min_latent_dim", 8)
-                    for agent_id in self.agent_ids
+                    for agent_id in self.observation_space
                 ],
             )
             max_latent_dim = max(
                 [
                     agent_configs[agent_id].get("max_latent_dim", 1024)
-                    for agent_id in self.agent_ids
+                    for agent_id in self.observation_space
                 ],
             )
             critic_encoder_config = format_shared_critic_encoder(encoder_configs)
-            critic_head_config = get_deepest_head_config(agent_configs, self.agent_ids)
+            critic_head_config = get_deepest_head_config(
+                agent_configs,
+                list(self.observation_space.keys()),
+            )
             critic_net_config = {
                 "encoder_config": critic_encoder_config,
                 "head_config": critic_head_config,
@@ -351,8 +384,8 @@ class MATD3(MultiAgentRLAlgorithm):
 
             def create_actor(agent_id: str) -> DeterministicActor:
                 actor: DeterministicActor = DeterministicActor(
-                    self.possible_observation_spaces[agent_id],
-                    self.possible_action_spaces[agent_id],
+                    self.observation_space[agent_id],
+                    self.action_space[agent_id],
                     device=self.device,
                     **copy.deepcopy(agent_configs[agent_id]),
                 )
@@ -373,26 +406,32 @@ class MATD3(MultiAgentRLAlgorithm):
                 )
 
             self.actors = ModuleDict(
-                {agent_id: create_actor(agent_id) for agent_id in self.agent_ids},
+                {
+                    agent_id: create_actor(agent_id)
+                    for agent_id in self.observation_space
+                },
             )
             self.critics_1 = ModuleDict(
-                {agent_id: create_critic() for agent_id in self.agent_ids},
+                {agent_id: create_critic() for agent_id in self.observation_space},
             )
             self.critics_2 = ModuleDict(
-                {agent_id: create_critic() for agent_id in self.agent_ids},
+                {agent_id: create_critic() for agent_id in self.observation_space},
             )
             self.actor_targets = ModuleDict(
-                {agent_id: create_actor(agent_id) for agent_id in self.agent_ids},
+                {
+                    agent_id: create_actor(agent_id)
+                    for agent_id in self.observation_space
+                },
             )
             self.critic_targets_1 = ModuleDict(
-                {agent_id: create_critic() for agent_id in self.agent_ids},
+                {agent_id: create_critic() for agent_id in self.observation_space},
             )
             self.critic_targets_2 = ModuleDict(
-                {agent_id: create_critic() for agent_id in self.agent_ids},
+                {agent_id: create_critic() for agent_id in self.observation_space},
             )
 
         # Initialise target network parameters
-        for agent_id in self.agent_ids:
+        for agent_id in self.observation_space:
             self.actor_targets[agent_id].load_state_dict(
                 self.actors[agent_id].state_dict(),
             )
@@ -507,21 +546,42 @@ class MATD3(MultiAgentRLAlgorithm):
         ), "AgileRL requires action masks to be defined in the information dictionary."
 
         action_masks, env_defined_actions, agent_masks = self.process_infos(infos)
+        vect_dim = get_vect_dim(obs, self.possible_observation_spaces)
+        unique_agents_ids = list(obs.keys())
 
         # Preprocess observations
         preprocessed_states = self.preprocess_observation(obs)
+        grouped_agents = defaultdict(list)
+        for agent_id in unique_agents_ids:
+            group_id = self.get_network_id(agent_id)
+            grouped_agents[group_id].append(agent_id)
 
-        action_dict: dict[str, torch.Tensor] = {}
-        for agent_id, agent_obs in preprocessed_states.items():
-            actor = self.actors[agent_id]
+        grouped_actions: dict[str, np.ndarray] = {}
+        for group_id, group_agent_ids in grouped_agents.items():
+            actor = self.actors[group_id]
             actor.eval()
+            grouped_obs = concatenate_tensors(
+                [preprocessed_states[agent_id] for agent_id in group_agent_ids],
+            )
             if self.accelerator is not None:
                 with actor.no_sync(), torch.no_grad():
-                    actions = actor(agent_obs)
+                    actions = actor(grouped_obs)
             else:
                 with torch.no_grad():
-                    actions = actor(agent_obs)
+                    actions = actor(grouped_obs)
+            grouped_actions[group_id] = actions.cpu().numpy()
 
+        action_dict = {
+            agent_id: torch.as_tensor(action, device=self.device)
+            for agent_id, action in self.disassemble_grouped_outputs(
+                grouped_actions,
+                vect_dim,
+                grouped_agents,
+            ).items()
+        }
+
+        for agent_id, actions in action_dict.items():
+            actor = self.actors[self.get_network_id(agent_id)]
             actor.train()
             if self.training:
                 if isinstance(self.possible_action_spaces[agent_id], spaces.Discrete):
@@ -536,17 +596,19 @@ class MATD3(MultiAgentRLAlgorithm):
                     torch.as_tensor(max_output, device=actions.device),
                 )
 
-            action_dict[agent_id] = actions.cpu()
+            action_dict[agent_id] = actions.detach().cpu()
 
         # Process actions for environment
         processed_action_dict: ArrayDict = OrderedDict()
         for agent_id in action_dict:
             action_space = self.possible_action_spaces[agent_id]
+            network_id = self.get_network_id(agent_id)
+            actor = self.actors[network_id]
             if isinstance(action_space, spaces.Discrete):
                 action = action_dict[agent_id].numpy()
                 mask = (
                     1 - np.array(action_masks[agent_id])
-                    if action_masks[agent_id] is not None
+                    if action_masks.get(agent_id) is not None
                     else None
                 )
                 action: np.ndarray = np.ma.array(action, mask=mask)
@@ -628,7 +690,10 @@ class MATD3(MultiAgentRLAlgorithm):
             for idx in indices:
                 self.current_noise[agent_id][idx, :] = 0
 
-    def learn(self, experiences: tuple[StandardTensorDict, ...]) -> dict[str, float]:
+    def learn(
+        self,
+        experiences: tuple[StandardTensorDict, ...],
+    ) -> dict[str, tuple[float | None, float]]:
         """Update agent network parameters from the gathered experiences.
 
         :param experience: Tuple of dictionaries containing batched states, actions,
@@ -659,17 +724,21 @@ class MATD3(MultiAgentRLAlgorithm):
 
         with torch.no_grad():
             next_actions = [
-                self.actor_targets[agent_id](next_states[agent_id])
+                self.actor_targets[self.get_network_id(agent_id)](next_states[agent_id])
                 for agent_id in self.agent_ids
             ]
 
         # Stack states and actions
-        stacked_actions = torch.cat(list(actions.values()), dim=1)
+        stacked_actions = torch.cat(
+            [actions[agent_id] for agent_id in self.agent_ids],
+            dim=1,
+        )
         stacked_next_actions = torch.cat(next_actions, dim=1)
 
-        loss_dict = {}
+        loss_dict: dict[str, tuple[float | None, float]] = {}
+        grouped_losses: dict[str, list[tuple[float | None, float]]] = defaultdict(list)
         for agent_id in self.agent_ids:
-            loss_dict[f"{agent_id}"] = self.learn_individual(
+            losses = self.learn_individual(
                 agent_id,
                 stacked_actions=stacked_actions,
                 stacked_next_actions=stacked_next_actions,
@@ -679,9 +748,22 @@ class MATD3(MultiAgentRLAlgorithm):
                 rewards=rewards,
                 dones=dones,
             )
+            if self.has_grouped_agents():
+                grouped_losses[self.get_group_id(agent_id)].append(losses)
+            else:
+                loss_dict[agent_id] = losses
 
-        if self.learn_counter[agent_id] % self.policy_freq == 0:
-            for agent_id in self.agent_ids:
+        if self.has_grouped_agents():
+            for group_id, group_loss in grouped_losses.items():
+                actor_losses = [loss[0] for loss in group_loss if loss[0] is not None]
+                critic_losses = [loss[1] for loss in group_loss]
+                mean_actor_loss = (
+                    float(np.mean(actor_losses)) if actor_losses else None
+                )
+                loss_dict[group_id] = (mean_actor_loss, float(np.mean(critic_losses)))
+
+        if all(counter % self.policy_freq == 0 for counter in self.learn_counter.values()):
+            for agent_id in self.observation_space:
                 self.soft_update(self.actors[agent_id], self.actor_targets[agent_id])
                 self.soft_update(
                     self.critics_1[agent_id],
@@ -727,14 +809,16 @@ class MATD3(MultiAgentRLAlgorithm):
         :return: Tuple containing actor loss (if applicable) and critic loss
         :rtype: tuple[float | None, float]
         """
-        actor = self.actors[agent_id]
-        critic_1 = self.critics_1[agent_id]
-        critic_target_1 = self.critic_targets_1[agent_id]
-        critic_2 = self.critics_2[agent_id]
-        critic_target_2 = self.critic_targets_2[agent_id]
-        actor_optimizer = self.actor_optimizers[agent_id]
-        critic_1_optimizer = self.critic_1_optimizers[agent_id]
-        critic_2_optimizer = self.critic_2_optimizers[agent_id]
+        network_id = self.get_network_id(agent_id)
+
+        actor = self.actors[network_id]
+        critic_1 = self.critics_1[network_id]
+        critic_target_1 = self.critic_targets_1[network_id]
+        critic_2 = self.critics_2[network_id]
+        critic_target_2 = self.critic_targets_2[network_id]
+        actor_optimizer = self.actor_optimizers[network_id]
+        critic_1_optimizer = self.critic_1_optimizers[network_id]
+        critic_2_optimizer = self.critic_2_optimizers[network_id]
 
         if self.accelerator is not None:
             with critic_1.no_sync():
@@ -812,9 +896,12 @@ class MATD3(MultiAgentRLAlgorithm):
         detached_actions[agent_id] = action
 
         # update actor and targets every policy_freq learn steps
-        self.learn_counter[agent_id] += 1
-        if self.learn_counter[agent_id] % self.policy_freq == 0:
-            stacked_detached_actions = torch.cat(list(detached_actions.values()), dim=1)
+        self.learn_counter[network_id] += 1
+        if self.learn_counter[network_id] % self.policy_freq == 0:
+            stacked_detached_actions = torch.cat(
+                [detached_actions[agent_key] for agent_key in self.agent_ids],
+                dim=1,
+            )
             if self.accelerator is not None:
                 with critic_1.no_sync():
                     actor_loss = -critic_1(states, stacked_detached_actions).mean()

--- a/tests/test_algorithms/test_core_base.py
+++ b/tests/test_algorithms/test_core_base.py
@@ -2512,6 +2512,23 @@ class TestMultiAgentPreprocessObservation:
         assert "agent_1" in result
         assert isinstance(result["agent_0"], torch.Tensor)
 
+    def test_preprocess_observation_grouped_output(self, vector_space):
+        obs = [vector_space, vector_space]
+        act = [spaces.Discrete(2), spaces.Discrete(2)]
+        agent = DummyMARLAlgorithm(obs, act, agent_ids=["agent_0", "agent_1"], index=0)
+        observation = {
+            "agent_0": np.zeros(4, dtype=np.float32),
+            "agent_1": np.ones(4, dtype=np.float32),
+        }
+
+        result = agent.preprocess_observation(observation, group_ids=["agent"])
+
+        assert "agent" in result
+        assert "agent_0" not in result
+        assert "agent_1" not in result
+        assert isinstance(result["agent"], torch.Tensor)
+        assert result["agent"].shape[0] == 2
+
 
 class TestMultiAgentExtractAgentMasksContinuousNan:
     def test_extract_agent_masks_none_continuous_action(self, vector_space):

--- a/tests/test_algorithms/test_multi_agent/test_maddpg.py
+++ b/tests/test_algorithms/test_multi_agent/test_maddpg.py
@@ -156,6 +156,17 @@ class DummyDeterministicActor(DeterministicActor):
         return DummyNoSync()
 
 
+def get_group_index_map(agent_ids):
+    group_to_index = {}
+    for idx, agent_id in enumerate(agent_ids):
+        group_to_index.setdefault(agent_id.rsplit("_", 1)[0], idx)
+    return group_to_index
+
+
+def get_network_id(agent, agent_id):
+    return agent.get_group_id(agent_id) if agent.has_grouped_agents() else agent_id
+
+
 @pytest.fixture(scope="function")
 def mlp_actor(observation_spaces, action_spaces, request):
     observation_spaces = request.getfixturevalue(observation_spaces)
@@ -344,9 +355,9 @@ def test_initialize_maddpg_with_net_config(
             isinstance(critic, OptimizedModule) for critic in maddpg.critics.values()
         )
     else:
-        for agent_id in maddpg.agent_ids:
-            actor = maddpg.actors[agent_id]
-            critic = maddpg.critics[agent_id]
+        for network_id in maddpg.observation_space:
+            actor = maddpg.actors[network_id]
+            critic = maddpg.critics[network_id]
             assert isinstance(actor, DeterministicActor)
             assert isinstance(critic, ContinuousQNetwork)
 
@@ -357,6 +368,62 @@ def test_initialize_maddpg_with_net_config(
         assert isinstance(critic_optimizer, expected_optimizer_cls)
 
     assert isinstance(maddpg.criterion, nn.MSELoss)
+    maddpg.clean_up()
+
+
+def test_maddpg_parameter_sharing_group_networks_and_optimizers(ma_vector_space):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    maddpg = MADDPG(
+        observation_spaces=ma_vector_space,
+        action_spaces=copy.deepcopy(ma_vector_space),
+        agent_ids=agent_ids,
+        device="cpu",
+    )
+
+    assert set(maddpg.actors.keys()) == set(maddpg.shared_agent_ids)
+    assert set(maddpg.critics.keys()) == set(maddpg.shared_agent_ids)
+    assert set(maddpg.actor_optimizers.optimizer.keys()) == set(maddpg.shared_agent_ids)
+    assert set(maddpg.critic_optimizers.optimizer.keys()) == set(
+        maddpg.shared_agent_ids
+    )
+
+    obs = {
+        agent_id: np.random.randn(*space.shape).astype(np.float32)
+        for agent_id, space in zip(agent_ids, ma_vector_space, strict=False)
+    }
+    processed_actions, raw_actions = maddpg.get_action(obs)
+    assert set(processed_actions.keys()) == set(agent_ids)
+    assert set(raw_actions.keys()) == set(agent_ids)
+    maddpg.clean_up()
+
+
+def test_maddpg_learn_returns_group_losses_for_parameter_sharing(ma_vector_space):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    batch_size = 8
+    maddpg = MADDPG(
+        observation_spaces=ma_vector_space,
+        action_spaces=copy.deepcopy(ma_vector_space),
+        agent_ids=agent_ids,
+        device="cpu",
+    )
+
+    states = {
+        agent_id: torch.randn(batch_size, ma_vector_space[idx].shape[0])
+        for idx, agent_id in enumerate(agent_ids)
+    }
+    actions = {
+        agent_id: torch.randn(batch_size, ma_vector_space[idx].shape[0])
+        for idx, agent_id in enumerate(agent_ids)
+    }
+    rewards = {agent_id: torch.randn(batch_size, 1) for agent_id in agent_ids}
+    next_states = {
+        agent_id: torch.randn(batch_size, ma_vector_space[idx].shape[0])
+        for idx, agent_id in enumerate(agent_ids)
+    }
+    dones = {agent_id: torch.zeros(batch_size, 1) for agent_id in agent_ids}
+
+    loss = maddpg.learn((states, actions, rewards, next_states, dones))
+    assert set(loss.keys()) == set(maddpg.shared_agent_ids)
     maddpg.clean_up()
 
 
@@ -379,24 +446,25 @@ def test_initialize_maddpg_with_mlp_networks(
     action_spaces = request.getfixturevalue(action_spaces)
     accelerator = Accelerator() if accelerator_flag else None
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    group_to_index = get_group_index_map(agent_ids)
     evo_actors = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=mlp_actor,
                 input_tensor=torch.randn(1, 6),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=mlp_critic,
                 input_tensor=torch.randn(1, 8),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     maddpg = MADDPG(
@@ -418,9 +486,9 @@ def test_initialize_maddpg_with_mlp_networks(
             isinstance(critic, OptimizedModule) for critic in maddpg.critics.values()
         )
     else:
-        for agent_id in maddpg.agent_ids:
-            actor = maddpg.actors[agent_id]
-            critic = maddpg.critics[agent_id]
+        for network_id in maddpg.observation_space:
+            actor = maddpg.actors[network_id]
+            critic = maddpg.critics[network_id]
             assert isinstance(actor, MakeEvolvable)
             assert isinstance(critic, MakeEvolvable)
 
@@ -494,25 +562,26 @@ def test_initialize_maddpg_with_cnn_networks(
 ):
     accelerator = Accelerator() if accelerator_flag else None
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    group_to_index = get_group_index_map(agent_ids)
     evo_actors = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=cnn_actor,
                 input_tensor=torch.randn(1, 3, 1, 32, 32),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=cnn_critic,
                 input_tensor=torch.randn(1, 3, 3, 32, 32),
                 secondary_input_tensor=torch.randn(1, 2),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     maddpg = MADDPG(
@@ -533,9 +602,9 @@ def test_initialize_maddpg_with_cnn_networks(
             isinstance(critic, OptimizedModule) for critic in maddpg.critics.values()
         )
     else:
-        for agent_id in maddpg.agent_ids:
-            actor = maddpg.actors[agent_id]
-            critic = maddpg.critics[agent_id]
+        for network_id in maddpg.observation_space:
+            actor = maddpg.actors[network_id]
+            critic = maddpg.critics[network_id]
             assert isinstance(actor, MakeEvolvable)
             assert isinstance(critic, MakeEvolvable)
 
@@ -583,25 +652,26 @@ def test_initialize_maddpg_with_evo_networks(
     observation_space = spaces.Dict(
         {agent_id: observation_spaces[idx] for idx, agent_id in enumerate(agent_ids)},
     )
+    group_to_index = get_group_index_map(agent_ids)
 
     evo_actors = ModuleDict(
         {
-            agent_id: DeterministicActor(
-                observation_spaces[i],
-                ma_discrete_space[i],
+            group_id: DeterministicActor(
+                observation_spaces[idx],
+                ma_discrete_space[idx],
                 device=device,
             )
-            for i, agent_id in enumerate(agent_ids)
+            for group_id, idx in group_to_index.items()
         },
     )
     evo_critics = ModuleDict(
         {
-            agent_id: ContinuousQNetwork(
+            group_id: ContinuousQNetwork(
                 observation_space=observation_space,
                 action_space=concatenate_spaces(ma_discrete_space),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
 
@@ -623,9 +693,9 @@ def test_initialize_maddpg_with_evo_networks(
             isinstance(critic, OptimizedModule) for critic in maddpg.critics.values()
         )
     else:
-        for agent_id in maddpg.agent_ids:
-            actor = maddpg.actors[agent_id]
-            critic = maddpg.critics[agent_id]
+        for network_id in maddpg.observation_space:
+            actor = maddpg.actors[network_id]
+            critic = maddpg.critics[network_id]
             assert isinstance(actor.encoder, encoder_cls)
             assert isinstance(critic.encoder, EvolvableMultiInput)
 
@@ -662,16 +732,14 @@ def test_initialize_maddpg_with_evo_networks(
         (
             ModuleDict(
                 {
-                    "agent_0": nn.Linear(6, 2),
-                    "agent_1": nn.Linear(6, 2),
-                    "other_agent_0": nn.Linear(6, 2),
+                    "agent": nn.Linear(6, 2),
+                    "other_agent": nn.Linear(6, 2),
                 },
             ),
             ModuleDict(
                 {
-                    "agent_0": nn.Linear(8, 1),
-                    "agent_1": nn.Linear(8, 1),
-                    "other_agent_0": nn.Linear(8, 1),
+                    "agent": nn.Linear(8, 1),
+                    "other_agent": nn.Linear(8, 1),
                 },
             ),
             TypeError,
@@ -1220,17 +1288,18 @@ def test_maddpg_learns_from_experiences(
     assert isinstance(loss, dict)
 
     for agent_id in maddpg.agent_ids:
-        assert loss[agent_id][-1] >= 0.0
+        network_id = get_network_id(maddpg, agent_id)
+        assert loss[network_id][-1] >= 0.0
 
-        updated_actor = maddpg.actors[agent_id]
+        updated_actor = maddpg.actors[network_id]
         assert_not_equal_state_dict(
-            actors_pre_learn_sd[agent_id],
+            actors_pre_learn_sd[network_id],
             updated_actor.state_dict(),
         )
 
-        updated_critic = maddpg.critics[agent_id]
+        updated_critic = maddpg.critics[network_id]
         assert_not_equal_state_dict(
-            critics_pre_learn_sd[agent_id],
+            critics_pre_learn_sd[network_id],
             updated_critic.state_dict(),
         )
     maddpg.clean_up()
@@ -1424,23 +1493,24 @@ def test_maddpg_clone_returns_identical_agent(
     assert clone_agent.accelerator == maddpg.accelerator
 
     for agent_id in clone_agent.agent_ids:
-        actor = maddpg.actors[agent_id]
-        clone_actor = clone_agent.actors[agent_id]
+        network_id = get_network_id(maddpg, agent_id)
+        actor = maddpg.actors[network_id]
+        clone_actor = clone_agent.actors[network_id]
         assert_state_dicts_equal(clone_actor.state_dict(), actor.state_dict())
 
-        critic = maddpg.critics[agent_id]
-        clone_critic = clone_agent.critics[agent_id]
+        critic = maddpg.critics[network_id]
+        clone_critic = clone_agent.critics[network_id]
         assert_state_dicts_equal(clone_critic.state_dict(), critic.state_dict())
 
-        actor_target = maddpg.actor_targets[agent_id]
-        clone_actor_target = clone_agent.actor_targets[agent_id]
+        actor_target = maddpg.actor_targets[network_id]
+        clone_actor_target = clone_agent.actor_targets[network_id]
         assert_state_dicts_equal(
             clone_actor_target.state_dict(),
             actor_target.state_dict(),
         )
 
-        critic_target = maddpg.critic_targets[agent_id]
-        clone_critic_target = clone_agent.critic_targets[agent_id]
+        critic_target = maddpg.critic_targets[network_id]
+        clone_critic_target = clone_agent.critic_targets[network_id]
         assert_state_dicts_equal(
             clone_critic_target.state_dict(),
             critic_target.state_dict(),
@@ -1521,34 +1591,35 @@ def test_clone_after_learning(compile_mode, ma_vector_space):
     assert clone_agent.accelerator == maddpg.accelerator
 
     for agent_id in clone_agent.agent_ids:
-        actor = maddpg.actors[agent_id]
-        clone_actor = clone_agent.actors[agent_id]
+        network_id = get_network_id(maddpg, agent_id)
+        actor = maddpg.actors[network_id]
+        clone_actor = clone_agent.actors[network_id]
         assert_state_dicts_equal(clone_actor.state_dict(), actor.state_dict())
 
-        critic = maddpg.critics[agent_id]
-        clone_critic = clone_agent.critics[agent_id]
+        critic = maddpg.critics[network_id]
+        clone_critic = clone_agent.critics[network_id]
         assert_state_dicts_equal(clone_critic.state_dict(), critic.state_dict())
 
-        clone_actor_target = clone_agent.actor_targets[agent_id]
-        actor_target = maddpg.actor_targets[agent_id]
+        clone_actor_target = clone_agent.actor_targets[network_id]
+        actor_target = maddpg.actor_targets[network_id]
         assert_state_dicts_equal(
             clone_actor_target.state_dict(),
             actor_target.state_dict(),
         )
 
-        clone_critic_target = clone_agent.critic_targets[agent_id]
-        critic_target = maddpg.critic_targets[agent_id]
+        clone_critic_target = clone_agent.critic_targets[network_id]
+        critic_target = maddpg.critic_targets[network_id]
         assert_state_dicts_equal(
             clone_critic_target.state_dict(),
             critic_target.state_dict(),
         )
 
-        clone_actor_opt = clone_agent.actor_optimizers.optimizer[agent_id]
-        actor_opt = maddpg.actor_optimizers.optimizer[agent_id]
+        clone_actor_opt = clone_agent.actor_optimizers.optimizer[network_id]
+        actor_opt = maddpg.actor_optimizers.optimizer[network_id]
         assert str(clone_actor_opt) == str(actor_opt)
 
-        clone_critic_opt = clone_agent.critic_optimizers.optimizer[agent_id]
-        critic_opt = maddpg.critic_optimizers.optimizer[agent_id]
+        clone_critic_opt = clone_agent.critic_optimizers.optimizer[network_id]
+        critic_opt = maddpg.critic_optimizers.optimizer[network_id]
         assert str(clone_critic_opt) == str(critic_opt)
     maddpg.clean_up()
     clone_agent.clean_up()

--- a/tests/test_algorithms/test_multi_agent/test_maddpg.py
+++ b/tests/test_algorithms/test_multi_agent/test_maddpg.py
@@ -923,6 +923,30 @@ def test_maddpg_get_action(
     maddpg.clean_up()
 
 
+def test_maddpg_get_action_with_partial_group_observations(
+    device,
+    ma_vector_space,
+    ma_discrete_space,
+):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    state = {
+        "agent_0": np.random.randn(*ma_vector_space[0].shape),
+        "other_agent_0": np.random.randn(*ma_vector_space[2].shape),
+    }
+
+    maddpg = MADDPG(
+        ma_vector_space,
+        ma_discrete_space,
+        agent_ids=agent_ids,
+        device=device,
+    )
+    processed_action, raw_action = maddpg.get_action(state)
+
+    assert set(processed_action.keys()) == set(state.keys())
+    assert set(raw_action.keys()) == set(state.keys())
+    maddpg.clean_up()
+
+
 @pytest.mark.parametrize("training", [False, True])
 def test_maddpg_get_action_action_masking_exception(
     training,

--- a/tests/test_algorithms/test_multi_agent/test_matd3.py
+++ b/tests/test_algorithms/test_multi_agent/test_matd3.py
@@ -117,6 +117,17 @@ class DummyDeterministicActor(DeterministicActor):
         return DummyNoSync()
 
 
+def get_group_index_map(agent_ids):
+    group_to_index = {}
+    for idx, agent_id in enumerate(agent_ids):
+        group_to_index.setdefault(agent_id.rsplit("_", 1)[0], idx)
+    return group_to_index
+
+
+def get_network_id(agent, agent_id):
+    return agent.get_group_id(agent_id) if agent.has_grouped_agents() else agent_id
+
+
 @pytest.fixture(scope="function")
 def mlp_actor(observation_spaces, action_spaces, request):
     observation_spaces = request.getfixturevalue(observation_spaces)
@@ -316,15 +327,76 @@ def test_initialize_matd3_with_net_config(
         )
 
     expected_optimizer_cls = optim.Adam if accelerator is None else AcceleratedOptimizer
-    for agent_id in matd3.agent_ids:
-        actor_optimizer = matd3.actor_optimizers[agent_id]
-        critic_1_optimizer = matd3.critic_1_optimizers[agent_id]
-        critic_2_optimizer = matd3.critic_2_optimizers[agent_id]
+    for network_id in matd3.observation_space:
+        actor_optimizer = matd3.actor_optimizers[network_id]
+        critic_1_optimizer = matd3.critic_1_optimizers[network_id]
+        critic_2_optimizer = matd3.critic_2_optimizers[network_id]
         assert isinstance(actor_optimizer, expected_optimizer_cls)
         assert isinstance(critic_1_optimizer, expected_optimizer_cls)
         assert isinstance(critic_2_optimizer, expected_optimizer_cls)
 
     assert isinstance(matd3.criterion, nn.MSELoss)
+
+
+def test_matd3_parameter_sharing_group_networks_and_optimizers(ma_vector_space):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    matd3 = MATD3(
+        observation_spaces=ma_vector_space,
+        action_spaces=copy.deepcopy(ma_vector_space),
+        agent_ids=agent_ids,
+        device="cpu",
+    )
+
+    assert set(matd3.actors.keys()) == set(matd3.shared_agent_ids)
+    assert set(matd3.critics_1.keys()) == set(matd3.shared_agent_ids)
+    assert set(matd3.critics_2.keys()) == set(matd3.shared_agent_ids)
+    assert set(matd3.actor_optimizers.optimizer.keys()) == set(matd3.shared_agent_ids)
+    assert set(matd3.critic_1_optimizers.optimizer.keys()) == set(
+        matd3.shared_agent_ids
+    )
+    assert set(matd3.critic_2_optimizers.optimizer.keys()) == set(
+        matd3.shared_agent_ids
+    )
+    assert set(matd3.learn_counter.keys()) == set(matd3.shared_agent_ids)
+
+    obs = {
+        agent_id: np.random.randn(*space.shape).astype(np.float32)
+        for agent_id, space in zip(agent_ids, ma_vector_space, strict=False)
+    }
+    processed_actions, raw_actions = matd3.get_action(obs)
+    assert set(processed_actions.keys()) == set(agent_ids)
+    assert set(raw_actions.keys()) == set(agent_ids)
+    matd3.clean_up()
+
+
+def test_matd3_learn_returns_group_losses_for_parameter_sharing(ma_vector_space):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    batch_size = 8
+    matd3 = MATD3(
+        observation_spaces=ma_vector_space,
+        action_spaces=copy.deepcopy(ma_vector_space),
+        agent_ids=agent_ids,
+        device="cpu",
+    )
+
+    states = {
+        agent_id: torch.randn(batch_size, ma_vector_space[idx].shape[0])
+        for idx, agent_id in enumerate(agent_ids)
+    }
+    actions = {
+        agent_id: torch.randn(batch_size, ma_vector_space[idx].shape[0])
+        for idx, agent_id in enumerate(agent_ids)
+    }
+    rewards = {agent_id: torch.randn(batch_size, 1) for agent_id in agent_ids}
+    next_states = {
+        agent_id: torch.randn(batch_size, ma_vector_space[idx].shape[0])
+        for idx, agent_id in enumerate(agent_ids)
+    }
+    dones = {agent_id: torch.zeros(batch_size, 1) for agent_id in agent_ids}
+
+    loss = matd3.learn((states, actions, rewards, next_states, dones))
+    assert set(loss.keys()) == set(matd3.shared_agent_ids)
+    matd3.clean_up()
 
 
 @pytest.mark.parametrize("observation_spaces", ["ma_vector_space"])
@@ -381,19 +453,20 @@ def test_initialize_matd3_with_mlp_networks(
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
     observation_spaces = request.getfixturevalue(observation_spaces)
     action_spaces = request.getfixturevalue(action_spaces)
+    group_to_index = get_group_index_map(agent_ids)
     evo_actors = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=mlp_actor,
                 input_tensor=torch.randn(1, observation_spaces[0].shape[0]),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics_1 = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=mlp_critic,
                 input_tensor=torch.randn(
                     1,
@@ -401,12 +474,12 @@ def test_initialize_matd3_with_mlp_networks(
                 ),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics_2 = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=mlp_critic,
                 input_tensor=torch.randn(
                     1,
@@ -414,7 +487,7 @@ def test_initialize_matd3_with_mlp_networks(
                 ),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics = [evo_critics_1, evo_critics_2]
@@ -454,10 +527,10 @@ def test_initialize_matd3_with_mlp_networks(
     assert matd3.steps == [0]
 
     expected_optimizer_cls = optim.Adam if accelerator is None else AcceleratedOptimizer
-    for agent_id in matd3.agent_ids:
-        actor_optimizer = matd3.actor_optimizers[agent_id]
-        critic_1_optimizer = matd3.critic_1_optimizers[agent_id]
-        critic_2_optimizer = matd3.critic_2_optimizers[agent_id]
+    for network_id in matd3.observation_space:
+        actor_optimizer = matd3.actor_optimizers[network_id]
+        critic_1_optimizer = matd3.critic_1_optimizers[network_id]
+        critic_2_optimizer = matd3.critic_2_optimizers[network_id]
         assert isinstance(actor_optimizer, expected_optimizer_cls)
         assert isinstance(critic_1_optimizer, expected_optimizer_cls)
         assert isinstance(critic_2_optimizer, expected_optimizer_cls)
@@ -479,36 +552,37 @@ def test_initialize_matd3_with_cnn_networks(
 ):
     accelerator = Accelerator() if accelerator_flag else None
     agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    group_to_index = get_group_index_map(agent_ids)
     evo_actors = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=cnn_actor,
                 input_tensor=torch.randn(1, 3, 1, 32, 32),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics_1 = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=cnn_critic,
                 input_tensor=torch.randn(1, 3, 3, 32, 32),
                 secondary_input_tensor=torch.randn(1, 2),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics_2 = ModuleDict(
         {
-            agent_id: MakeEvolvable(
+            group_id: MakeEvolvable(
                 network=cnn_critic,
                 input_tensor=torch.randn(1, 3, 3, 32, 32),
                 secondary_input_tensor=torch.randn(1, 2),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics = [evo_critics_1, evo_critics_2]
@@ -547,10 +621,10 @@ def test_initialize_matd3_with_cnn_networks(
     assert matd3.steps == [0]
 
     expected_optimizer_cls = optim.Adam if accelerator is None else AcceleratedOptimizer
-    for agent_id in matd3.agent_ids:
-        actor_optimizer = matd3.actor_optimizers[agent_id]
-        critic_1_optimizer = matd3.critic_1_optimizers[agent_id]
-        critic_2_optimizer = matd3.critic_2_optimizers[agent_id]
+    for network_id in matd3.observation_space:
+        actor_optimizer = matd3.actor_optimizers[network_id]
+        critic_1_optimizer = matd3.critic_1_optimizers[network_id]
+        critic_2_optimizer = matd3.critic_2_optimizers[network_id]
         assert isinstance(actor_optimizer, expected_optimizer_cls)
         assert isinstance(critic_1_optimizer, expected_optimizer_cls)
         assert isinstance(critic_2_optimizer, expected_optimizer_cls)
@@ -582,35 +656,36 @@ def test_initialize_matd3_with_evo_networks(
     observation_space = spaces.Dict(
         {agent_id: observation_spaces[idx] for idx, agent_id in enumerate(agent_ids)},
     )
+    group_to_index = get_group_index_map(agent_ids)
 
     evo_actors = ModuleDict(
         {
-            agent_id: DeterministicActor(
+            group_id: DeterministicActor(
                 observation_spaces[idx],
                 ma_discrete_space[idx],
                 device=device,
             )
-            for idx, agent_id in enumerate(agent_ids)
+            for group_id, idx in group_to_index.items()
         },
     )
     evo_critics_1 = ModuleDict(
         {
-            agent_id: ContinuousQNetwork(
+            group_id: ContinuousQNetwork(
                 observation_space=observation_space,
                 action_space=concatenate_spaces(ma_discrete_space),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics_2 = ModuleDict(
         {
-            agent_id: ContinuousQNetwork(
+            group_id: ContinuousQNetwork(
                 observation_space=observation_space,
                 action_space=concatenate_spaces(ma_discrete_space),
                 device=device,
             )
-            for agent_id in agent_ids
+            for group_id in group_to_index
         },
     )
     evo_critics = [evo_critics_1, evo_critics_2]
@@ -656,10 +731,10 @@ def test_initialize_matd3_with_evo_networks(
     assert matd3.steps == [0]
 
     expected_optimizer_cls = optim.Adam if accelerator is None else AcceleratedOptimizer
-    for agent_id in matd3.agent_ids:
-        actor_optimizer = matd3.actor_optimizers[agent_id]
-        critic_1_optimizer = matd3.critic_1_optimizers[agent_id]
-        critic_2_optimizer = matd3.critic_2_optimizers[agent_id]
+    for network_id in matd3.observation_space:
+        actor_optimizer = matd3.actor_optimizers[network_id]
+        critic_1_optimizer = matd3.critic_1_optimizers[network_id]
+        critic_2_optimizer = matd3.critic_2_optimizers[network_id]
         assert isinstance(actor_optimizer, expected_optimizer_cls)
         assert isinstance(critic_1_optimizer, expected_optimizer_cls)
         assert isinstance(critic_2_optimizer, expected_optimizer_cls)
@@ -679,24 +754,21 @@ def test_initialize_matd3_with_evo_networks(
         (
             ModuleDict(
                 {
-                    "agent_0": nn.Linear(6, 2),
-                    "agent_1": nn.Linear(6, 2),
-                    "other_agent_0": nn.Linear(6, 2),
+                    "agent": nn.Linear(6, 2),
+                    "other_agent": nn.Linear(6, 2),
                 },
             ),
             [
                 ModuleDict(
                     {
-                        "agent_0": nn.Linear(8, 1),
-                        "agent_1": nn.Linear(8, 1),
-                        "other_agent_0": nn.Linear(8, 1),
+                        "agent": nn.Linear(8, 1),
+                        "other_agent": nn.Linear(8, 1),
                     },
                 ),
                 ModuleDict(
                     {
-                        "agent_0": nn.Linear(8, 1),
-                        "agent_1": nn.Linear(8, 1),
-                        "other_agent_0": nn.Linear(8, 1),
+                        "agent": nn.Linear(8, 1),
+                        "other_agent": nn.Linear(8, 1),
                     },
                 ),
             ],
@@ -1226,7 +1298,8 @@ def test_matd3_learns_from_experiences(
     assert isinstance(loss, dict)
 
     for agent_id in matd3.agent_ids:
-        assert loss[agent_id][-1] >= 0.0
+        network_id = get_network_id(matd3, agent_id)
+        assert loss[network_id][-1] >= 0.0
 
     for agent_id, old_actor_target in matd3.actor_targets.items():
         updated_actor_target = matd3.actor_targets[agent_id]
@@ -1295,13 +1368,13 @@ def test_matd3_learns_from_experiences_distributed(
         torch_compiler=compile_mode,
     )
 
-    for agent_id in matd3.agent_ids:
-        actor = matd3.actors[agent_id]
-        critic_1 = matd3.critics_1[agent_id]
-        critic_2 = matd3.critics_2[agent_id]
-        actor_target = matd3.actor_targets[agent_id]
-        critic_target_1 = matd3.critic_targets_1[agent_id]
-        critic_target_2 = matd3.critic_targets_2[agent_id]
+    for network_id in matd3.observation_space:
+        actor = matd3.actors[network_id]
+        critic_1 = matd3.critics_1[network_id]
+        critic_2 = matd3.critics_2[network_id]
+        actor_target = matd3.actor_targets[network_id]
+        critic_target_1 = matd3.critic_targets_1[network_id]
+        critic_target_2 = matd3.critic_targets_2[network_id]
         actor.no_sync = no_sync.__get__(actor)
         critic_1.no_sync = no_sync.__get__(critic_1)
         critic_2.no_sync = no_sync.__get__(critic_2)
@@ -1328,7 +1401,8 @@ def test_matd3_learns_from_experiences_distributed(
 
     assert isinstance(loss, dict)
     for agent_id in matd3.agent_ids:
-        assert loss[agent_id][-1] >= 0.0
+        network_id = get_network_id(matd3, agent_id)
+        assert loss[network_id][-1] >= 0.0
 
     for agent_id, old_actor_sd in actors_pre_learn_sd.items():
         updated_actor = matd3.actors[agent_id]
@@ -1368,13 +1442,13 @@ def test_matd3_soft_update(device, compile_mode, ma_vector_space, ma_discrete_sp
         torch_compiler=compile_mode,
     )
 
-    for agent_id in matd3.agent_ids:
-        actor = matd3.actors[agent_id]
-        actor_target = matd3.actor_targets[agent_id]
-        critic_1 = matd3.critics_1[agent_id]
-        critic_target_1 = matd3.critic_targets_1[agent_id]
-        critic_2 = matd3.critics_2[agent_id]
-        critic_target_2 = matd3.critic_targets_2[agent_id]
+    for network_id in matd3.observation_space:
+        actor = matd3.actors[network_id]
+        actor_target = matd3.actor_targets[network_id]
+        critic_1 = matd3.critics_1[network_id]
+        critic_target_1 = matd3.critic_targets_1[network_id]
+        critic_2 = matd3.critics_2[network_id]
+        critic_target_2 = matd3.critic_targets_2[network_id]
 
         # Check actors
         matd3.soft_update(actor, actor_target)
@@ -1553,36 +1627,37 @@ def test_matd3_clone_returns_identical_agent(
     assert clone_agent.torch_compiler == matd3.torch_compiler
 
     for agent_id in clone_agent.agent_ids:
+        network_id = get_network_id(matd3, agent_id)
         assert torch.equal(clone_agent.expl_noise[agent_id], matd3.expl_noise[agent_id])
 
-        clone_actor = clone_agent.actors[agent_id]
-        actor = matd3.actors[agent_id]
+        clone_actor = clone_agent.actors[network_id]
+        actor = matd3.actors[network_id]
         assert_state_dicts_equal(clone_actor.state_dict(), actor.state_dict())
 
-        clone_actor_target = clone_agent.actor_targets[agent_id]
-        actor_target = matd3.actor_targets[agent_id]
+        clone_actor_target = clone_agent.actor_targets[network_id]
+        actor_target = matd3.actor_targets[network_id]
         assert_state_dicts_equal(
             clone_actor_target.state_dict(),
             actor_target.state_dict(),
         )
 
-        clone_critic_1 = clone_agent.critics_1[agent_id]
-        critic_1 = matd3.critics_1[agent_id]
+        clone_critic_1 = clone_agent.critics_1[network_id]
+        critic_1 = matd3.critics_1[network_id]
         assert_state_dicts_equal(clone_critic_1.state_dict(), critic_1.state_dict())
 
-        clone_critic_target_1 = clone_agent.critic_targets_1[agent_id]
-        critic_target_1 = matd3.critic_targets_1[agent_id]
+        clone_critic_target_1 = clone_agent.critic_targets_1[network_id]
+        critic_target_1 = matd3.critic_targets_1[network_id]
         assert_state_dicts_equal(
             clone_critic_target_1.state_dict(),
             critic_target_1.state_dict(),
         )
 
-        clone_critic_2 = clone_agent.critics_2[agent_id]
-        critic_2 = matd3.critics_2[agent_id]
+        clone_critic_2 = clone_agent.critics_2[network_id]
+        critic_2 = matd3.critics_2[network_id]
         assert_state_dicts_equal(clone_critic_2.state_dict(), critic_2.state_dict())
 
-        clone_critic_target_2 = clone_agent.critic_targets_2[agent_id]
-        critic_target_2 = matd3.critic_targets_2[agent_id]
+        clone_critic_target_2 = clone_agent.critic_targets_2[network_id]
+        critic_target_2 = matd3.critic_targets_2[network_id]
         assert_state_dicts_equal(
             clone_critic_target_2.state_dict(),
             critic_target_2.state_dict(),
@@ -1653,36 +1728,37 @@ def test_clone_after_learning(compile_mode, ma_vector_space):
     assert matd3.torch_compiler == compile_mode
 
     for agent_id in clone_agent.agent_ids:
+        network_id = get_network_id(matd3, agent_id)
         assert torch.equal(clone_agent.expl_noise[agent_id], matd3.expl_noise[agent_id])
 
-        clone_actor = clone_agent.actors[agent_id]
-        actor = matd3.actors[agent_id]
+        clone_actor = clone_agent.actors[network_id]
+        actor = matd3.actors[network_id]
         assert_state_dicts_equal(clone_actor.state_dict(), actor.state_dict())
 
-        clone_actor_target = clone_agent.actor_targets[agent_id]
-        actor_target = matd3.actor_targets[agent_id]
+        clone_actor_target = clone_agent.actor_targets[network_id]
+        actor_target = matd3.actor_targets[network_id]
         assert_state_dicts_equal(
             clone_actor_target.state_dict(),
             actor_target.state_dict(),
         )
 
-        clone_critic_1 = clone_agent.critics_1[agent_id]
-        critic_1 = matd3.critics_1[agent_id]
+        clone_critic_1 = clone_agent.critics_1[network_id]
+        critic_1 = matd3.critics_1[network_id]
         assert_state_dicts_equal(clone_critic_1.state_dict(), critic_1.state_dict())
 
-        clone_critic_target_1 = clone_agent.critic_targets_1[agent_id]
-        critic_target_1 = matd3.critic_targets_1[agent_id]
+        clone_critic_target_1 = clone_agent.critic_targets_1[network_id]
+        critic_target_1 = matd3.critic_targets_1[network_id]
         assert_state_dicts_equal(
             clone_critic_target_1.state_dict(),
             critic_target_1.state_dict(),
         )
 
-        clone_critic_2 = clone_agent.critics_2[agent_id]
-        critic_2 = matd3.critics_2[agent_id]
+        clone_critic_2 = clone_agent.critics_2[network_id]
+        critic_2 = matd3.critics_2[network_id]
         assert_state_dicts_equal(clone_critic_2.state_dict(), critic_2.state_dict())
 
-        clone_critic_target_2 = clone_agent.critic_targets_2[agent_id]
-        critic_target_2 = matd3.critic_targets_2[agent_id]
+        clone_critic_target_2 = clone_agent.critic_targets_2[network_id]
+        critic_target_2 = matd3.critic_targets_2[network_id]
         assert_state_dicts_equal(
             clone_critic_target_2.state_dict(),
             critic_target_2.state_dict(),

--- a/tests/test_algorithms/test_multi_agent/test_matd3.py
+++ b/tests/test_algorithms/test_multi_agent/test_matd3.py
@@ -944,6 +944,30 @@ def test_matd3_get_action(
     matd3.clean_up()
 
 
+def test_matd3_get_action_with_partial_group_observations(
+    device,
+    ma_vector_space,
+    ma_discrete_space,
+):
+    agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+    state = {
+        "agent_0": np.random.randn(*ma_vector_space[0].shape),
+        "other_agent_0": np.random.randn(*ma_vector_space[2].shape),
+    }
+
+    matd3 = MATD3(
+        ma_vector_space,
+        ma_discrete_space,
+        agent_ids=agent_ids,
+        device=device,
+    )
+    processed_action, raw_action = matd3.get_action(state)
+
+    assert set(processed_action.keys()) == set(state.keys())
+    assert set(raw_action.keys()) == set(state.keys())
+    matd3.clean_up()
+
+
 @pytest.mark.parametrize("observation_spaces", ["ma_vector_space", "ma_image_space"])
 @pytest.mark.parametrize("action_spaces", ["ma_discrete_space", "ma_vector_space"])
 @pytest.mark.parametrize("training", [0, 1])

--- a/tests/test_hpo/test_mutation.py
+++ b/tests/test_hpo/test_mutation.py
@@ -1693,7 +1693,8 @@ def test_mutation_applies_architecture_mutations_multi_agent(
         for network in individual.evolvable_attributes(networks_only=True).values():
             network.rng = EvoDummyRNG()
 
-    test_agent = "agent_0" if algo != "IPPO" else "agent"
+    sample_agent_id = population[0].agent_ids[0]
+    test_agent = population[0].get_network_id(sample_agent_id)
     mut_methods = population[0].actors[test_agent].mutation_methods
     applied_mutations = set()
     for mut_method in mut_methods:
@@ -1815,7 +1816,8 @@ def test_mutation_applies_bert_architecture_mutations_multi_agent(
         accelerator=accelerator,
     )
 
-    test_agent = "agent_0"
+    sample_agent_id = population[0].agent_ids[0]
+    test_agent = population[0].get_network_id(sample_agent_id)
     mut_methods = population[0].actors[test_agent].mutation_methods
     for mut_method in mut_methods:
 


### PR DESCRIPTION
Adds IPPO-style parameter sharing to MADDPG and MATD3, enabling group-based shared networks and optimizers for homogeneous agents.

Key changes:

Constructor: initialize actor/critic/target/optimizer by group, not only per individual agent.
Action selection: update get_action to run grouped forward passes, then split outputs back to each agent.
Learning path: route networks/optimizers by group in learn; return losses keyed by group in parameter-sharing mode.
Tests: add/adjust MADDPG and MATD3 tests for parameter sharing, including custom network key validation updates.