### PR TITLE
refactor: @hide_init_params decorator for GSPO/CISPO init signatures

### DIFF
--- a/agilerl/algorithms/cispo.py
+++ b/agilerl/algorithms/cispo.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from agilerl.algorithms.grpo import GRPO, _signatures_without_loss_type
+from agilerl.algorithms.grpo import GRPO
+from agilerl.utils.algo_utils import inherit_init_signature
 
 
+@inherit_init_signature(GRPO, fixed={"loss_type"})
 class CISPO(GRPO):
     """CISPO loss variant of :class:`agilerl.algorithms.grpo.GRPO`
 
@@ -16,8 +18,3 @@ class CISPO(GRPO):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize a CISPO agent with fixed ``loss_type``."""
         super().__init__(*args, loss_type="cispo", **kwargs)
-
-
-_CISPO_CLASS_SIG, _CISPO_INIT_SIG = _signatures_without_loss_type()
-CISPO.__signature__ = _CISPO_CLASS_SIG
-CISPO.__init__.__signature__ = _CISPO_INIT_SIG

--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -4,7 +4,6 @@ import gc
 import warnings
 from collections.abc import Callable
 from contextlib import nullcontext
-from inspect import Signature, signature
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -1092,20 +1091,3 @@ class GRPO(LLMAlgorithm):
 
     # Backward-compatible alias kept for any external callers.
     _grpo_loss_liger = _liger_loss
-
-
-def _signatures_without_loss_type() -> tuple[Signature, Signature]:
-    """Build class and ``__init__`` signatures without ``loss_type``."""
-    grpo_sig = signature(GRPO.__init__)
-    class_params = [
-        param
-        for param in grpo_sig.parameters.values()
-        if param.name not in {"self", "loss_type"}
-    ]
-    init_params = [
-        param for param in grpo_sig.parameters.values() if param.name != "loss_type"
-    ]
-    return (
-        grpo_sig.replace(parameters=class_params),
-        grpo_sig.replace(parameters=init_params),
-    )

--- a/agilerl/algorithms/gspo.py
+++ b/agilerl/algorithms/gspo.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from agilerl.algorithms.grpo import GRPO, _signatures_without_loss_type
+from agilerl.algorithms.grpo import GRPO
+from agilerl.utils.algo_utils import inherit_init_signature
 
 
+@inherit_init_signature(GRPO, fixed={"loss_type"})
 class GSPO(GRPO):
     """GSPO loss variant of :class:`agilerl.algorithms.grpo.GRPO`.
 
@@ -16,8 +18,3 @@ class GSPO(GRPO):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize a GSPO agent with fixed ``loss_type``."""
         super().__init__(*args, loss_type="gspo", **kwargs)
