### PR TITLE
Mark test_applies_rl_hp_mutation_llm_algorithm as @pytest.mark.gpu

### DIFF
--- a/tests/test_hpo/test_mutation.py
+++ b/tests/test_hpo/test_mutation.py
@@ -1311,6 +1311,7 @@ class TestMutationsMutation:
 
             assert mutation_found, f"Mutation not applied for agent index {old.index}"
 
+    @pytest.mark.gpu
     @pytest.mark.skipif(
         not HAS_LLM_DEPENDENCIES, reason="LLM dependencies not installed"
     )


### PR DESCRIPTION
## Summary

One-line fix: \`test_applies_rl_hp_mutation_llm_algorithm\` in \`tests/test_hpo/test_mutation.py\` was missing \`@pytest.mark.gpu\`. Every sibling test in \`TestMutationsMutation\` already has the marker — this one was an oversight.

## Why it matters

Without the marker, the test doesn't get routed into the \`gputest0..3\` xdist pool that caps GPU-touching tests at 4 concurrent workers (see \`tests/conftest.py::pytest_collection_modifyitems\` docstring). Its \`deepspeed_env → get_free_port → init_process_group\` sequence then races with whatever pool-resident test happens to be init'ing \`torch.distributed\` at the same moment, producing flakes like:

\`\`\`
FAILED tests/test_hpo/test_mutation.py::TestMutationsMutation::test_applies_rl_hp_mutation_llm_algorithm[lr-DPO-True-False]
  - torch.distributed.DistNetworkError: ... EADDRINUSE, port: 46833 ... address already in use
\`\`\`

(observed on Linux 3.10 in [#509](https://github.com/AgileRL/AgileRL/pull/509); 3.11/3.12/3.13 happened to pass that run).

## Test plan

- [ ] Linux 3.10 CI passes consistently