### PR TITLE
Three small fixes for v2.7.0 nightly→main CI

### DIFF
--- a/demos/llm/debugging/debugging_llm.py
+++ b/demos/llm/debugging/debugging_llm.py
@@ -132,8 +132,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
             max_output_tokens=max_new,
         )
 
-    eval_fn = lambda a: evaluate_hit_rate(a, tokenizer, target_token, eval_eps, True)
-
     original_save = train_llm.save_llm_checkpoint
     train_llm.save_llm_checkpoint = lambda *args, **kwargs: None
     try:
@@ -142,7 +140,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
             max_turns=1,
             init_hp=init_hp,
             max_steps=int(dbg["max_sample_steps"]),
-            eval_fn=eval_fn,
             evaluation_interval=int(dbg["evaluation_interval"]),
             wb=False,
             save_elite=False,

--- a/demos/llm/debugging/debugging_llm_stage_1.py
+++ b/demos/llm/debugging/debugging_llm_stage_1.py
@@ -181,8 +181,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
             max_output_tokens=max_new,
         )
 
-    eval_fn = lambda a: evaluate_accuracy(a, tokenizer, eval_eps, greedy=True)[0]
-
     original_save = train_llm.save_llm_checkpoint
     train_llm.save_llm_checkpoint = lambda *args, **kwargs: None
     try:
@@ -191,7 +189,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
             max_turns=1,
             init_hp=init_hp,
             max_steps=int(dbg["max_sample_steps"]),
-            eval_fn=eval_fn,
             evaluation_interval=int(dbg["evaluation_interval"]),
             wb=False,
             save_elite=False,

--- a/demos/llm/debugging/debugging_llm_stage_2.py
+++ b/demos/llm/debugging/debugging_llm_stage_2.py
@@ -214,8 +214,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
             max_output_tokens=max_new,
         )
 
-    eval_fn = lambda a: evaluate_accuracy(a, tokenizer, eval_eps, greedy=True)[0]
-
     original_save = train_llm.save_llm_checkpoint
     train_llm.save_llm_checkpoint = lambda *args, **kwargs: None
     try:
@@ -224,7 +222,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
             max_turns=1,
             init_hp=init_hp,
             max_steps=int(dbg["max_sample_steps"]),
-            eval_fn=eval_fn,
             evaluation_interval=int(dbg["evaluation_interval"]),
             wb=False,
             save_elite=False,

--- a/demos/llm/debugging/debugging_llm_stage_3.py
+++ b/demos/llm/debugging/debugging_llm_stage_3.py
@@ -325,10 +325,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
                 max_output_tokens=max_new,
             )
 
-        eval_fn = lambda a: evaluate_accuracy(
-            a, tokenizer, grid_size, max_turns, eval_eps, greedy=True
-        )
-
         original_save = train_llm.save_llm_checkpoint
         train_llm.save_llm_checkpoint = lambda *args, **kwargs: None
         try:
@@ -337,7 +333,6 @@ def run_single_seed(cfg: dict, seed: int) -> tuple[float, float]:
                 max_turns=max_turns,
                 init_hp=init_hp,
                 max_steps=int(dbg["max_sample_steps"]),
-                eval_fn=eval_fn,
                 evaluation_interval=int(dbg["evaluation_interval"]),
                 wb=False,
                 save_elite=False,

--- a/demos/llm/debugging/debugging_llm_training_matrix.py
+++ b/demos/llm/debugging/debugging_llm_training_matrix.py
@@ -490,7 +490,6 @@ def run_multiturn_case(
         save_elite=False,
         verbose=False,
         evaluation_interval=args.evaluation_interval,
-        eval_fn=None,
         evo_steps=evo_steps,
         tournament=tournament,
         mutation=mutation,

--- a/tests/test_hpo/test_mutation.py
+++ b/tests/test_hpo/test_mutation.py
@@ -1311,6 +1311,7 @@ class TestMutationsMutation:
 
             assert mutation_found, f"Mutation not applied for agent index {old.index}"
 
+    @pytest.mark.gpu
     @pytest.mark.skipif(
         not HAS_LLM_DEPENDENCIES, reason="LLM dependencies not installed"
     )

--- a/tests/test_train/test_train.py
+++ b/tests/test_train/test_train.py
@@ -5415,6 +5415,13 @@ class TestTrainBandits:
         )
         assert os.path.isfile(elite_path)
 