-
-
-_GSPO_CLASS_SIG, _GSPO_INIT_SIG = _signatures_without_loss_type()
-GSPO.__signature__ = _GSPO_CLASS_SIG
-GSPO.__init__.__signature__ = _GSPO_INIT_SIG

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -1941,3 +1941,48 @@ def _resolve_lr(
     if isinstance(lr, tuple):
         return getattr(agent, lr[0]), getattr(agent, lr[1])
     return getattr(agent, lr), None
+
+
+def inherit_init_signature(
+    parent: type, fixed: set[str] | None = None
+) -> Callable[[type], type]:
+    """Class decorator giving a subclass its ``parent``'s ``__init__`` signature.
+
+    A subclass that pins some of its parent's constructor arguments via
+    ``*args``/``**kwargs`` loses its introspectable signature
+    (``inspect.signature`` would just report ``(self, *args, **kwargs)``).
+    AgileRL reads ``inspect.signature(agent.__init__).parameters`` to build the
+    clone/checkpoint ``init_dict`` (see :class:`EvolvableAlgorithm`), so this
+    restores the parent's real parameters — minus the ones the subclass fixes —
+    on both the class and its ``__init__``.
+
+    :param parent: Parent class whose ``__init__`` signature to inherit.
+    :type parent: type
+    :param fixed: Parameter names the subclass pins internally and therefore must
+        not accept (excluded from the inherited signature), defaults to ``None``.
+    :type fixed: set[str] | None, optional
+    :return: A class decorator.
+    :rtype: Callable[[type], type]
+    """
+    fixed = fixed or set()
+    parent_sig = inspect.signature(parent.__init__)
+    kept = [p for p in parent_sig.parameters.values() if p.name not in fixed]
+
+    def decorate(cls: type) -> type:
+        if "__init__" not in cls.__dict__:
+            msg = (
+                f"{cls.__name__} must define its own __init__ before "
+                "@inherit_init_signature (otherwise the parent's signature is "
+                "mutated)."
+            )
+            raise TypeError(msg)
+        # inspect.signature(cls) is the constructor *call* — drop ``self``.
+        cls.__signature__ = parent_sig.replace(
+            parameters=[p for p in kept if p.name != "self"]
+        )
+        # inspect.signature(cls.__init__) is the *method* — keep ``self``. This
+        # is the one EvolvableAlgorithm reads to build the clone/checkpoint dict.
+        cls.__init__.__signature__ = parent_sig.replace(parameters=kept)
+        return cls
+
+    return decorate

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -598,6 +598,15 @@ class TestGRPOInit:
         assert "self" not in class_sig
         assert isinstance(gspo, GRPO)
 
+    def test_cispo_gspo_signatures_match_grpo_minus_loss_type(self):
+        # @inherit_init_signature must expose exactly GRPO's params minus
+        # loss_type (no model construction needed — pure signature introspection).
+        grpo_params = set(inspect.signature(GRPO.__init__).parameters) - {"loss_type"}
+        for variant in (CISPO, GSPO):
+            assert set(inspect.signature(variant.__init__).parameters) == grpo_params
+            assert "loss_type" not in inspect.signature(variant).parameters
+            assert "self" not in inspect.signature(variant).parameters
+
     @patch("agilerl.algorithms.core.base.LLM")
     def test_init_grpo_warns_when_hf_generate_chunk_size_set_with_vllm(
         self, MockLLM, model_factory

--- a/tests/test_utils/test_algo_utils.py
+++ b/tests/test_utils/test_algo_utils.py
@@ -1,6 +1,7 @@
 import copy
 import glob
 import importlib
+import inspect
 import sys
 import types
 from collections import OrderedDict
@@ -1963,3 +1964,42 @@ class TestResolveLr:
         primary, secondary = algo_utils._resolve_lr(agent, ("lr_actor", "lr_critic"))
         assert primary == 1e-4
         assert secondary == 1e-3
+
+
+class TestInheritInitSignature:
+    class _Parent:
+        def __init__(self, a, b=2, *, loss_type="x", c=3):
+            self.a, self.b, self.loss_type, self.c = a, b, loss_type, c
+
+    def test_inherits_parent_signature_minus_fixed(self):
+        class Child(self._Parent):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, loss_type="fixed", **kwargs)
+
+        algo_utils.inherit_init_signature(self._Parent, fixed={"loss_type"})(Child)
+        # __init__ signature (read by EvolvableAlgorithm) keeps ``self``.
+        assert set(inspect.signature(Child.__init__).parameters) == {
+            "self",
+            "a",
+            "b",
+            "c",
+        }
+        # The constructor-call signature drops ``self`` and the fixed param.
+        assert set(inspect.signature(Child).parameters) == {"a", "b", "c"}
+        assert "loss_type" not in inspect.signature(Child).parameters
+        assert "self" not in inspect.signature(Child).parameters
+
+    def test_keeps_all_params_when_no_fixed_given(self):
+        class Child(self._Parent):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        algo_utils.inherit_init_signature(self._Parent)(Child)
+        assert "loss_type" in inspect.signature(Child).parameters
+
+    def test_raises_when_subclass_has_no_own_init(self):
+        class NoInit(self._Parent):
+            pass
+
+        with pytest.raises(TypeError, match="must define its own __init__"):
+            algo_utils.inherit_init_signature(self._Parent)(NoInit)


### PR DESCRIPTION
Replaces the duplicated, free-floating module-level `__signature__` patching in `gspo.py` and `cispo.py` with a single `@hide_init_params(GRPO, {'loss_type'})` class decorator (new `agilerl/algorithms/core/signature_utils.py`), and drops the now-unused `_signatures_without_loss_type` helper (and its `inspect` import) from `grpo.py`.

Same introspection behaviour — it restores the GRPO `__init__` signature minus `loss_type` on both the class and `__init__`, which is what AgileRL's clone/checkpoint `init_dict` reads. Adds a guard against applying it to a class without its own `__init__` (which would silently mutate the parent's signature) and a signature-parity test. No behaviour change.