+    # Same xdist_group as ``test_remove_saved_models`` below — the
+    # accelerator branch of ``train_bandits`` writes into ``models/<env_name>/``,
+    # which ``test_remove_saved_models`` then rmtrees. On macOS the rmtree can
+    # land between this test's mkdir and save_checkpoint, producing
+    # ``Parent directory models/<env_name> does not exist``. Pinning both to
+    # the same xdist worker forces serial execution.
+    @pytest.mark.xdist_group("models_dir")
     @pytest.mark.parametrize(
         "state_size, action_size, accelerator_flag",
         [((6,), 2, True), ((6,), 2, False)],
@@ -5457,11 +5464,16 @@ class TestTrainBandits:
                 assert os.path.isfile(f"{checkpoint_path}_{i}_{10 * (s + 1)}.pt")
 
 
+@pytest.mark.xdist_group("models_dir")
 def test_remove_saved_models():
-    # Under xdist a sibling worker may still be writing into ``models/`` (e.g.
-    # checkpoint-saving training tests on another worker) while this teardown
-    # runs, racing ``rmtree`` to ``OSError: Directory not empty``. The test is
-    # purely a cleanup hook, so swallow the race and retry once.
+    # Pinned to the ``models_dir`` xdist_group alongside
+    # ``test_bandit_train_save_checkpoint`` so the two never run on different
+    # workers — the bandit test's checkpoint writes used to race this rmtree
+    # on macOS (``Parent directory models/<env_name> does not exist``).
+    #
+    # The retry below remains for the inverse race against any *other*
+    # sibling worker's writes into ``models/`` (rmtree losing to a concurrent
+    # write), which the xdist_group can't cover.
     if not os.path.exists("models"):
         return
     for _ in range(3):


### PR DESCRIPTION
Three small fixes surfaced by #509 CI:

## 1. \`eval_fn\` kwarg dead at debug-demo call sites

[#513](https://github.com/AgileRL/AgileRL/pull/513) removed the \`eval_fn\` callback parameter from \`finetune_llm_multiturn\` — the function now calls \`agent.test(test_env)\` internally on a fresh env from \`env_factory\` every \`evaluation_interval\`. Five debug demos under \`demos/llm/debugging/\` still passed \`eval_fn=\` and would \`TypeError\` at runtime. CodeQL flagged this on #509.

Changes:
- \`debugging_llm.py\`, \`debugging_llm_stage_1.py\`, \`debugging_llm_stage_2.py\`, \`debugging_llm_stage_3.py\` — remove the now-unused \`eval_fn = lambda ...\` definition and the \`eval_fn=eval_fn\` kwarg.
- \`debugging_llm_training_matrix.py\` — remove the \`eval_fn=None\` kwarg.

What this drops: the mid-training callback that printed custom per-demo eval scores. Pre/post-train evaluation via \`evaluate_hit_rate\` / \`evaluate_accuracy\` is unchanged. If we want the mid-train callback back, either restore \`eval_fn\` upstream or wire each demo's eval through \`agent.test\`.

## 2. \`test_applies_rl_hp_mutation_llm_algorithm\` missing \`@pytest.mark.gpu\`

The only test in \`TestMutationsMutation\` without the marker — every sibling has it. Without it, the test doesn't get routed into the \`gputest0..3\` xdist pool that caps GPU-touching tests at 4 concurrent workers (see \`tests/conftest.py::pytest_collection_modifyitems\` docstring). Its \`deepspeed_env → get_free_port → init_process_group\` sequence then races with a pool-resident test on the same free-port TOCTOU window, producing:

\`\`\`
FAILED tests/test_hpo/test_mutation.py::TestMutationsMutation::test_applies_rl_hp_mutation_llm_algorithm[lr-DPO-True-False]
  - torch.distributed.DistNetworkError: ... EADDRINUSE, port: 46833 ... address already in use
\`\`\`

Observed on Linux 3.10 in #509.

## 3. Bandit checkpoint test races \`test_remove_saved_models\` on macOS

\`test_bandit_train_save_checkpoint[state_size0-2-True]\` runs the accelerator branch of \`train_bandits\`, which writes into \`models/<env_name>/\` via \`tournament_selection_and_mutation\` (\`agilerl/utils/utils.py:1187\`). The sibling \`test_remove_saved_models\` \`rmtree\`s \`models/\`. Under xdist they can land on different workers, and on macOS the rmtree wins the race between the bandit test's \`mkdir\` and \`save_checkpoint\`, producing:

\`\`\`
FAILED tests/test_train/test_train.py::TestTrainBandits::test_bandit_train_save_checkpoint[state_size0-2-True]
  - RuntimeError: Parent directory models/bandit_env_name does not exist.
\`\`\`

Pinning both tests to a shared \`models_dir\` xdist_group forces them onto the same worker, serialising them. The rmtree's existing retry loop stays to cover the inverse race against any *other* worker's concurrent writes into \`models/\`, which the group can't cover.

Observed on macOS 3.12 in #509.

## Test plan

- [ ] CodeQL clean on #509 once this lands in nightly.
- [ ] Linux 3.10 \`tests\` job on #509 passes consistently after this lands (covers fix #2).
- [ ] macOS 3.12 \`tests\` job on #509 passes consistently after this lands (covers fix #3).