### PR TITLE
Auto-config Phase 0: vLLM engine knob hygiene

### DIFF
--- a/.research-reports/agilerl-knobs.md
+++ b/.research-reports/agilerl-knobs.md
@@ -1,0 +1,297 @@
+# AgileRL LLM RL Stack — Exhaustive Config-Knob Inventory (memory & throughput)
+
+Repo audited: `/Users/michaeldoherty/git/AgileRL/.claude/worktrees/auto-config-llm-batch` (main, HEAD `6da75e08`).
+Branch comparison: `deepspeed-fsdp` in `/Users/michaeldoherty/git/AgileRL` (see §13).
+
+All `file:line` references are relative to the worktree root unless prefixed with `[deepspeed-fsdp]`.
+
+Legend for the "Set by" column: **U** = user-settable constructor/config arg; **H** = hardcoded; **D** = derived internally; **DEAD** = declared but never used.
+
+---
+
+## 1. vLLM engine configuration (colocated rollout engine)
+
+### 1.1 `VLLMConfig` dataclass — `agilerl/utils/algo_utils.py:1416-1495`
+
+| Knob | file:line | Default | Controls | Memory impact | Throughput impact | Set by | Should be derived from |
+|---|---|---|---|---|---|---|---|
+| `tensor_parallel_size` | algo_utils.py:1474 | `1` | vLLM TP degree; also defines trainer rank→TP subgroup layout (base.py:4749-4764) | Splits engine weights/KV across GPUs | TP comm overhead vs per-GPU batch | U | GPU count, model size vs VRAM, interconnect (NVLink vs PCIe) |
+| `gpu_memory_utilization` | algo_utils.py:1475 | `0.3` | Fraction of total GPU memory vLLM may claim (weights + KV + activations) | THE primary trainer/rollout memory split in colocated mode | More KV cache → more concurrent seqs → higher gen throughput | U | VRAM, model size+dtype, trainer peak (micro-batch × seq len × optimizer), sleep_mode on/off |
+| `max_num_seqs` | algo_utils.py:1476 | `8` | Max concurrent sequences in vLLM scheduler | KV-cache working set | Decode batch size; should be ≥ `data_batch_size_per_gpu × group_size` to avoid queuing (docstring says ≥ group_size, algo_utils.py:1425-1427) | U | rollout batch (prompts×group), KV budget, env profile (decode-heavy wants this high) |
+| `swap_space` | algo_utils.py:1477 | `None` | **DEAD** — declared but never forwarded to `LLM(...)` (absent from llm_kwargs base.py:4773-4797) | none (no-op) | none | DEAD | CPU RAM size; should either be wired or removed |
+| `enforce_eager` | algo_utils.py:1478 | `None` | **DEAD** — declared, never forwarded | CUDA-graph memory (~hundreds MB–GBs) would be saved if wired & True | Eager mode slows decode ~10-20% | DEAD | VRAM headroom; small GPUs want True |
+| `sleep_mode` | algo_utils.py:1479 | `False` | Enables vLLM `enable_sleep_mode` + time-slice sleep/wake around learn/generate | When True, frees vLLM weights+KV during training (level-2 sleep) | Sleep/wake cycles + full weight re-load each iteration cost wall time | U | topology mode: must be True for colocated when trainer needs the GPU; incompatible with populations on one device (warning algo_utils.py:1489-1495) |
+| `dtype` | algo_utils.py:1480 | `None` (vLLM picks) | Engine weight dtype (`"bfloat16"`/`"float16"`) | Engine weight footprint | Marginal | U | model config dtype; should match trainer dtype to keep weight-sync lossless |
+| `quantization` | algo_utils.py:1481 | `None` | vLLM quantization method (`"awq"`, `"gptq"`, …) | Big engine weight reduction | Dequant overhead | U | model size vs VRAM; quantization initiative |
+| `stop_sequences` | algo_utils.py:1482 | `None` | `SamplingParams.stop` | Shorter completions → less KV + shorter train sequences | Faster generation | U | env profile (e.g. `</answer>` tags) |
+| `presence_penalty` / `frequency_penalty` | algo_utils.py:1483-1484 | `0.0` | SamplingParams | Indirect (completion length) | Indirect | U | env profile |
+| `kv_cache_memory_bytes` | algo_utils.py:1487 | `None` | Pins KV cache size in bytes; skips vLLM's auto-profiling (`determine_available_memory` early return) | Exact KV cache budget — the most precise existing rollout-memory knob; also required for multi-process-per-GPU safety (docstring algo_utils.py:1449-1470) | Bounds concurrent tokens | U | VRAM − trainer peak − engine weights; an auto-config layer should compute this directly |
+
+### 1.2 Hardcoded engine kwargs — `LLMAlgorithm._configure_vllm`, `agilerl/algorithms/core/base.py:4723-4816`
+
+| Item | file:line | Value | Notes |
+|---|---|---|---|
+| `max_model_len` | base.py:4778 | `self.max_model_len` (algo arg, default 1024) | Engine context length = trainer context length; single shared value |
+| `max_num_batched_tokens` | base.py:4781-4782 | **`max_num_seqs * max_model_len`** (H) | Derived heuristic, not user-settable. At defaults 8×1024=8k is fine, but e.g. 64 seqs × 32k ctx → 2M token prefill budget: effectively disables chunked-prefill admission control and inflates activation/profiling memory. Should be its own knob derived from env profile (prefill-heavy wants larger; decode-heavy wants ~4-8k) |
+| `distributed_executor_backend` | base.py:4779 | `"external_launcher"` (H) | Required for accelerate-launched colocated SPMD |
+| `seed` | base.py:4780 | `process_index // tp_size` (D) | Per-TP-group sampling seed |
+| `model_impl` | base.py:4783 | `"vllm"` (H) | |
+| `enable_sleep_mode` | base.py:4784 | from `vllm_config.sleep_mode` | |
+| `enable_prefix_caching` | — | **never passed** (vLLM default: on in v1) | Implicit. GRPO sends each prompt `group_size` times as separate requests (base.py:3946-3950, `n=1` hardcoded at base.py:3993); prefill dedupe across the group relies entirely on vLLM's default prefix caching. Should be an explicit knob (prefill-heavy envs benefit massively; tiny-VRAM cases may want it off) |
+| `enforce_eager`, `swap_space`, `cpu_offload_gb`, `max_seq_len_to_capture`, `block_size` | — | never passed | All would matter for auto-sizing |
+| immediate `llm.sleep(level=2)` after init | base.py:4812-4813 | H | Sleep level **2** hardcoded — discards weights. Known-bad for bnb 4-bit (re-quantize garbage); the validated fix (standby patch keeping `"weights"` allocs resident) lives outside main |
+| `VLLM_ATTENTION_BACKEND` | base.py:4801-4810 | env var pass-through | Only env-var-driven engine option acknowledged |
+
+### 1.3 Generation kwargs (vLLM path) — `_generate_with_vllm_colocate`, base.py:3874-4084
+
+| Item | file:line | Value | Notes |
+|---|---|---|---|
+| `n` | base.py:3993 | `1` (H) | Group fan-out done by duplicating prompts instead of `n=group_size`; trades vLLM-native dedupe for explicit replication |
+| per-prompt `max_tokens` | base.py:3923-3931, 4007-4010 | `min(max_output_tokens or max_model_len, max_model_len − prompt_len)`, raised to `min(min_output_tokens, room)` | Derived; the only place prompt length feeds output budget |
+| sampling: `temperature, top_p, top_k, min_p, repetition_penalty, min_tokens` | base.py:3992-4001 | from algo args | GRPO defaults: temp 0.9 (grpo.py:202), top_p 0.95 (204), top_k 50 (205), min_p 0.0 (206), repetition_penalty 1.0 (203) |
+| eval temperature | grpo.py:507-509 (also ppo_llm.py:411) | **`0.01` hardcoded** when `training=False` | "Almost deterministic" eval; not configurable |
+| TP all-gather of prompts + full-batch generate on every rank, then slice | base.py:3952-3990, 4024-4034 | H | Every rank in a TP group generates the whole group batch and keeps its slice |
+
+### 1.4 HF-generation fallback (no vLLM)
+
+| Knob | file:line | Default | Notes |
+|---|---|---|---|
+| `hf_generate_chunk_size` | grpo.py:213,386-394; ppo_llm.py:186,310-317 | `None → 1` | Prompts per HF `generate` chunk; inner loop is still per-prompt with the group as the batch dim (grpo.py:451-501). Memory: group_size×seq KV per generate call. Ignored under vLLM (warning) |
+| `GenerationConfig` | grpo.py:395-406 | `do_sample=True, max_length=max_model_len, max_new_tokens=max_output_tokens, min_new_tokens, pad_token_id, repetition_penalty, top_p, top_k, min_p` | HF path mirror of SamplingParams |
+
+---
+
+## 2. Sleep/wake + colocated memory time-slicing
+
+| Mechanism | file:line | Behavior | Knob? |
+|---|---|---|---|
+| `_prepare_vllm_for_training` | base.py:4911-4921 | `torch.cuda.empty_cache()` then `llm.sleep(level=2)` on main process | level hardcoded; sleep level should be a knob (level-1 vs level-2 vs standby-patch) derived from quantization + VRAM |
+| `_prepare_vllm_for_generation` | base.py:4923-4933 | `empty_cache()` → `llm.wake_up()` → optionally move trainer params to CPU → `_move_model_to_vllm()` | |
+| `use_memory_efficient_params` | base.py:2066 (default `True`), grpo.py:207 | During generation, moves the **entire trainer model to CPU** (`move_params_to_cpu`, llm_utils.py:403-414) and back for training (`_memory_efficient_params` ctx, base.py:3392-3412) | U. Only allowed with vLLM **and** sleep_mode (guards base.py:2124-2138). Incompatible with ZeRO-3 (warns + no-ops, base.py:3401-3408). Costs 2 full PCIe transfers of model weights per iteration — should be derived from (VRAM − vLLM budget − trainer peak) |
+| Weight sync trainer→vLLM | `_move_model_to_vllm` base.py:3839-3872 | `merge_adapter(["actor"])` → per-parameter `llm_model.load_weights([(name, param)])` → `unmerge_adapter()` → `reset_prefix_cache()` (base.py:3871) | All hardcoded. Full dense-weight copy each learn→generate transition (LoRA merge/unmerge each time). Throughput cost grows with model size. The colocated zero-copy base-weight sharing redesign exists on the quant branch (PR #522 lineage), not on this main |
+| Per-`learn` cache scrubbing | grpo.py:525-528, sft.py:213-216 | `gc.collect()` + `torch.cuda.empty_cache()` (+ mps) at the top of every learn call | H; measurable throughput cost on fast iteration loops |
+
+---
+
+## 3. Batch-size hierarchy / gradient accumulation
+
+The effective hierarchy in the reasoning flow:
+
+```
+env.data_batch_size_per_gpu (prompts per rank per step, default 8; llm_envs/base.py:74)
+  × group_size (GRPO fan-out, default 8; grpo.py:201)
+  = num_samples entering learn() per rank        ← actual rollout/train sequence count
+algo batch_size (default 16; grpo.py:195)        ← used ONLY for DeepSpeed micro/accum bookkeeping
+  ÷ num_processes = batch_size_per_process (base.py:4236)
+  ÷ gradient_accumulation_steps (from DS config) = micro_batch_size_per_gpu (base.py:4255-4257)
+learn() minibatch loop step = min(num_samples, micro_batch_size_per_gpu) (grpo.py:596-600)
+```
+
+| Knob | file:line | Default | Controls | Memory | Throughput | Set by | Derive from |
+|---|---|---|---|---|---|---|---|
+| `batch_size` (algo) | grpo.py:195; base.py:2046 | `16` | Total nominal optimizer batch across ranks; drives DS `train_micro_batch_size_per_gpu` & `gradient_accumulation_steps` reconciliation | Indirect | Indirect | U | desired effective batch; group_size; world size |
+| `micro_batch_size_per_gpu` | grpo.py:209; base.py:2063, 4210-4304 | `None` → derived; **create_population defaults it to `BATCH_SIZE`** (utils.py:147-152, with an inline `NOTE we should take a look into deepspeed auto batch-sizing`) | Per-rank per-forward sequence count in learn(); under DS also written into `ds_config["train_micro_batch_size_per_gpu"]` (base.py:4268, 4295) | **Primary trainer activation-memory knob** (activations ∝ micro_bs × seq_len; logits ∝ micro_bs × seq_len × V on unfused path) | More accumulation = more steps per optimizer update | U | VRAM, seq len (max_model_len), vocab size, liger/fused flags, gradient checkpointing |
+| `gradient_accumulation_steps` | DS config (benchmarking/configs/ds_config.json: `2`); reconciled at base.py:4238-4303 | DS-config-owned | Derived as `batch_size / num_processes / micro_batch_size_per_gpu` (base.py:4296-4303) when micro specified; else read from DS config | none (just step count) | linear | U (DS json) / D | batch_size, micro, world size |
+| divisibility constraints | base.py:4230-4234, 4279-4287 | — | `batch_size % num_processes == 0`; `batch_size % (micro × num_processes) == 0` — hard errors | — | — | — | auto-config must respect these |
+| **GRPO group/batch mismatch** | grpo.py:553-559 | — | `num_samples % group_size == 0` enforced in learn; but `num_samples = data_batch_size_per_gpu × group_size` is set by the **env**, while `batch_size` (the DS bookkeeping value) is a separate arg — nothing reconciles them. DS loss averaging assumes its micro/accum mapping matches the actual loop, which is only true if the user keeps `batch_size == data_batch_size_per_gpu × group_size × num_processes` by hand | — | — | implicit | should be a single derived quantity |
+| `update_epochs` | grpo.py:200 | `1` | Passes over the rollout per learn() | none | linear ×epochs | U | algo choice (off-policy drift) |
+| `group_size` | grpo.py:201 | `8` | Completions per prompt (GRPO advantage groups); also generation fan-out | rollout KV ∝ group; learn batch ∝ group | generation tokens ∝ group | U (+ **HPO-mutable**, see §10) | reward variance needs vs token budget |
+| `data_batch_size_per_gpu` (env) | llm_envs/base.py:74 | `8` | Prompts per rank per env step (DataLoader batch size; llm_envs/base.py:101-114) | rollout + learn batch | step granularity | U | with group_size and micro: the master scheduling quantity |
+| `batch_size` (multiturn loop) | train_llm.py:1279, 1345 | `INIT_HP["BATCH_SIZE"]` | Number of parallel multi-turn envs: `SyncMultiTurnVecEnv(env_factory, batch_size, group_size)` → batch×group simultaneous trajectories all generated in one vLLM batch per turn | rollout KV ∝ batch×group×ctx | env parallelism | U | max_num_seqs, KV budget, env profile |
+| DPO/SFT micro-batch | dpo.py:243-246; sft.py:238-241 | `min(num_samples, micro_batch_size_per_gpu)` | Same micro pattern; DPO doubles it again internally (chosen+rejected forward) | DPO: 2× sequences per step | — | D | |
+
+---
+
+## 4. Context length & how it flows
+
+| Stage | Knob | file:line | Default | Notes |
+|---|---|---|---|---|
+| Algorithm | `max_model_len` | grpo.py:212, 383-385; ppo_llm.py:185; reinforce_llm.py | `1024` | Single value used for: vLLM engine `max_model_len` (base.py:4778), vLLM `max_num_batched_tokens` product (base.py:4781), HF `GenerationConfig.max_length` (grpo.py:398), per-prompt output budget (base.py:3924). Falls back to `max_output_tokens` if None (grpo.py:383-385); one of the two must be set (grpo.py:374-378) |
+| Algorithm | `max_output_tokens` | grpo.py:210, 379-381 | `None` → max_model_len | Completion cap. Also passed to Liger GRPO as normalizer (grpo.py:1079) |
+| Algorithm | `min_output_tokens` | grpo.py:211 | `None` → 0 | `SamplingParams.min_tokens` (base.py:3999-4001); can override room cap (base.py:3929-3930) |
+| Env (dataset gyms) | `max_context_length` | llm_envs/base.py:75, 87, 188-215 | `None` | **Filters out** training samples whose prompt exceeds `max_context_length − min_completion_length` (base.py:201-205). Completely decoupled from algo `max_model_len` — user must pass the same number to both (benchmark does: `max_context_length=init_hp["MAX_MODEL_LEN"]`, benchmarking_llm_reasoning.py:124) |
+| Env (preference) | padding to `max_context_length` | llm_envs/preference.py:81-97 | — | When set, **every** chosen/rejected pair is padded to the full `max_context_length` (`padding="max_length"`) → DPO trains on fixed max-size tensors regardless of actual lengths. Without it, pads to batch max (preference.py:99-122). Memory-wasteful hardcode |
+| Env (SFT) | `padding="longest"` | llm_envs/sft.py:85-87 | — | Dynamic per-batch padding (better) |
+| Multi-turn wrapper | `max_model_len`, `max_output_tokens` | llm_envs/token_observation.py:25-34, 117-122 | `None` | Sliding-window prompt truncation: keeps initial user segment, drops oldest middle turns, records `stitch_prefix_ids` so the full sequence is reassembled for training (`max_prompt_tokens_for_sliding_window` llm_utils.py:66-90; stitching base.py:4066-4073, llm_utils.py:417-552). Means **training sequences can exceed the engine context** — trainer activation memory governed by full stitched length, not max_model_len |
+| Guard | prompt > max_model_len | base.py:3925-3927 | — | hard ValueError |
+
+**No packing anywhere.** Sequences are stacked + right-padded to the longest sequence of the batch (`stack_and_pad_experiences`, algo_utils.py:1286-1316; pad value = `pad_token_id`). Mixed-length groups burn quadratic attention on pads (masked but computed in sdpa). A packing/sorting-by-length option is an obvious missing throughput knob.
+
+---
+
+## 5. Trainer model memory: dtype, LoRA, checkpointing, value/reference heads
+
+| Knob | file:line | Default | Controls | Memory | Set by | Derive from |
+|---|---|---|---|---|---|---|
+| model load dtype | llm_utils.py:200-204 | **bf16 without accelerator, fp16 with accelerator** + `attn_implementation="sdpa"` | base-model weights | model_size × 2 bytes | H (overridable via `model_config` dict, grpo.py:192) | hardware bf16 support; DS bf16 config (note: fp16-under-accelerator clashes with bf16 DS configs); flash-attention availability |
+| `model_config` | grpo.py:192; base.py:2071 | `None` | full kwargs passthrough to `from_pretrained` (quantization_config, attn impl, etc.) — the only current entry point for bnb 4/8-bit trainer quantization | arbitrary | U | model + VRAM |
+| `lora_config` | base.py:2055, 2102-2116 | `None` → warns + defaults `r=16, alpha=32, target_modules="all-linear", dropout=0.05` | trainable param count → optimizer state size, gradient size, weight-sync cost | LoRA params ≈ 2·r·d per layer; AdamW states ×2 | U (also via INIT_HP `LORA_R=16, LORA_ALPHA=64, LORA_DROPOUT=0.0, TARGET_MODULES` — utils.py:81-99; note alpha default differs 32 vs 64) | model size, task; mostly user-policy |
+| liger forces `exclude_modules=["lm_head"]` | base.py:2117-2122 | — | LoRA never applied to lm_head with liger | — | H | — |
+| `gradient_checkpointing` | grpo.py:223; base.py:2072 (default `True`); enabled at wrap_models base.py:2720-2732 with `use_reentrant=False` | `True` | recompute activations | huge activation savings; ~30% slower fwd+bwd | U | micro_bs × seq_len vs VRAM — prime auto-config target |
+| `torch_compiler` | base.py:2073, 3342-3357 | `None` | torch.compile mode | — | kernel fusion speedups | U | incompatible with DeepSpeed (skipped) and with gradient checkpointing (disables ckpt!) — base.py:3343-3356 |
+| `use_value_head` (LLMPPO) | base.py:2058; ppo_llm | `False` (True for PPO) | adds `AutoModelForCausalLMWithValueHead` + critic adapter; **doubles** fused-forward batch (`ids.repeat(2,1)`, base.py:3601-3604) | 2× sequences per training forward | algo-fixed | — |
+| `use_separate_reference_adapter` | grpo.py:229 (default **True**); base.py:2056 | GRPO/PPO/REINFORCE: True; DPO: True; SFT: False | Reference = dedicated frozen LoRA adapter copy vs disabling actor adapter (`disable_adapter_layers`, base.py:3124). Deprecation warning says prefer False (base.py:2252-2265) | adapter copy is small; but with separate adapter the no-grad pass batches reference+actor(+critic) as `ids.repeat(N,1)` (base.py:3654-3668) → N× no-grad forward batch; with False, reference logprobs are a **second full forward** (base.py:3678-3685) | U | — (semantics choice); memory layer should know N multiplies the no-grad batch |
+| reference refresh | `set_reference_policy` base.py:3002-3031 | per dataset epoch (train_llm.py:706,1032) | copies actor→reference adapter, or **merges actor LoRA into dense base in place** (base.py:3033-3103) when no separate adapter | merge path mutates base weights (matters for zero-copy sharing) | cheap | D | — |
+| **No full reference model is ever kept** — reference is always adapter-based (LoRA-disable trick or adapter snapshot). Zero extra full-model memory. | | | | | | |
+
+---
+
+## 6. Loss / log-prob memory paths (the (B,T,V) problem)
+
+| Knob | file:line | Default | Controls | Memory | Set by | Derive from |
+|---|---|---|---|---|---|---|
+| `use_liger_loss` | grpo.py:225 (False), dpo.py:117, sft.py:124, ppo_llm.py:206; gate base.py:2088-2094 | `False` | Liger chunked fused-linear loss: GRPO/GSPO/CISPO via `LigerFusedLinearGRPOFunction` (grpo.py:1063-1088), DPO via `_LigerDPOWithAlpha` (fused_loss.py:440-485), SFT via `LigerCrossEntropyLoss` (sft.py:169-172), PPO via custom turn-aware chunk loop (fused_loss.py:200-240) | avoids materializing (B,T,V) logits **with grad** — the dominant train-time peak for large vocabs | U | should default on when liger installed (docs/llm_finetuning/fused_logprobs.rst:17-23 already describes a `None`→auto default that **does not match this code** — doc/code drift) |
+| `use_fused_linear_logprobs` | grpo.py:235 (False); base.py:2075, 3469-3473, 3714 | `False` | no-grad rollout/reference logprobs via lm_head-identity patch + chunked matmul (`_logprobs_from_hidden_fused`, base.py:4146-4208) | avoids no-grad (B,T,V); ~0.3GB vs ~5GB per doc example (fused_logprobs.rst:92-109) | U | same auto-on policy |
+| `cast_logprobs_to_fp32` | grpo.py:236; base.py:2076, 2020-2037 | `True` | fp32 promotion inside logprob reduction | docstring: disabling saves ~18 GB on unfused path at B=8,T=2048,V≈152k; ~6 MB on fused | U | vocab size, dtype tolerance |
+| `_chunk_rows` (unfused logits) | base.py:4091 | `1` | rows per fp32 logprob chunk | bounds fp32 workspace to (1,T,V) | H (private default) | VRAM headroom — explicitly invites tuning in docstring (base.py:4096-4099) |
+| `_chunk_rows` (fused hidden) | base.py:4153 | `1024` | flat (B·T) rows per matmul chunk | workspace = chunk×V | H | VRAM |
+| Liger `chunk_size` | grpo.py:1086; fused_loss.py:226 (PPO), fused_loss.py:457 (DPO) | `1` | sequences per Liger chunk | workspace ∝ chunk×T×V | H | VRAM — should be a knob |
+| grad-path no chunking | `_fused_forward` base.py:3566-3617 | — | training forward always one chunk ("preserve gradient-checkpoint routing", base.py:3577-3580) → micro_batch_size_per_gpu **is** the grad-time chunk | — | — | micro must be sized for this |
+| no-grad chunking | `_fused_forward_no_grad` base.py:3619-3689; `_fused_model_pass(batch_size=...)` base.py:3431-3564 | micro_batch_size_per_gpu | old/ref logprob pass chunked; preallocated output buffers avoid 2× cat peak (base.py:3533-3563) | — | — | — |
+| `temperature` division of logits | base.py:3515, 3761 | from algo | training logits divided by sampling temperature | — | — | inherits sampling knob | — |
+| `calc_position_embeddings` | grpo.py:208 | `True` | explicit position_ids from attention mask | tiny | tiny | U | model family |
+
+---
+
+## 7. Optimizer & schedule
+
+| Knob | file:line | Default | Notes |
+|---|---|---|---|
+| optimizer class | base.py:3145-3161 | **AdamW** (or `DummyOptimizer` when DS config defines its own optimizer) | No optimizer choice knob; no weight_decay/betas exposure for LLM path (`init_llm_optimizer` optimizer_wrapper.py:67-102 passes only param groups + lr). Optimizer state = 2× fp32 per LoRA param (small for LoRA). Muon etc. would need the DS-native hook (separate ticket) |
+| `lr` / `lr_critic` | grpo.py:197 (5e-7); ppo_llm.py:171-172 (actor 5e-7, critic 5e-5) | | `align_deepspeed_lr` overwrites DS config lr (llm_utils.py:611-636) |
+| `cosine_lr_schedule_config` | grpo.py:215; algo_utils.py:1408-1413 (`num_epochs`, `warmup_proportion`) | `None` | disabled when DS config has an optimizer (base.py:2180-2190) |
+| `max_grad_norm` | grpo.py:199 (0.1); ppo_llm 1.0 | | DS: overwrites `ds_config["gradient_clipping"]` (base.py:2173-2179) + mutation hook resync (base.py:4818-4840). Non-DS: `clip_grad_norm_` per group (base.py:3784-3791) |
+| backward path | `_backward_pass` base.py:3774-3794 | | DS: `accelerator.backward` (engine handles accum/clip). Plain: backward→clip→step→zero per minibatch (no accumulation support outside DS on main!) |
+
+---
+
+## 8. Accelerator / DeepSpeed plumbing (main)
+
+| Item | file:line | Notes |
+|---|---|---|
+| `create_llm_accelerator` | llm_utils.py:313-357 | Returns None on 0 GPUs; **requires** a DeepSpeed plugin otherwise (raises with setup instructions). Only hardware introspection in the entire stack: `torch.cuda.device_count()` (llm_utils.py:339). **No `mem_get_info`, no `get_device_properties`, no interconnect detection anywhere** (verified by grep) |
+| ZeRO stage | read from DS config base.py:2192; stage-3 warning base.py:2193-2201 | stage is user-owned in the accelerate/DS json. Reference DS config: stage 2, `offload_optimizer: cpu`, bf16, micro 8, accum 2, 2e8 buckets (benchmarking/configs/ds_config.json) |
+| ZeRO-3 gathers | `gather_if_zero3` llm_utils.py:138-166 used for checkpoint/weight-sync/merge paths | |
+| per-agent accelerators | `get_llm_accelerator` llm_utils.py:360-387 | population idx 0 reuses, idx>0 fresh `Accelerator()` |
+| mixed precision (no accelerator) | `_amp_ctx` base.py:3414-3429 | autocast bf16 hardcoded when CUDA bf16 supported |
+| device resolution | grpo.py:238-248 | `cuda:{process_index}` under accelerator |
+
+---
+
+## 9. Per-algorithm default table (memory/throughput-relevant args only)
+
+| Arg | GRPO (grpo.py:186-237) | LLMPPO (ppo_llm.py:156-206) | LLMREINFORCE (reinforce_llm.py:140-186) | DPO (dpo.py:92-120) | SFT (sft.py:102-126) | ILQL (ilql.py:84-108) |
+|---|---|---|---|---|---|---|
+| batch_size | 16 | 16 | 16 | 16 | 16 | 64 |
+| micro_batch_size_per_gpu | None | None | None | None | None | — |
+| max_model_len | 1024 | 1024 | 1024 | — | — | — |
+| max_output_tokens | None | None | None | — | — | — |
+| group_size | 8 | — (1 implicit) | — | — | — | — |
+| temperature | 0.9 | 1.0 | 1.0 | — | — | — |
+| update_epochs | 1 | 1 | 1 | 1 | 1 | — |
+| gradient_checkpointing | True | True | True | True | True | — |
+| use_liger_loss | False | False | False | False | False | — |
+| use_fused_linear_logprobs | False | False | False | — | — | — |
+| use_separate_reference_adapter | True | True | True | True | False | — |
+| use_memory_efficient_params | True | True | True | — | — | — |
+| use_vllm | False | False | False | — | — | — |
+| use_value_head | False | True | False | False | False | (own Q/V heads) |
+| gamma / gae_lambda | — | 1.0 / 1.0 | gamma 1.0 | — | — | 0.99 |
+| extra | loss_type grpo/gspo/cispo (GSPO/CISPO are thin wrappers, gspo.py:16-18, cispo.py) | action_granularity "auto", turn_level_clip True, vf_coef 0.5 | — | beta 0.1, nll_alpha 1.0 | — | legacy offline stack, not vLLM/accelerate-integrated |
+
+PPO turn-mode pooling (`pool_by_turns`, llm_utils.py:256-310) is a Python per-turn loop — throughput-relevant for many-turn episodes (O(num_turns) kernel launches).
+
+---
+
+## 10. HPO / evolutionary interactions
+
+| Item | file:line | Notes |
+|---|---|---|
+| What HPO can mutate | `rl_hyperparam_mutation` hpo/mutation.py:412-452 | Any attribute registered as `RLParameter` in `hp_config` — plain `setattr(individual, attr, value)` with grow/shrink factors 1.2/0.8 (registry.py:110-134). LR mutation triggers optimizer reinit (mutation.py:441-450) |
+| What's registered in the shipped configs | configs/training/llm_finetuning/grpo.yaml | `lr` (1e-7→1e-5), `beta` (1e-4→1e-2), **`group_size` (4→12)** — i.e. **HPO directly mutates a memory/throughput knob**: group_size changes rollout KV demand and learn-batch size with **no revalidation** of `max_num_seqs`, batch divisibility, or vLLM capacity after mutation |
+| What HPO cannot touch | mutation.py:528-534, train_llm.py:81-97 | architecture/parameter/activation mutations hard-disabled for LLMs |
+| batch_size mutation hazard | base.py:4210 only runs at `__init__` | if `batch_size`/`micro_batch_size_per_gpu` were registered as RLParameters, mutation would NOT re-run `_configure_batch_size_per_process` → DS config silently stale |
+| Populations | utils.py:726-816; VLLMConfig.__post_init__ algo_utils.py:1489-1495 | each agent = full model copy (+ optional own vLLM); sleep_mode warns it can't be used with populations on a single device. POP_SIZE is a brute multiplier on everything |
+| Cloning (tournament) | base.py:2773-2932 | clone via temp-dir save/load of adapters; vLLM/tp_group handles shared by reference (base.py:2886-2898) |
+
+---
+
+## 11. Hardware introspection — current state
+
+- `torch.cuda.device_count()` — llm_utils.py:339 (GPU presence check only).
+- `torch.cuda.is_bf16_supported()` — base.py:3425 (autocast dtype choice).
+- `torch.backends.mps.is_available()` — device fallback (grpo.py:245) and cache clears.
+- **Nothing else.** No `torch.cuda.mem_get_info`, no `get_device_properties`, no NVLink/interconnect probing, no model-size estimation, no free-memory-driven sizing. Every memory split is a static user number. (vLLM internally profiles for KV sizing — the only dynamic memory measurement in the stack, and `kv_cache_memory_bytes` can bypass it.)
+
+---
+
+## 12. Hardcoded / implicit things that SHOULD be knobs (auto-config targets)
+
+1. **`max_num_batched_tokens = max_num_seqs × max_model_len`** (base.py:4781) — should be independent and env-profile-driven (prefill-heavy vs decode-heavy).
+2. **vLLM sleep level 2** (base.py:4813, 4917) — should be `{1, 2, standby}` derived from quantization (bnb requires standby/level-1 semantics) and VRAM.
+3. **`enable_prefix_caching`** never set — group_size-duplicate prompts depend on vLLM's default; make explicit, derive from env profile (multi-turn/long shared prompts → on).
+4. **`enforce_eager` / `swap_space` declared but never forwarded** (algo_utils.py:1477-1478 vs base.py:4773-4797) — wire or delete.
+5. **Eval temperature 0.01** (grpo.py:509, ppo_llm.py:411).
+6. **`n=1` + prompt duplication for groups** (base.py:3993, 3946) — using `SamplingParams.n=group_size` would let vLLM share prefill KV natively.
+7. **Trainer load dtype fp16-under-accelerator** (llm_utils.py:202) — should follow mixed-precision config (bf16 DS configs get an fp16 model today unless `model_config` overrides).
+8. **`attn_implementation="sdpa"`** (llm_utils.py:203) — flash-attention-2 not auto-selected.
+9. **Liger `chunk_size=1`** (grpo.py:1086, fused_loss.py:226,457) and **`_chunk_rows`** (base.py:4091 `1`; base.py:4153 `1024`) — VRAM-derivable.
+10. **Fused/liger flags default False** while docs describe auto-on (fused_logprobs.rst:17-23) — resolve drift; auto-on when installed.
+11. **Padding-only batching, no packing/length-sorting** (algo_utils.py:1286) — biggest untapped throughput knob for mixed-length groups; preference env even pads to full `max_context_length` (preference.py:87).
+12. **`gc.collect()+empty_cache()` every learn()** (grpo.py:525-528).
+13. **env `max_context_length` vs algo `max_model_len` duplication** — single source of truth needed; today the benchmark manually passes the same INIT_HP value to both (benchmarking_llm_reasoning.py:124 vs utils.py:783).
+14. **`batch_size` (DS bookkeeping) vs actual learn batch (`data_batch_size_per_gpu × group_size`)** — nothing ties them; should be one derived quantity (utils.py:152 already carries a TODO for DS auto batch-sizing).
+15. **Weight-sync strategy** — full dense merge→copy→unmerge per cycle (base.py:3839-3872); LoRA-adapter-only sync / zero-copy base sharing exist only off-main.
+16. **`use_memory_efficient_params` CPU round-trip** — should be computed from whether trainer-peak + woken-vLLM fit, not defaulted True.
+17. **Optimizer choice / weight decay** — AdamW hardcoded (base.py:3161).
+18. **micro default = full batch** in `create_population` (utils.py:147-152) — pathological for big models; should derive from VRAM.
+19. **HPO mutation of `group_size` without capacity revalidation** (mutation.py:438; grpo.yaml MIN/MAX_GROUP_SIZE).
+20. **Sliding-window stitched sequences can exceed `max_model_len` at train time** (token_observation.py:205-272) — trainer memory bound is the stitched length; no cap knob exists for the training-side sequence length.
+21. **vLLM TP rank seeding / external launcher / model_impl** (base.py:4779-4783) — fine as hardcodes, but an async/decoupled mode needs a different executor backend; today colocated-external-launcher is the only wired topology in this repo (the Ray decoupled topology lives in agilerl-integration).
+
+---
+
+## 13. `deepspeed-fsdp` branch: what the torch-native backend changes
+
+Commits on top of main: `1f357a25` (Remove DeepSpeed: torch-native DDP/FSDP2), `feb1505d`, `5b6c66bd`, `844a5ccd`, `b2eb2a21`. Net −3,945/+1,642 lines; `agilerl/algorithms/core/base.py` −1,028 lines churn.
+
+Knob-relevant deltas:
+
+| Area | main (DeepSpeed) | deepspeed-fsdp (DDP/FSDP2) |
+|---|---|---|
+| Accelerator factory | `create_llm_accelerator(deepspeed_plugin=...)`, requires DS plugin | `create_llm_accelerator(fsdp_plugin=None, gradient_accumulation_steps=None)`; default = plain `Accelerator()` → DDP; FSDP2 only via plugin/config with `fsdp_version: 2` enforced (raises on FSDP1); passing `deepspeed_plugin` raises |
+| Grad accumulation | DS json `gradient_accumulation_steps` reconciled into ds_config | owned by `Accelerator(gradient_accumulation_steps=…)` / accelerate yaml; `_configure_batch_size_per_process` derives `self.gradient_accumulation_steps = batch_size_per_process // micro_batch_size_per_gpu`; `_backward_pass` counts micro-batches itself (`self._micro_batch_count % accumulation_steps`), clips with `max_grad_norm` then steps — accumulation now works without DS |
+| ZeRO stages / offload | stage 1-3 + cpu offload via DS json | gone. Replacements: DDP (whole weights per rank — required by colocated vLLM zero-copy weight sharing) or FSDP2 `fsdp_reshard_after_forward: true` (ZeRO-3-like) + `fsdp_cpu_ram_efficient_loading`. **No optimizer-CPU-offload equivalent** — an offload knob disappears |
+| FSDP2 vs colocated vLLM | — | explicitly documented as incompatible with colocated weight sharing ("use this config for decoupled trainer/rollout setups or HF generation only", configs/accelerate/fsdp2_accelerate_config.yaml header) → **topology mode now constrains the sharding knob**: COLOCATED ⇒ DDP; ASYNC/DECOUPLED ⇒ DDP or FSDP2 |
+| Param gathering | `gather_if_zero3` (deepspeed.zero.GatheredParameters) | `gather_full_params` (FSDP2 unshard/reshard; read-only) + `load_full_state_dict` / `get_state_dict` via `torch.distributed.checkpoint` |
+| Knob surface for FSDP2 (accelerate yaml) | — | `fsdp_version: 2`, `fsdp_reshard_after_forward`, `fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP`, `fsdp_state_dict_type: FULL_STATE_DICT`, `fsdp_cpu_ram_efficient_loading`, `mixed_precision: bf16`, `gradient_accumulation_steps`, `num_processes` |
+| Removed | `align_deepspeed_lr`, `_sync_deepspeed_gradient_clipping`, DS gradient_clipping override, DummyOptimizer-from-DS-config path | optimizer is always AgileRL-owned AdamW |
+
+For the auto-config effort: on the new backend the trainer-side knob set collapses to {DDP vs FSDP2, reshard_after_forward, micro_batch_size_per_gpu, gradient_accumulation_steps, mixed_precision, gradient_checkpointing, liger/fused flags} — simpler to model than ZeRO stages, but introduces the hard coupling *colocated ⇒ no sharding ⇒ model must fit whole per GPU alongside the vLLM budget*.
+
+---
+
+## 14. Compact master list (knob → primary derivation inputs)
+
+- `vllm_config.gpu_memory_utilization` (0.3) ← VRAM, model+dtype, trainer peak, sleep_mode
+- `vllm_config.kv_cache_memory_bytes` (None) ← VRAM − engine weights − trainer peak (exact-pin alternative)
+- `vllm_config.max_num_seqs` (8) ← data_batch×group, KV budget, decode-vs-prefill profile
+- `max_num_batched_tokens` (H: seqs×len) ← env profile, VRAM
+- `vllm_config.tensor_parallel_size` (1) ← model size vs per-GPU VRAM, GPU count, interconnect
+- `vllm_config.sleep_mode` (False) + sleep level (H: 2) ← topology=colocated, quantization
+- `use_memory_efficient_params` (True) ← does trainer fit beside woken engine
+- `vllm_config.dtype`/`quantization` (None) ← model dtype/quant plan
+- `max_model_len` (1024) ← env context profile (prompt+gen percentiles)
+- `max_output_tokens`/`min_output_tokens` (None) ← env gen-length profile
+- `batch_size` (16) / `micro_batch_size_per_gpu` (None→derived) / grad-accum ← VRAM, seq len, vocab, liger flags, world size, target effective batch
+- `group_size` (8) ← reward-variance vs token budget; must co-move with max_num_seqs & batch
+- `data_batch_size_per_gpu` (8) ← effective-batch plan
+- `gradient_checkpointing` (True) ← activation memory vs speed
+- `use_liger_loss`/`use_fused_linear_logprobs` (False) /`cast_logprobs_to_fp32` (True) ← vocab size, VRAM
+- liger/logprob chunk sizes (H: 1 / 1024) ← VRAM headroom
+- `lora_config` r/alpha/targets (16/32 all-linear) ← model size, task
+- `use_separate_reference_adapter` (True) ← no-grad batch multiplier awareness
+- ZeRO stage / offload (DS json) → branch: DDP vs FSDP2 reshard ← model size vs VRAM, topology mode
+- `hf_generate_chunk_size` (1) ← only non-vLLM path
+- env `max_context_length` (None) ← must equal max_model_len (single source of truth)
+- sampling (temp 0.9, top_p .95, top_k 50, min_p 0, penalties 0) ← task policy, minor memory effect via lengths

--- a/.research-reports/agilerl-ray.md
+++ b/.research-reports/agilerl-ray.md
@@ -1,0 +1,251 @@
+# agilerl-integration (agilerl_ray): the Ray orchestration layer for ASYNC/DECOUPLED LLM RL
+
+Research slice for the auto-config effort. Repo: `/Users/michaeldoherty/git/agilerl-integration` (read-only).
+
+## 0. Which code is canonical (branch topology matters)
+
+The async/decoupled architecture is **not on `dev`** yet. Branch state as of 2026-06-11:
+
+| Checkout | Branch | Contents |
+|---|---|---|
+| `/Users/michaeldoherty/git/agilerl-integration` | `parallel-tests` (≈ `origin/dev` + CI test fixes) | NO async rollout. Only the legacy `LLMInferenceEngine` (offline eval) exists in `agilerl_ray/inference/`. |
+| `/Users/michaeldoherty/git/agilerl-integration/.claude/worktrees/refactor-async-rl` | `feat/lora-only-weight-sync` | NCCL LoRA-sync work (merged forward). |
+| **`/Users/michaeldoherty/git/agilerl-integration/.claude/worktrees/async-rollout-bnb-quant`** | **`claude/async-rollout-bnb-quant`** | **The bleeding edge: full async rollout (off-policy + on-policy modes), NCCL LoRA weight sync, bnb-4bit quant configs, configurable vLLM knobs. "Async rollout working and training with CISPO" validated on cluster.** |
+
+All file:line references below are into the **async-rollout-bnb-quant worktree** (abbreviated `WT/`) unless noted. Lineage: `feature/async_rl` → `merge/async-rl-arch-change` → `feat/lora-only-weight-sync` (NCCL) → `claude/async-rollout-bnb-quant` (quant + configurable vLLM + on-policy mode). Auto-config design should target this branch's shape.
+
+## 1. End-to-end architecture
+
+### 1.1 Entry point and spec pipeline
+
+```
+ray job submit (ray_jobs/scripts/remote/submit-multi-turn-llm.sh)
+  → python -m agilerl_ray.train --run-id N --manifest m.yaml --llm-model
+        --resource-spec '{"computeResource":{"numCpus":23,"numGpus":2,"memoryBytes":"155"}}'
+        --num-nodes 2
+  → agilerl_ray/run.py:run() (CLI: WT/agilerl_ray/run.py:18-103)
+  → EvoHPOTrainer (WT/agilerl_ray/training/trainer.py)
+      → ConfigBuilder (WT/agilerl_ray/specs/builder.py)
+          ├ AlgorithmSpecFactory → LLMAlgorithmSpec subclass (GRPO/GSPO/CISPO/DPO/SFT/LLMPPO/LLMREINFORCE)
+          ├ EnvSpecFactory → LLMEnvSpec (env_type: reasoning|preference|sft|multiturn, WT/agilerl_ray/_typing.py:126-132)
+          ├ ResourceSpecFactory → LLMResourceSpec.build (THE GPU split: WT/agilerl_ray/specs/resource.py:392-533)
+          ├ TrainingSpec.build (async knobs: WT/agilerl_ray/specs/training.py:243-340)
+          └ ReplayBufferSpecFactory (kind: rl|llm → LLMReplayBufferSpec, training.py:216-240)
+      → DistributedPopulation (WT/agilerl_ray/agents/population.py) — one LLMAgentManager per pop member
+```
+
+Manifests are explicitly "Arena-like" (`WT/agilerl_ray/specs/builder.py:28`); the platform frontend hands the job a manifest plus the `--resource-spec` computeResource JSON.
+
+### 1.2 The actor tree (async mode, per population member)
+
+```
+EvoHPOTrainer (driver, in job entrypoint)
+└── DistributedPopulation (plain python, holds Ray handles)
+    └── LLMAgentManager  [@ray.remote, llm_agent.py:2084]  — one per agent_idx
+        │   creates ONE placement group = training_bundles + rollout_bundles (llm_agent.py:2237-2268)
+        ├── DistributedLLMAgent ×N (trainer workers; @ray.remote via .options(), llm_agent.py:2292-2331)
+        │     num_gpus=GPUS_PER_WORKER=1 (hardcoded, llm_agent.py:155-157), one per training bundle,
+        │     torch.distributed/Accelerate+DeepSpeed group across them (master picked via socket bind, :2333-2344)
+        ├── LLMReplayBuffer  [@ray.remote, llm_replay_buffer.py:682] — bundle_index=0, num_gpus=0
+        │     ├── AsyncLLMRolloutBuffer (in-proc FIFO deques, one per learner)
+        │     └── LLMExperienceReceiver (Pulsar consumer, mem_utils.py:123)
+        └── LLMRolloutEngine  [@ray.remote, llm_rollout_engine.py:277] — one per rollout bundle
+              num_cpus=0.01, num_gpus=0 (rollout_factory.py:32-33) — the GPU is consumed by its child:
+              ├── AsyncEngine (vLLM AsyncLLMEngine subclass in its OWN Ray actor,
+              │     llm_rollout_engine.py:219-273, scheduled onto the same PG bundle :891-901)
+              └── AsyncRayMultiturnEnvWrapper ×(per agent) — Ray-actor vec env workers
+                    (created in start(), :694-711; worker count auto-sized, see §4.3)
+```
+
+Key structural facts:
+
+- **1 manager = 1 rollout engine = 1 agent** today. `engine_id` is set to `agent_idx` (llm_rollout_engine.py:312-322); `TrainingSpec` validator enforces `rollout_engines_per_agent == 1` (training.py:307-313) and `LLMResourceSpec.build` raises for any other value (resource.py:449-451). Round-robin multi-engine sharding code exists (`_agent_indices_for_engine`, llm_rollout_engine.py:203-216) but is currently bypassed.
+- NCCL backend additionally requires exactly one engine per manager (llm_agent.py:2184-2190).
+- The vLLM engine actor itself requests `num_cpus=0, num_gpus=0` and relies on `VLLM_RAY_BUNDLE_INDICES` + PG bundle scheduling for GPU affinity (llm_rollout_engine.py:230-233, 891-901), with `RAY_EXPERIMENTAL_NOSET_CUDA_ENV_VAR=1` set cluster-wide (multi-turn-llm-runtime-env.yaml).
+
+### 1.3 Work/data flow
+
+```
+LLMRolloutEngine.run_loop (async, per batch):
+  for each owned agent: spawn rollout_batch_size*group_size episode tasks
+    each: vec_env.reset → loop { vLLM generate_async (LoRARequest per agent) → vec_env.step } until done/max_turns/prompt-budget
+  as each GRPO group (group_size episodes) completes → pickle envelope → Pulsar producer.send_async
+       topic: {AGILERL_ROLLOUT_TOPIC_ROUTE}/run_{run_id}/agent_{agent_idx}  (ZSTD, batching)
+Pulsar broker
+LLMExperienceReceiver (in LLMReplayBuffer actor) → validate → AsyncLLMRolloutBuffer.append_group
+       (staleness fences: run_id, group_size, rollout_version lag, cycle_id)
+DistributedLLMAgent (per-GPU learner) → memory.pop_batch_for_learner(learner_idx=rank, batch_num=data_batch_size_per_gpu)
+  → _prepare_and_learn_multiturn → core_algo.learn()
+  → every weight_sync_interval learns (off-policy) or every learn (on-policy): sync_weights() → buffer fence
+```
+
+Transport is **Pulsar pub/sub with pickled tensor envelopes** (llm_rollout_engine.py:1688-1723; envelope schema `RolloutGroupEnvelope`, llm_replay_buffer.py:47-96). The Ray object store is not used for experience; Ray is used for control-plane RPC + NCCL handles only. Envelope carries: run_id, engine_id, agent_idx, rollout_version, event_ts, correlation id, group_index, cycle_id, batch sizes, episode ids, completion ids/action masks/turn ids/rewards tensors, optional per-token vLLM sampling logps.
+
+### 1.4 Trainer loops
+
+`WT/agilerl_ray/training/train_llm_multi_turn.py`:
+
+- `llm_multiturn_trainer_sync` (:470) — colocated/sync path (trainer drives `collect_rollouts_for_env` itself; HF generate or trainer-owned vLLM).
+- `llm_multiturn_trainer_async` (:674) — async path. Two modes via `training.async_rollout_mode`:
+  - **off_policy** (default): engines free-run (`start_rollout_engine` → `run_loop.remote()` unbounded, llm_agent.py:2560-2573); trainer pops from buffer; warmup gate `_wait_for_min_buffer_occupancy` requires `batch_size * buffer_occupancy_multiplier` groups (:403-445); weight sync every `algorithm.weight_sync_interval` learn steps (:829-841).
+  - **on_policy**: per learn step the main process runs one bounded rollout cycle (`run_loop(max_iterations=1, cycle_id=k)`, :795-801), fences the buffer by cycle_id, pops only that cycle's groups, learns, then syncs weights immediately (:926-953). `rollout_batch_size` is auto-corrected to `data_batch_size_per_gpu * num_trainer_workers` (:711-727) and `weight_sync_interval` is overridden to 1 (:730-735).
+
+`EvoHPOTrainer.train` starts/stops engines around the HPO loop: `population.start_rollout()` (off-policy) or `population.prepare_rollout()` (on-policy) at trainer.py:494-502, `stop_rollout()` at :706-708. `DistributedPopulation.mutations` pauses engines (soft quiesce), mutates, pushes new `AgentRuntimeConfig`, resumes (population.py:244-279).
+
+### 1.5 Evaluation/fitness under async
+
+`DistributedLLMAgent._evaluation_loop` (llm_agent.py:483-516): async mode computes fitness from the **newest buffered rollout group at the current rollout_version** (peek, no consumption, no extra GPU work) — falls back to most recent group. No dedicated eval rollouts in async mode.
+
+## 2. Weight sync (the staleness machinery)
+
+Two backends, selected by `training.weight_sync_backend: filesystem | nccl` (training.py:294; dispatcher `use_nccl_weight_sync`, weight_merge.py:34-36).
+
+### 2.1 Filesystem (default)
+
+Trainer writes the actor LoRA adapter to `AGILERL_ADAPTER_ROOT/agent_{idx}/actor` (`save_peft_model`, llm_agent.py:1087; root env var set in runtime env to `/opt/data`). Rollout engine `refresh_adapter` (llm_rollout_engine.py:1012-1101) re-reads from disk via vLLM `add_lora` with `load_inplace=True` after first load; content change detected via `compute_adapter_marker` (hash/stat marker, llm_utils.py:145). Requires shared filesystem between trainer and rollout nodes.
+
+### 2.2 NCCL LoRA-only broadcast (the new path; bnb-quant compatible)
+
+- Init: `LLMAgentManager._init_nccl_for_owned_engines` (llm_agent.py:2405-2529) — readiness pings, rendezvous (trainer node ip + open port), vLLM `WeightTransferConfig(backend="nccl")` on the engine (llm_rollout_engine.py:869-889) + trainer-side `NCCLWeightTransferEngine.trainer_init` (llm_agent.py:1141-1167), world_size=2 (trainer rank 0, vLLM worker rank 1). Retries: `AGILERL_NCCL_INIT_MAX_ATTEMPTS` (default 2), timeout 600s.
+- Per sync (`sync_weights`, llm_utils.py:562-720): soft-quiesce engine → drain in-flight batch (unbounded wait, progress log every 60s) → pause vLLM generation + `start_weight_update(is_checkpoint_format=False)` → trainer broadcasts ONLY the actor-LoRA tensor state (`broadcast_weights_via_nccl`, llm_agent.py:1233-1313) → vLLM worker extension `AgileRLLoRAWorkerExtension.update_lora_via_nccl` (lora_worker_ext.py:55+) receives into a dict and hot-swaps the per-agent LoRA slot via `LoRAModel.from_lora_tensors` (no disk, base untouched → bnb-safe) → resume generation → `increment_agent_rollout_version`.
+- Payload: KB–MB (e.g. 516 tensors for r=2 × 7 target modules). `packed=False` currently forced — vLLM's packed-buffer path corrupts small-r LoRA tensors (llm_agent.py:1294-1311). Buffers sized 16 MiB × 2 instead of vLLM's 1 GiB × 2 base-broadcast default (llm_agent.py:90-98).
+- **Quiesce semantics**: soft — new batches blocked, in-flight episodes finish naturally (preserves up to ~50 episodes of GPU work per sync on long-episode envs like 50-turn Sudoku); drained groups land at the **old** rollout_version and are kept/fenced per buffer policy (llm_rollout_engine.py:406-501).
+
+### 2.3 Staleness bounds (off-policyness controls)
+
+Three independent fences in `AsyncLLMRolloutBuffer.append_group` (llm_replay_buffer.py:202-320):
+1. **run_id**: receiver drops envelopes from stale runs (mem_utils.py:189-202) + per-run Pulsar topics make isolation broker-side.
+2. **rollout_version lag**: `replay_buffer.max_rollout_version_lag` (manifest; training.py:156) prunes groups older than `latest - lag` versions. `max_rollout_version_lag: 1` + `weight_sync_interval: 1` ≈ near-on-policy (documented in cispo_multiturn_quant_nccl.yaml:32-36, 196-198).
+3. **group_size / cycle_id**: HPO mutation of group_size clears the buffer (fence at :243-275); on_policy mode rejects/evicts non-current cycle_ids (:223-242).
+
+Additionally `fence_agent_rollouts(rollout_version=...)` is called by the trainer right after each sync (train_llm_multi_turn.py:837-841, 931-936), dropping anything not matching the new version.
+
+## 3. GPU/resource allocation model
+
+### 3.1 Cluster discovery → LLMResourceSpec (resource.py)
+
+`ResourceSpec.calculate_resources` (resource.py:121-224): cluster totals come either from the **user/platform `--resource-spec` JSON** (`computeResource.{numCpus,numGpus,memoryBytes}` × num_nodes via `get_nodespec_from_user`) or from live `ray.nodes()` enumeration of alive non-head workers (with `WORKERS_PER_JOB` env cap for parallel benchmarking).
+
+`LLMResourceSpec.build` (worktree version, resource.py:392-533) — **the central GPU-split rule for async**:
+
+```
+async_rollout:
+    assert total_gpus >= 2 * pop_size                 # hard floor (resource.py:453-455)
+    training_gpus            = total_gpus - pop_size  # rollout takes exactly 1 GPU per agent
+    training_gpus_per_agent  = training_gpus // pop_size
+    rollout_gpus_per_agent   = rollout_engines_per_agent (=1)
+else (colocated/sync):
+    training_gpus_per_agent  = total_gpus // pop_size; rollout gets 0
+cpus_per_agent   = total_cpus  / (pop_size + rollout_engines_per_agent*pop_size)   # even CPU split trainer vs rollout
+memory_per_agent = total_mem   / (pop_size + rollout_engines_per_agent*pop_size)
+training_cpus_per_agent = rollout_cpus_per_agent = cpus_per_agent - RESERVED_CPUS(0.5)
+training_memory = rollout_memory = memory_per_agent * WORKER_MEMORY_RATIO(0.9)
+actor (manager) overheads: ACTOR_CPUS=0.01, ACTOR_GPUS=0, ACTOR_MEMORY_RATIO=0.05  (resource.py:20-25)
+```
+
+So today the rollout:training GPU ratio is **fixed at 1 : (total/pop − 1)** — there is no knob for "2 rollout GPUs per trainer GPU" or fractional sharing; that's the most obvious auto-config gap. `env_resource_ratio` (manifest `ray_params`/`training`, default 0.5; e.g. 0.8 in async manifests) splits the CPU budget between env workers and the agent/engine process.
+
+### 3.2 Placement groups
+
+`LLMAgentManager.__init__` builds **one PG per agent** = `training_bundles + rollout_bundles` (llm_agent.py:2237-2268):
+- training bundle i: `{CPU: training_cpus/N, GPU: training_gpus/N, memory: training_mem/N}` ×N trainer engines
+- rollout bundle j: `{CPU: rollout_cpus*(R/N), GPU: rollout_gpus/R, memory: rollout_mem*(R/N)}` ×R engines
+- PG `ready()` timeout 720s. Buffer pinned to bundle 0 (training.py:190-196). Strategy comes from `ray_params.ray_strategy` (manifests use `SPREAD`).
+- vLLM child workers are pinned to the rollout bundle via `VLLM_RAY_BUNDLE_INDICES` (llm_rollout_engine.py:230-233) and a nested Ray runtime env (`build_vllm_nested_ray_runtime_env`, ray_utils.py:49).
+
+### 3.3 Async env worker auto-sizing (existing mini-auto-config)
+
+`_plan_async_multiturn_resources` (ray_utils.py:392-459) + `_resolve_async_env_num_workers` (:372-389): env worker count = `min(logical_num_envs, max(async_min_workers, (cpu_budget*env_resource_ratio − async_cpu_safety_margin)/async_cpu_per_worker))`, where `logical_num_envs = rollout_batch_size * group_size`. Knobs in `environment:` manifest block — `async_cpu_per_worker` (default 1.0; manifests use 0.25), `async_cpu_safety_margin` (1.0), `async_min_workers` (1), `async_require_parent_pg` (True) (env.py:331-341).
+
+## 4. The complete knob inventory at this layer
+
+### 4.1 Topology / mode switches
+| Knob | Where | Default | Notes |
+|---|---|---|---|
+| `training.async_rollout` | training.py:291 | False | The COLOCATED↔DECOUPLED switch at this layer. False ⇒ trainer-driven rollouts (HF generate or trainer-owned vLLM per upstream AgileRL); True ⇒ rollout engines + Pulsar + buffer. |
+| `training.async_rollout_mode` | training.py:292 | `off_policy` | `on_policy` = bounded cycles + sync-every-learn. |
+| `training.rollout_engines_per_agent` | training.py:293, resource.py:449 | 0 (sync) / must be 1 (async) | Multi-engine support "soon"; sharding code already exists. |
+| `training.weight_sync_backend` | training.py:294 | `filesystem` | `nccl` = LoRA-over-NCCL hot-swap. |
+| `training.pop_size` | manifest | — | Drives GPU floor: async needs ≥ 2×pop GPUs. HPO population. |
+| `training.hpo` | training.py:295 | True | Gates mutations (incl. rollout pause/resume cycle). |
+
+### 4.2 Batching / queueing / staleness
+| Knob | Where | Default | Notes |
+|---|---|---|---|
+| `training.rollout_batch_size` | training.py:289 | 1 | Groups per engine batch; logical env slots = this × group_size. Auto-overridden in on_policy mode. |
+| `algorithm.group_size` | algo specs | — | GRPO group; also Pulsar message granularity. HPO-mutable (with buffer-thrash warning, manifest :151-160). |
+| `algorithm.batch_size` → `data_batch_size_per_gpu` | algo.py:657-660 | — | Per-rank learn batch = batch_size // num_processes. |
+| micro_batch_size_per_gpu | algo.py:661-664 | **hardcoded `min(per_rank,1)`** | "FIXME depends on model size and node size — needs to be dynamic". Prime auto-config target. |
+| `algorithm.weight_sync_interval` | algo.py:473 | 2 | Learns between syncs (off-policy mode). |
+| `replay_buffer.memory_size` | training.py:32 | env `DEFAULT_BUF_SIZE` or 10000 | Deque slots (groups), per learner shard. |
+| `replay_buffer.buffer_occupancy_multiplier` | training.py:155 | 1 | Warmup gate: needs batch_size×mult groups before first learn. |
+| `replay_buffer.max_rollout_version_lag` | training.py:156 | None (∞) | THE off-policyness bound. |
+| learner routing | llm_replay_buffer.py:190-200 | crc32(episode_id) % num_learners (off-policy) / group_index % learners (on-policy) | Deterministic shard per trainer rank; `require_all_learners_ready=True` on pop. |
+
+### 4.3 vLLM engine sizing (`algorithm.vllm_config`, consumed at llm_rollout_engine.py:773-901)
+| Knob | Default | Notes |
+|---|---|---|
+| `gpu_memory_utilization` | **0.9 injected for async** when omitted (algo.py:65-74, 572-591; env-overridable `AGILERL_VLLM_GPU_MEMORY_UTILIZATION`); agilerl's colocated default is 0.3 | The codified colocated-vs-decoupled memory-split heuristic. |
+| `max_num_seqs` | 16 (llm_rollout_engine.py:806-809) | Concurrency vs KV cache. Manifest doc: size num_slots ≈ 2× max_num_seqs so the KV cache stays saturated through the long-tail (cispo_multiturn_quant_nccl.yaml:218-227). |
+| `max_num_batched_tokens` | unset → vLLM default (=max_model_len) | Prefill throughput knob (llm_rollout_engine.py:858-867). |
+| `max_loras` | max(manifest, agents-on-engine) (:783-789) | One slot per agent. |
+| `max_lora_rank` | 16, raised to lora_config.r (:790-795) | |
+| `enable_lora` | True (:796-802) | False only for base-only smoke runs. |
+| `quantization` / `dtype` / `kv_cache_dtype` / `kv_cache_memory_bytes` | None passthroughs (:841-857) | `quantization: bitsandbytes` pairs with trainer `quantization_config: nf4`. |
+| `tensor_parallel_size` | 1 (NCCL path hardcodes 1, :884; factory reads it for CPU calc, rollout_factory.py:53-56) | Multi-GPU rollout engines not wired yet. |
+| `enforce_eager` | False (FIXME at :827) | |
+| sampling: `temperature`/`top_p`/`max_output_tokens` | spec, runtime-updatable via `AgentRuntimeConfig` (protocols.py:59-71) | Pushed at mutation/HPO boundaries; no engine restart. |
+
+### 4.4 Context-length plumbing
+`network.max_context_length` → `algorithm.max_model_len` (algo.py:524-525) → both trainer (HF prompt-budget validation) and rollout vLLM `max_model_len`. `algorithm.max_output_tokens` = per-turn generation cap (must be < max_model_len). Prompt-budget guard terminates episodes that would overflow (`_is_prompt_too_long`, llm_rollout_engine.py:1469-1481); `enable_sliding_window` opts into prompt truncation instead. `environment.max_turns` caps episode length (env.py:331).
+
+### 4.5 Timeouts / env vars (all auto-config-relevant because they scale with workload)
+- `AGILERL_ASYNC_POP_BATCH_TIMEOUT_S` (default 3000; cluster runtime-env sets 1000 with a rationale tied to 50-turn episodes × max_output_tokens through one bnb engine — train_llm_multi_turn.py:35, runtime-env yaml).
+- `AGILERL_ASYNC_BOUNDED_CYCLE_TIMEOUT_S` (defaults to pop-batch timeout; :36-41).
+- `AGILERL_GENERATION_TIMEOUT_S` 1200, `AGILERL_NCCL_SYNC_TIMEOUT_S` 1800, `VLLM_ENGINE_STARTUP_TIMEOUT_S` 900 (llm_rollout_engine.py:97-100); `AGILERL_ROLLOUT_STOP_TIMEOUT_S` 600, `NCCL_INIT_TIMEOUT_S` 600 (llm_agent.py:158-160).
+- Required: `AGILERL_ROLLOUT_TOPIC_ROUTE` (Pulsar topic prefix; llm_rollout_engine.py:195-200), `APP_PULSAR_URL`, `AGILERL_ADAPTER_ROOT` (filesystem sync), `RAY_EXPERIMENTAL_NOSET_CUDA_ENV_VAR=1`.
+- `AGILERL_ATTN_IMPLEMENTATION` default trainer attention backend when manifest omits (algo.py:539-544).
+
+### 4.6 Trainer-side (consumed here, owned by agilerl lib but set via manifest)
+`quantization_config` (nf4/int8/dict), `activation_offload`, `lora_target_scope`, `use_liger_loss`, `liger_token_chunk_size`, `cast_logprobs_to_fp32`, `gradient_checkpointing`, `attn_implementation`, `use_sequence_packing`, `fused_logprobs_chunk_rows`, `vllm_importance_sampling_{correction,apply,cap}` (Feature A — corrects rollout-vs-trainer numeric divergence, "matters more" under bnb-4bit + LoRA-NCCL; algo.py:447-510). DeepSpeed config is a hardcoded ZeRO-2 + CPU optimizer offload template (`DEFAULT_DEEPSPEED_CONFIG`, llm_agent.py:123-153); `gradient_accumulation_steps: 1` fixed; only `gradient_clipping` is wired from the manifest.
+
+### 4.7 ConfigBuilder coercions (existing auto-config precedents)
+- `use_vllm` force-coerced to False under async_rollout (builder.py:102-133) — the trainer must not spin an idle colocated vLLM.
+- `use_vectorized_env=False` ignored under async (env.py:351-356).
+- async gpu_memory_utilization default injection (algo.py:572-591).
+- on_policy `rollout_batch_size` and `weight_sync_interval` auto-correction at runtime (train_llm_multi_turn.py:711-735).
+
+## 5. Telemetry already present
+
+- **MetricsHandler** (WT/agilerl_ray/utils/metrics_utils.py:92-374): OpenTelemetry counters/gauges/histograms (OTLP → OpenObserve per docs/openobserve.rst) + Pulsar `metrics_names` topic (Avro) announcing new series, keyed `run_{id}` / `agent_{idx}`. `get_system_resources()` reports CPU/mem/disk + **per-GPU load, used/free memory, utilization %, temperature** via GPUtil (:332-374; known FIXME: always reports as GPU 0 under Ray's device isolation).
+- **Engine health endpoint** `LLMRolloutEngine.health()` (llm_rollout_engine.py:1890-1919): published/failed Pulsar counts, active_batches/active_generations, per-agent rollout_version, adapter path, sampling params, pending runtime updates — polled but not yet exported as metrics.
+- **Trainer metric series** (train_llm_multi_turn.py:50-68, 644-660, 1022-1035): loss, kl, score, **completion_lengths (mean assistant tokens per episode)**, accuracy, ppo_updates, pg/vf loss, entropy, clipfrac, GRPO signal-health (`n_groups`, `surviving_group_frac`, `mean_group_reward_std`), vLLM IS-correction diagnostics (`vllm_is_ratio_mean/p95`, `frac_clamped`, `rows_skipped`); GPU allocated/reserved GB logged each report.
+- Buffer occupancy is computable (`buffer_count_for_learner`) and logged on ingest; eviction causes are logged with per-cause breakdown (group_size change WARNING, version-lag prune INFO; llm_replay_buffer.py:248-318).
+- **Missing for auto-config feedback loops**: no tokens/s, no vLLM KV-cache utilization, no queue-latency (event_ts is on envelopes but unused), no prefill/decode split, no NCCL sync duration metric (only print-logged stage markers `[NCCL_SYNC]`/`[NCCL_INIT]`).
+
+## 6. Where auto-config naturally plugs in
+
+1. **Manifest generation time (strongest fit)**: the Arena platform → manifest + `--resource-spec` JSON → `ConfigBuilder`. Everything auto-config wants to set is already a manifest field; an auto-config pass could consume (hardware = `--resource-spec`/`ray.nodes()`, model = `network.*`, workload = `environment.*` + `max_output_tokens`/`max_turns`) and emit the `training`/`vllm_config`/`replay_buffer` blocks. The benchmarking layer already programmatically mutates manifests (`benchmarking/manifest_builder.py` + `benchmarking/utils.py`).
+2. **Spec-build time (`LLMResourceSpec.build` / `LLMAlgorithmSpec.from_dict`)**: precedents exist — the async 0.9 gpu_memory_utilization injection, the use_vllm coercion, the on_policy batch auto-correction, env-worker CPU auto-sizing. The trainer:rollout GPU split (resource.py:447-465) is the single highest-value formula to generalize (currently rigid 1-GPU-rollout-per-agent + integer floor-divide trainer GPUs, ≥2×pop assertion).
+3. **Actor startup**: `LLMRolloutEngine._build_async_vllm` already resolves max_loras/max_lora_rank from runtime facts; could similarly derive max_num_seqs / max_num_batched_tokens / kv_cache budget from profiled model+VRAM instead of fixed defaults.
+4. **Runtime**: `AgentRuntimeConfig` push path (update_agent_runtime → applied at batch boundaries) handles sampling/geometry only; engine-level vLLM settings need restart. A runtime auto-tuner would need new plumbing or engine recycling via the existing stop/start lifecycle.
+
+## 7. Arena / platform-frontend hooks (for surfacing decisions in UI)
+
+- Manifests are "Arena-like" throughout (builder.py:28, specs/__init__.py:118,208); platform submits via Ray Job API with per-job runtime envs (`ray_jobs/runtime-envs/*.yaml`) to clusters like `https://ray-dev-training-XXXX.arena-train.agilerl.rlops.ai`.
+- The `--resource-spec '{"computeResource":{numCpus,numGpus,memoryBytes}}'` JSON is the platform's node-shape handshake (run.py:49-54, submit-multi-turn-llm.sh:29) — the natural place for the platform to also pass (or receive back) auto-config output.
+- Metrics flow to the platform via Pulsar (`APP_TOPIC_PREFIX` e.g. `persistent://agilerl/ray-dev`, `metrics_names` topic registers series for the UI) and OTel; run_id keys everything, so auto-config decisions could be emitted as gauges/attributes on the same channel for arena UI display.
+- A separate Streamlit benchmarking dashboard exists (`benchmarking/dashboard/`) reading S3 results — internal, not the arena UI.
+- Datasets/rewards/checkpoints round-trip via S3 buckets under arena user paths (e.g. `s3://agrl-core-arena-dev/.../users/{id}/...`, llm_inference_engine.py:57).
+
+## 8. Gotchas / constraints an auto-configurator must respect
+
+- Hard assertion `total_gpus >= 2*pop_size` for async (resource.py:453-455); `pop_size > total_gpus` rejected (:437-442); 0-training-GPU resolution raises (:505-509).
+- GPUS_PER_WORKER (trainer) hardcoded 1 (llm_agent.py:155); vLLM TP hardcoded 1 on NCCL path (llm_rollout_engine.py:884). Whole-GPU granularity everywhere in LLM async; fractional GPU only exists in the non-LLM RL specs (pack rule, main checkout resource.py:263-275).
+- group_size mutation under HPO ⇒ buffer flush ⇒ trainer starvation risk — manifests pin min=max as a workaround (cispo_multiturn_quant_nccl.yaml:151-160).
+- num_slots (= rollout_batch_size×group_size) vs max_num_seqs oversubscription ratio ~2× is the documented throughput heuristic (manifest :218-227).
+- `pop_batch` timeouts must scale with max_turns × max_output_tokens × concurrency (runtime-env comment).
+- vLLM packed NCCL broadcast is buggy for small-r LoRA (packed=False both sides or 300s NCCL watchdog deadlock; llm_utils.py:632-650, llm_agent.py:1294-1311).
+- vLLM LoRA keep-resident patch (from agilerl lib) is mandatory on the engine or the adapter silently degrades to base (llm_rollout_engine.py:261-269, 903-913).
+- Per-engine `DEFAULT_VLLM_GPU_MEMORY_UTILIZATION` env override exists but explicit manifest values always win.
+- Trainer micro-batch is clamped to 1 with an explicit FIXME "needs to be dynamic" (algo.py:661-664) — gradient accumulation is implicitly batch_size/1.

--- a/.research-reports/fsdp2-trainer-memory.md
+++ b/.research-reports/fsdp2-trainer-memory.md
@@ -1,0 +1,245 @@
+# FSDP2 (`fully_shard`) trainer-side memory model
+
+Research slice for AgileRL auto-config: predicting TRAINER memory under the torch-native FSDP2 backend.
+
+Sources read directly:
+
+- PyTorch trunk clone at `/Users/michaeldoherty/git/Misc/pytorch` (commit `8fa0e605718`, 2026-05-26) — `torch/distributed/fsdp/_fully_shard/*`, `test/distributed/_composable/fsdp/*`, `torch/distributed/_tools/*`, `docs/source/distributed.fsdp.fully_shard.md`.
+- torchtitan main (GitHub API): `torchtitan/distributed/fsdp.py`, `torchtitan/config` (job config), historic `scripts/estimate/estimation.py` (v0.2.2).
+- torchtune main (GitHub API): `recipes/lora_finetune_distributed.py`, `torchtune/training/_distributed.py`; torchao `torchao/quantization/quantize_/workflows/nf4/nf4_tensor.py`.
+- prime-rl local clone: `src/prime_rl/trainer/model.py` (a production RL trainer using FSDP2 — useful corroborating wrapping policy).
+- AgileRL worktree (current state): trainer goes through HF Accelerate (`agilerl/utils/llm_utils.py:313` still has the DeepSpeed contract; the DDP/FSDP2 migration replaces it). Accelerate 1.7.0 in the repo venv exposes `FullyShardedDataParallelPlugin(fsdp_version=2, reshard_after_forward=..., mixed_precision_policy=..., cpu_offload=..., activation_checkpointing=...)` which maps onto everything below.
+
+All `file:line` references into PyTorch are relative to `/Users/michaeldoherty/git/Misc/pytorch`.
+
+---
+
+## 1. FSDP2 public knobs
+
+Entry point: `fully_shard(module_or_list, *, mesh, reshard_after_forward, shard_placement_fn, mp_policy, offload_policy, ignored_params, dp_mesh_dims)` — `torch/distributed/fsdp/_fully_shard/_fully_shard.py:98-108`.
+
+### 1.1 Communication grouping (the implicit, most important knob)
+
+Each `fully_shard` call creates ONE communication group ("param group") containing all parameters of that module not already claimed by an earlier (deeper) call. One all-gather per group per forward, one reduce-scatter per group per backward (`_fully_shard.py:134-143`; `docs/source/distributed.fsdp.fully_shard.md:58-133`). There is **no `bucket_cap_mb`** — the unsharded-peak granularity *is* the wrapping granularity. Calling `fully_shard` only on the root degenerates to "all-gather everything → forward → backward → reduce-scatter everything": full unsharded model resident, zero overlap. The canonical policy (torchtitan `torchtitan/distributed/fsdp.py::apply_fsdp`, prime-rl `src/prime_rl/trainer/model.py:607-680`, torchtune `torchtune/training/_distributed.py::shard_model`) is:
+
+- `fully_shard(block)` per transformer block (bottom-up),
+- `fully_shard(embed_tokens)` as its own group,
+- `fully_shard([final_norm, lm_head], reshard_after_forward=False)` grouped (and skipped/merged with embeddings when weights are tied — tied params must live in one group to avoid double all-gather),
+- `fully_shard(model)` last; leftovers form the root group.
+
+`fully_shard([a, b, ...])` (list form) groups several modules into one collective — used for norm+lm_head and for chunked-loss patterns (`_fully_shard.py:145-157`).
+
+### 1.2 `reshard_after_forward: bool | int | None` (`_fully_shard.py:180-203`)
+
+- `True`: free the group's unsharded params after its forward; re-all-gather in backward. Lowest memory, 1.5× param comm volume (AG fwd + AG bwd + RS).
+- `False`: keep unsharded params resident from forward through backward. No backward all-gather. Memory cost: the whole model unsharded resident at end of forward (see §2.3).
+- `None` (default): `True` for non-root groups, `False` for the **root** group — set during lazy init (`_fsdp_state.py:203-205`, `_fully_shard.py:189-190`). Root is needed first in backward anyway, so resharding it only adds latency.
+- `int k`: reshard post-forward to a *smaller world size* `k` instead of fully (`_fsdp_init.py:152-182`). `k` must divide the shard-mesh size; `k=1` ⇒ `False`, `k=world` ⇒ `True`. Between forward and backward the group holds `numel/k` bytes per rank (a cloned slice of the all-gather output, `_fsdp_param.py:707-744`), and the backward all-gather runs over the `k`-size group (intra-node `k = torch.cuda.device_count()` is the suggested choice — turns the backward AG into NVLink-only). Not yet supported with `dp_mesh_dims` SPMD meshes (`_fully_shard.py:249-258`).
+- Runtime mutators: `set_reshard_after_forward(bool, recurse=True)` (`_fully_shard.py:453`), `set_reshard_after_backward(bool)` (`_fully_shard.py:490`, for grad accumulation: keep params unsharded across microbatches), `module.reshard()` / `module.unshard(async_op)` manual control (`_fully_shard.py:335-373`).
+
+### 1.3 `MixedPrecisionPolicy` (`_fsdp_api.py:13-54`)
+
+`MixedPrecisionPolicy(param_dtype=None, reduce_dtype=None, output_dtype=None, cast_forward_inputs=True)`.
+
+- `param_dtype`: dtype of the **unsharded** (all-gathered) params, hence the compute dtype and AG payload dtype. The **sharded** params stay in original dtype — this is the implicit "master weights" copy: *"FSDP does not require any extra memory to keep a high-precision copy of the parameters for the optimizer step"* (`_fsdp_api.py:21-24`).
+- `reduce_dtype`: dtype of the gradient reduce-scatter/all-reduce payload. If `None`, falls back to gradient compute dtype (= `param_dtype`). After reduction the sharded grad is cast back to the original dtype (`_fsdp_collectives.py:696`), so sharded `.grad` is in **orig dtype** (fp32 if the model was loaded fp32).
+- Clamping: `param_dtype` is ignored for non-floating params and when equal to orig dtype; `reduce_dtype` is ignored when equal to `param_dtype` (`_fsdp_param.py:584-598`).
+- All trainable params in one group must share orig dtype and reduce dtype (`_fsdp_param_group.py:262-283`); **frozen params may have different dtypes** — mixed-dtype groups all-gather as a flat `uint8` buffer (`_fsdp_collectives.py:343-346`, `789-801`). This is what lets a quantized frozen base and bf16 trainable adapters share one group.
+- Reference defaults: torchtitan `mixed_precision_param="bfloat16"`, `mixed_precision_reduce="float32"`, `cast_forward_inputs=False`; prime-rl same (`model.py:609`). torchtune LoRA recipes instead load the whole model in bf16 with **no** mp_policy (pure-bf16: halves sharded param/grad/optimizer bytes at some numerics risk; fp32 reduce unavailable then).
+
+### 1.4 `OffloadPolicy` / `CPUOffloadPolicy(pin_memory=True)` (`_fsdp_api.py:174-199`)
+
+CPU offload moves **sharded params, sharded grads, and optimizer states** to CPU (optimizer step runs on CPU). GPU holds only the transient unsharded group(s): sharded params are H2D-copied before all-gather, reduced grads D2H-copied after reduce-scatter (`_fsdp_api.py:183-190`, D2H copy at `_fsdp_collectives.py:711-743`). `pin_memory` enables overlap but pins host RAM. Throughput cost is large (CPU Adam + PCIe); for auto-config treat it as the last resort tier. Note prime-rl deliberately implements its own `CPUOffloadOptimizer` instead ("keeps weights on GPU", `src/prime_rl/trainer/optim.py:19-22`) — offloading only optimizer state is often the better trade.
+
+### 1.5 `shard_placement_fn` (`_fully_shard.py:204-220`)
+
+Per-parameter override of shard dim/mesh. Default `Shard(0)` (dim-0 chunking). Returning `Shard(i)` for i>0 requires even divisibility; used e.g. for MoE experts (`Shard(1)` when FSDP degree > num_experts, torchtitan `fsdp.py`) and for tying parameter layouts to vLLM TP layouts if you ever want zero-copy alignment. Nonzero shard dims add a transient chunk-cat copy in AG copy-out (`_fsdp_collectives.py:465-471, 493-518`) and a chunk-cat before reduce-scatter (`_fsdp_collectives.py:579-590`) — small extra transient memory.
+
+### 1.6 Prefetching: `set_modules_to_forward_prefetch` / `set_modules_to_backward_prefetch` (`_fully_shard.py:513-551`)
+
+Default behavior already overlaps one group ahead: implicit forward prefetch (CPU runahead issues next AG on the AG stream) and explicit reverse-post-forward-order backward prefetch of 1 module. These APIs override the target list; *"Passing a list with at least length two is required for more aggressive overlap and will use more reserved memory"* — each extra prefetched module adds one more unsharded group to the peak (§2.3). Auto-config: leave at default (1-ahead) unless comm-bound and memory-rich.
+
+### 1.7 `ignored_params: set[nn.Parameter]` (`_fully_shard.py:227-229`)
+
+Ignored params are **not sharded, not moved, not gradient-reduced** — they stay as plain replicated tensors. For LoRA this enables a hybrid topology: `fully_shard(model, ignored_params=base_params)` shards only adapters while the frozen base stays replicated with **zero** FSDP communication (see §3.3).
+
+### 1.8 Other runtime knobs relevant to memory/accounting
+
+- `set_requires_gradient_sync(bool)` (`_fully_shard.py:413`): grad accumulation **without** reduction. Memory consequence: gradients are then accumulated **unsharded** (full model size per rank) in `reduce_dtype` (`_fsdp_api.py:38-39`, `_fsdp_param.py:800-819`). This is expensive; the cheap accumulation is to reduce every microbatch (sharded fp32 grads accumulate at `N/W`) — FSDP2's per-microbatch RS costs comm, not memory.
+- `set_is_last_backward(bool)` (`_fully_shard.py:403`), `set_unshard_in_backward(False)` for params not needed in backward (embedding) (`_fully_shard.py:707`), `set_reduce_scatter_unused_params` (conditional-routing models, `_fully_shard.py:680`), `set_post_optim_event` (`_fully_shard.py:622`), custom comms / symmetric memory / PG allocators (`_fully_shard.py:553-771`).
+- HSDP: pass a 2-D mesh `(replicate, shard)` or `dp_mesh_dims=DataParallelMeshDims(shard=..., replicate=...)` (`_fsdp_api.py:131-171`). Sharded sizes below then use `W = shard-dim size` only, plus an extra all-reduce of the reduced grads across the replicate dim.
+
+### 1.9 Composition with activation checkpointing
+
+Apply AC to the block **first**, then `fully_shard` the same (or an enclosing) block — the test pattern is `checkpoint(mlp); fully_shard(mlp)` (`test/distributed/_composable/fsdp/test_fully_shard_frozen.py:77-81`); torchtune does `set_activation_checkpointing` then `shard_model` (`recipes/lora_finetune_distributed.py:529-552`). Semantics under recompute: the recomputed forward re-fires FSDP's pre-forward (unshard — a no-op if backward prefetch already unsharded the group), and the post-forward hook detects backward via `is_bw()` and skips resharding/order-recording (`_fsdp_param_group.py:545-554`). Net memory effect: with `reshard_after_forward=True` + per-block AC, each block is unsharded exactly while being (re)computed; no interaction penalty. AC composes per-module, orthogonal to FSDP grouping.
+
+### 1.10 Composition with torch.compile
+
+Dynamo never traces FSDP hooks — they are skipped (`test/distributed/_composable/fsdp/test_fully_shard_compile.py::test_disable_compiling_hooks`); managed modules are flagged `_is_fsdp_managed_module` / `_fsdp_use_orig_params = True` for Dynamo (`_fully_shard.py:288-290`). Practical patterns: (a) torchtitan-style **compile each transformer block individually, then `fully_shard` it** — graph breaks at FSDP boundaries are then free; (b) whole-model `model.compile()` works with graph breaks at hooks; (c) full-graph backward needs compiled autograd (still experimental). Compile does not change the FSDP memory model below; it changes activation memory only via the AC/partitioner path (`memory_budget`, §5.2).
+
+---
+
+## 2. The memory model (formulas)
+
+Notation: `P` = total param count; `P_t` = trainable param count; `W` = FSDP shard world size; `G_max` = parameter count of the **largest fully_shard group** (typically one transformer block; for tied-embed models often the embed+lm_head group — check both!); `b_orig`, `b_param`, `b_reduce` = bytes/element of original dtype, `param_dtype`, `reduce_dtype`; `n_opt` = optimizer state multiplier in elements (Adam/AdamW = 2; SGD-momentum = 1; plus a transient for `foreach` ops); `mb` = micro-batch size, `s` = sequence length, `h` = hidden size, `L` = layer count, `V` = vocab size.
+
+Per-parameter dim-0 sharding pads dim 0 up to a multiple of `W` (`_fsdp_param.py:298-316`), so per-rank shard of one param = `ceil(dim0/W) * prod(other dims)`. Padding overhead is bounded by `(W-1)/dim0` per tensor — negligible for real LLM weights but can matter for many tiny tensors (per-layer norms with `dim0=h ≫ W` are still fine). Treat sharded numel ≈ `P/W` with a ~0.1–1% safety factor.
+
+### 2.1 Persistent (steady-state, between steps)
+
+```
+M_params_sharded = P/W · b_orig                       # DTensor shards, original dtype
+M_grads_sharded  = P_t/W · b_orig                     # after RS + cast back to orig dtype
+M_optim_sharded  = n_opt · P_t/W · 4                  # Adam moments, fp32 if orig fp32
+                   (n_opt · P_t/W · b_orig if pure-bf16 loading)
+```
+
+Evidence: sharded grads are viewed out of the RS output and cast to orig dtype (`_fsdp_collectives.py:696-754`); optimizer states follow `sharded_param` dtype. The memory test asserts post-step memory = `3 × model_sharded_numel × 4` (1× params + 2× Adam states) `+ 1× sharded grads` until `zero_grad` (`test_fully_shard_memory.py:213-239`).
+
+So for full fine-tune, fp32 master + bf16 compute (`param_dtype=bf16`): persistent ≈ `P/W·(4+4+8) = 16·P/W` bytes — identical to ZeRO-3's `16N/W` rule. Pure-bf16 load: `P/W·(2+2+4) = 8·P/W`.
+
+### 2.2 Transient comm buffers and unsharded params
+
+Mechanics (`_fsdp_collectives.py:325-378, 431-519`): per group, forward unshard allocates (i) one flat AG output buffer `G·b_param·1` (input slice is a view of it at rank offset — actually input copy-in is a separate `G/W·b_param` staging buffer, line 419-425, minor), then copy-out allocates (ii) per-param unsharded storages totalling `G·b_param`, then frees (i). In forward with implicit prefetch, the current flat buffer is intentionally kept alive until the *next* group's copy-out (`_fsdp_param_group.py:404-420`), and the next group's AG buffer is already allocated → **3 unsharded group-copies coexist in forward**. In backward the AG result is freed right after copy-out → 2 param copies, but gradients add 2 more (autograd-produced unsharded grads + flat RS input buffer of `G·b_reduce`); the RS output (`G/W·b_reduce`) is accounted within sharded grads since grads view into it (`test_fully_shard_memory.py:182-190` NOTE).
+
+From the assertions in `test_fully_shard_memory.py` (world=2, fp32, no MP — generalized to dtypes):
+
+```
+# reshard_after_forward=True (per-block wrapping, root kept unsharded)
+M_peak_fwd  = M_persistent_params + nonblock_unsharded·b_param + 3·G_max·b_param + A_live
+M_peak_bwd  = M_persistent       + nonblock_unsharded·b_param
+              + 2·G_max·b_param              # AG buffer (prefetched next) + copy-out (current)
+              + G_max·b_param                # unsharded grads of current block (computed in param_dtype)
+              + G_max·b_reduce               # flat reduce-scatter input
+              + A_live
+# test form (fp32, b_param=b_reduce=4): 4·G_max + nonblock, lines 182-209
+
+# reshard_after_forward=False
+M_peak_fwd  = P/W·b_orig + P·b_param + G_max·b_param + A_live          # whole model unsharded + 1 copy-out
+M_peak_bwd  = P/W·b_orig + P·b_param + 1.5·G_max·(b_param/b_reduce mix) + A_live
+# test form: model_sharded + model_unsharded + 1.5·max_unsharded (RS in+out), lines 200-208
+
+# reshard_after_forward=k (int): between fwd and bwd each group holds G/k·b_param instead of 0 (True) or G·b_param (False)
+M_between   = Σ_groups G/k·b_param  = P/k·b_param   (plus root group unsharded)
+```
+
+Extra prefetch: each additional module in `set_modules_to_forward/backward_prefetch` adds `+G·b_param` to the respective peak.
+
+Gradient accumulation: with per-microbatch sync (default) no extra term. With `set_requires_gradient_sync(False)`: `+ P_t·b_reduce` **unsharded** accumulated grads persist across microbatches (`_fsdp_param.py:800-819`). With `set_reshard_after_backward(False)`: params stay unsharded between microbatches: `+ P·b_param`.
+
+HSDP all-reduce holds one extra `G/W_shard·b_reduce` buffer alive across layers (`_fsdp_param_group.py:249-259`).
+
+CPU offload: GPU persistent terms drop to ≈0; GPU peak ≈ `3·G_max·b_param + G_max·b_reduce + A_live`; CPU RAM gains `P/W·b_orig + P_t/W·(b_orig + 4·n_opt)` (pinned). Init-time GPU transient ≈ `1.5·G_max·4` (`test_fully_shard_memory.py:139-141`).
+
+### 2.3 Activation memory `A_live`
+
+FSDP does not change activation math; activations are full-size per rank (DP shards the batch, not the activations). For a Llama-style block (SDPA/FlashAttention — no materialized attention matrix), saved-for-backward bytes per layer per token are approximately:
+
+```
+A_layer ≈ mb · s · h · b_act · c_arch
+  c_arch ≈ 2 (attn in/out, qkv) + 4·r_ff (SwiGLU up/gate/act) + norms ≈ 12–20 for r_ff≈3.5, GQA
+           (classic no-flash fp16 estimate: s·b·h·(34 + 5·a·s/h) bytes — use only without SDPA)
+
+No AC:        A_live ≈ L · A_layer                                   + cross-entropy/logits term
+Full AC:      A_live ≈ L · (mb·s·h·b_act)            # one boundary input per layer
+              + A_layer                              # recompute live set of one block
+Selective every-k layers (torchtitan selective_ac_option=int k):
+              A_live ≈ (L/k)·A_layer + L·(mb·s·h·b_act) ≈ full-AC + 1/k of no-AC
+Selective per-op (save matmul/SDPA outputs only): ≈ 0.3–0.5 × no-AC (empirical; torchtitan _save_list policy)
+```
+
+The **logits term dominates for RL fine-tuning**: `mb·s·V·b_act` for logits + up to `mb·s·V·4` for fp32 softmax/log-softmax, plus a same-size grad buffer. For Qwen-style `V≈150k`, one sequence of 4k tokens is ~1.2 GB in bf16 before fp32 upcast. Chunked/fused losses (Liger-style, which AgileRL already uses — `fused_loss` with chunked logits/log-softmax, repo commit `0a9ad78b`) cap this at `chunk_size·V` terms; the auto-config should model logits memory only when fused loss is OFF, else `n_chunks`-divided. Because RL rollouts are variable-length, use `s = max_context` (prefill-heavy) or `max_prompt+max_completion` for the worst-case micro-batch; decode-heavy multi-turn workloads have larger `s·mb` activation pressure relative to model size, pushing toward AC-on and smaller `mb`.
+
+### 2.4 Putting it together (auto-config predictor, reshard=True, per-block wrap)
+
+```
+M_trainer_peak ≈ P/W·b_orig                          # sharded params
+               + P_t/W·b_orig                        # sharded grads
+               + n_opt·P_t/W·4                       # optimizer
+               + E·b_param                           # root/non-block group unsharded (embeds+lm_head)
+               + (3 + n_extra_prefetch)·G_max·b_param
+               + G_max·b_reduce
+               + A_live(mb, s, h, L, V, AC, fused_loss)
+               + C_overhead                          # CUDA ctx + NCCL + allocator frag: budget 1.5–2.5 GB/GPU
+```
+
+Solve for `mb` (largest s.t. `M_trainer_peak ≤ VRAM_budget_trainer`); set grad-accum = `ceil(global_batch / (mb·W))`. In COLOCATED mode, `VRAM_budget_trainer = VRAM − M_vllm_resident_during_training` (with sleep/standby, vLLM weights stay resident if shared zero-copy; KV freed). FSDP2's deterministic allocator behavior (no `recordStream`; avoids FSDP1's non-determinism, `docs/source/distributed.fsdp.fully_shard.md:147-150`) makes this prediction usefully tight — torchtitan reported FSDP2 ~7% lower peak than FSDP1.
+
+Validation tool: **`FSDPMemTracker`** (`torch/distributed/_tools/fsdp2_mem_tracker.py:122`) — a TorchDispatchMode that categorizes FSDP2 memory per module/state, works under `FakeTensorMode` (no GPU needed!). torchtitan's removed-from-main estimation script (`scripts/estimate/estimation.py` @ v0.2.2) ran exactly this: fake-mode two-iteration dry run, `display_modulewise_snapshots`, compare tracker peak vs `active_bytes.all.peak`. **Recommendation: AgileRL's auto-config should use the closed-form above for the search, then verify the chosen config with one fake-mode FSDPMemTracker dry run.**
+
+---
+
+## 3. LoRA + FSDP2
+
+### 3.1 What is sharded, what optimizer state exists
+
+Everything passed to `fully_shard` is sharded — frozen base and trainable adapters alike become dim-0 DTensor shards in the same group. Frozen/trainable can mix freely in one group (FSDP2's per-param sharding "relaxes constraints around frozen parameters" vs FSDP1, docs:145); only **trainable** params must share orig/reduce dtype (`_fsdp_param_group.py:265-283`).
+
+- **All-gather: full group including frozen base, every forward (and every backward if reshard=True).** Frozen weights are needed for compute, so the unsharded-peak terms in §2.2 are unchanged by freezing.
+- **Reduce-scatter: trainable-only.** Post-backward collects only params with grads; RS payload numel = adapter numel (verified: `test_fully_shard_frozen.py:96-103` asserts RS numel = bias-only; collection logic `_fsdp_param_group.py:603-624`).
+- **Persistent memory:** `M_grads = P_lora/W·b_orig`, `M_optim = n_opt·P_lora/W·4` — both negligible (`P_lora` ~0.1–1% of `P`). Sharded base params: `P/W·b_orig`.
+- **Does reshard matter?** Yes — exactly as much as for full FT, because the dominant transient is all-gathering the *frozen base*. `reshard_after_forward=True` keeps only ~3 blocks unsharded; `False` keeps the whole bf16 model unsharded through backward (then FSDP2 sharding bought you almost nothing memory-wise — only optimizer/grad sharding, which LoRA already made tiny). For LoRA: reshard=True if you need the memory; if the unsharded model fits, you shouldn't be using FSDP at all (→ §4).
+
+torchtune's distributed LoRA recipe: shards each `layers.{i}` block + root via `shard_model` (`torchtune/training/_distributed.py:661-706`), `fsdp_reshard_after_forward=True` default (`recipes/lora_finetune_distributed.py:326`), model loaded bf16, no mp_policy; NOTE comment: "register (pre-)forward hooks with fully_shard instead of wrapping nn.Module" (`recipes/lora_finetune_distributed.py:489`).
+
+### 3.2 QLoRA (4-bit base) under FSDP2 — the torchtune/torchao mechanism
+
+FSDP2 supports tensor-subclass extension hooks `fsdp_pre_all_gather` / `fsdp_post_all_gather` (`_fsdp_param.py:601-655`, must define both). torchao's `NF4Tensor` implements them (`torchao/quantization/quantize_/workflows/nf4/nf4_tensor.py:986-1041`):
+
+- `fsdp_pre_all_gather` returns the **quantized payloads** `(quantized_scalers, quantization_factor, quantized_data)` — so the AG moves ~0.5 byte/param, not bf16.
+- `fsdp_post_all_gather` reconstructs an **NF4Tensor as the unsharded param** (stays quantized; the mixed-dtype group goes through the uint8 flat-buffer path, `_fsdp_collectives.py:343-346`). Dequant to bf16 happens inside `linear_nf4` per matmul, not held.
+
+Memory consequence vs bf16-base LoRA: sharded base `≈0.55·P/W` bytes; unsharded transient per block `≈3·0.55·G_max` instead of `3·2·G_max`; adapter terms unchanged. QLoRA+FSDP2 trainer memory is therefore ≈ 27% of bf16-base LoRA on both persistent and transient param terms — activations unchanged. Caveats: 2-D weights only (`nf4_tensor.py:1028-1031`); early FSDP2+NF4 dispatch gaps existed (torchtune issue #1072) — fixed by these hooks; dequant kernel cost per re-gathered block is the throughput tax. **bitsandbytes `Params4bit` (AgileRL's current bnb path) has no `fsdp_pre_all_gather` implementation** — bnb-quantized bases cannot be sharded by FSDP2 directly; the workable topologies are DDP/replicated base (bnb) or NF4 (torchao) if sharding the base is required. torchtitan does not do QLoRA at all (pretraining-focused); its quantization story is fp8/MXFP8 compute via `Float8Linear` (`torchao/float8/fsdp_utils.py` implements the same AG hooks for fp8 all-gather).
+
+### 3.3 The `ignored_params` hybrid
+
+`fully_shard(model, ignored_params=set(base_params))` ⇒ adapters sharded (DTensor), base left replicated and untouched (no AG, no RS for base, `_fully_shard.py:227-229`). Memory = full base per rank + `P_lora/W` adapter terms; comm = adapter RS only (~DDP-of-adapters but with sharded optimizer state). This is the right FSDP2 spelling of "base fits, adapters trained" — including the colocated case where the base is zero-copy shared with vLLM and must NOT be sharded or moved. It also sidesteps the bnb-can't-shard problem entirely.
+
+---
+
+## 4. DDP vs FSDP2 for LoRA-only training
+
+DDP memory per rank (every rank identical): `P·b_model` params + `P_lora·b` grads (bucketed; default `bucket_cap_mb=25`, `torch/nn/parallel/distributed.py:31`; `gradient_as_bucket_view=True` avoids the 2× grad copy) + `n_opt·P_lora·4` optimizer. Comm per step: one all-reduce of `P_lora` (only `requires_grad` params are bucketed). With `P_lora` ~10–50 MB this is a **single sub-millisecond-amortized collective** — effectively free even on PCIe-only boxes.
+
+FSDP2-for-LoRA changes exactly one persistent term — base params `P·b → P/W·b` — and pays for it with per-block all-gathers of the *entire frozen base* every forward (+ backward if resharding): comm volume `≈ 2·P·b_param` per step vs DDP's `P_lora·b`, i.e. **3–4 orders of magnitude more bytes on the wire**, plus latency exposure on weak interconnects (multi-node Ethernet, or PCIe boxes without NVLink).
+
+**Decision rule (auto-config):**
+
+```
+M_ddp_peak = P·b_model + P_lora·(b + 4·n_opt) + A_live(mb_min, ...) + C_overhead
+if M_ddp_peak ≤ VRAM_budget_trainer:           → DDP (or fully_shard+ignored_params if you
+                                                  want DTensor checkpoints / sharded adapter state)
+elif activations are the binding constraint:   → stay DDP, enable full AC / fused loss / smaller mb first
+else (base params don't fit replicated):       → FSDP2, reshard_after_forward=True, per-block wrap;
+                                                  consider reshard=int(intra-node) on multi-node
+QLoRA wrinkle: 4-bit base shrinks P·b_model 4×, so DDP wins far more often;
+               and bnb base *cannot* be FSDP2-sharded anyway (§3.2) — bnb + won't-fit ⇒ NF4 or more GPUs.
+```
+
+Crossover intuition: sharding base params saves `P·b·(1−1/W)`; it only matters when that quantity rescues an otherwise-infeasible config or buys a ≥2× micro-batch increase that AC couldn't. For AgileRL's typical envelope (≤8B base, 4-bit or bf16, LoRA, A100-40/80), DDP is strictly better in almost all colocated configs — FSDP2 earns its keep at bf16 ≥13B on 40 GB cards, or full fine-tuning, or when grad+optim states are non-trivial (`P_t` large). Note also: in COLOCATED mode the time-sliced vLLM engine wants the base resident and unsharded for zero-copy sharing — sharding the base conflicts with that design; FSDP2-with-sharded-base fits the ASYNC/decoupled topology better, where the trainer GPUs don't host vLLM.
+
+(HSDP is the middle ground if you outgrow one node with FSDP2: shard intra-node, replicate inter-node — set via 2-D mesh, §1.8.)
+
+---
+
+## 5. Ecosystem heuristics for auto-configuration
+
+### 5.1 torchtitan
+
+- **No automatic micro-batch picking.** `training.local_batch_size` (default 8) is user-set; `global_batch_size` defaults to `local_batch_size × dp_degree`; grad-accum is derived. Auto-config must do its own solve (§2.4).
+- **Wrapping policy is the codified heuristic** (`torchtitan/distributed/fsdp.py::apply_fsdp`): per-block, embeddings separate, `[norm, lm_head]` grouped with `reshard_after_forward=False` ("FSDP would prefetch them immediately"); weight-tied models group embed+norm+lm_head; **PP ⇒ reshard_after_forward=False** (`get_fsdp_reshard_after_forward_policy`: "default" = `not pp_enabled` — backward follows forward immediately per microbatch, resharding is pure overhead).
+- **Activation checkpointing config**: `mode ∈ {none, selective, full, memory_budget}`, default `selective` with `selective_ac_option="2"` (checkpoint every 2nd block); `"op"` mode saves high-arithmetic-intensity ops (matmuls/SDPA via `_save_list`, only every other matmul) and recomputes the rest; `memory_budget` mode (requires compile) exposes the partitioner's automatic compute↔memory tradeoff with `memory_budget` default 0.5 and a pareto-visualization flag. The sensible AC ladder for an auto-config: none → selective-op → selective-k (k=2,4) → full.
+- **Memory estimation**: `--memory_estimation.enable` (historic `scripts/estimate/estimation.py`, v0.2.2) = `FSDPMemTracker` under `FakeTensorMode`, FSDP/HSDP only (no TP/PP/CP), reports per-module snapshots and tracker-vs-CUDA peak.
+- PyTorch additionally ships an **auto-SAC ILP stack**: `torch/distributed/_tools/{sac_estimator,sac_ilp,ilp_utils}.py` — estimates per-op recompute time/memory and solves a knapsack for the best selective-AC policy under a memory budget. Research-grade but directly reusable machinery.
+
+### 5.2 torchtune
+
+- **No predictive estimator**; runtime utilities only: `training.get_memory_stats`/`log_memory_stats` (alloc/reserved/peak logging) plus the memory-optimization toolkit: per-layer AC, **activation offloading** (`enable_activation_offloading`, stream-overlapped CPU offload of saved activations — composes with AC), torchao `CPUOffloadOptimizer` ("expect RAM ≈ 4× model size"), optimizer-in-backward (frees grad memory eagerly; FSDP2 supports it via post-accumulate-grad hooks — `test_fully_shard_memory.py:345-357` and the D2H special-casing at `_fsdp_collectives.py:711-733`), 8-bit optimizers, and `fsdp_cpu_offload`. The torchtune docs' decision table (memory_optimizations.html) is the closest thing to a published heuristic ladder: LoRA/QLoRA → AC → activation offload → optimizer-in-backward/8-bit → CPU offload.
+- LoRA recipe defaults: `fsdp_reshard_after_forward=True`, `fsdp_cpu_offload=False`, LoRA weights init on CPU when offloading (`recipes/lora_finetune_distributed.py:568`).
+
+### 5.3 Distillation for AgileRL's auto-config
+
+1. Choose topology first: adapters-only + base fits ⇒ DDP (or ignored_params FSDP2); else FSDP2 per-block, reshard=True, bf16 param_dtype / fp32 reduce_dtype, root+lm_head unresharded.
+2. Compute `M_trainer_peak` closed-form (§2.4) over candidate `(mb, AC mode)` pairs; prefer raising `mb` before easing AC for prefill-heavy workloads (activations scale with `mb·s`); always force fused/chunked loss for large-V models.
+3. Verify winner with a `FakeTensorMode` + `FSDPMemTracker` dry run (no GPU time needed) before launching.
+4. Keep 1.5–2.5 GB/GPU headroom for CUDA context, NCCL buffers, and allocator fragmentation; under colocated sleep/wake add the vLLM resident set to the budget.

--- a/.research-reports/prime-rl.md
+++ b/.research-reports/prime-rl.md
@@ -1,0 +1,232 @@
+# prime-rl (Prime Intellect async RL trainer) — config system, auto-sizing, packing, FSDP, and implicit sizing tables
+
+Repo: `/Users/michaeldoherty/git/Misc/prime-rl` (read-only reference clone), HEAD `e5c91695` (2026-06-04).
+All `file:line` references below are relative to the repo root at that commit.
+
+prime-rl is an **async-first, three-process** RL stack:
+
+- **Trainer** (`src/prime_rl/trainer/rl/train.py`) — torchrun process group, FSDP2 (+EP/CP/HSDP), consumes packed micro-batches.
+- **Orchestrator** (`src/prime_rl/orchestrator/orchestrator.py`) — single asyncio process; schedules rollouts against the inference pool via OpenAI-compatible HTTP, assembles batches, ships them to the trainer over a filesystem or ZMQ transport.
+- **Inference** (`src/prime_rl/inference/server.py`) — patched vLLM server(s) with `/update_weights`, `/load_lora_adapter`, `/init_broadcaster` endpoints.
+
+There is **no Ray**: process orchestration is the `rl` entrypoint (subprocesses + `CUDA_VISIBLE_DEVICES` partitioning) on one node, or generated SLURM sbatch scripts multi-node. Weight sync is full-weights (filesystem snapshots or layerwise NCCL broadcast), *not* LoRA-adapter-diff sync (LoRA runs broadcast merged weights via filesystem; NCCL+LoRA is explicitly rejected, `packages/prime-rl-configs/src/prime_rl/configs/trainer.py:641-646`).
+
+---
+
+## 1. Config system — every perf-relevant knob
+
+Configs are Pydantic models in a separate package `packages/prime-rl-configs/src/prime_rl/configs/{trainer,orchestrator,inference,rl,sft,shared}.py`, loaded via `pydantic-config` (TOML files composed left-to-right with `@`, CLI dotted overrides win; `docs/configuration.md:23-42`). The top-level `RLConfig` (`configs/rl.py:180`) nests `trainer` / `orchestrator` / `inference` plus *shared* fields (`model`, `seq_len`, `max_steps`, `wandb`, `ckpt`, `weight_broadcast`, `deployment`, `slurm`) that are propagated into sub-configs pre-validation by `propagate_shared_fields` (`packages/prime-rl-configs/src/prime_rl/utils/validation.py:10-195`) with a "fill-if-absent + conflict-on-disagreement" rule. Cross-process consistency is then *validated* (same model name, `trainer.model.seq_len >= orchestrator.seq_len` at `validation.py:285-293`, same max_steps/ckpt interval/broadcast type).
+
+### 1.1 Trainer knobs (`configs/trainer.py`)
+
+`ModelConfig` (trainer side):
+
+| Knob | Default | Ref |
+|---|---|---|
+| `seq_len` | 2048 | trainer.py:119 |
+| `attn` | `flash_attention_2` (eager/sdpa/fa2/fa3/fa4) | trainer.py:122, alias map :27 |
+| `compile` (sub-config; per-block torch.compile, `fullgraph` flag) | None (off) | trainer.py:125, :61-63 |
+| `ac` — activation checkpointing: `mode = full\|selective`, `freq` (every N layers), `targets` (norm/attn_proj/mlp/mla_up_proj/routed_experts/linear_attn) | None (off) | trainer.py:35-50, :128 |
+| `ac_offloading` — `pin_memory=True`, `max_inflight_activations=5` | None (off); enabling it auto-enables `ac` (trainer.py:225-230) | trainer.py:53-58, :131 |
+| `fsdp_cpu_offload` (params+grads+optim to CPU, pinned) | False | trainer.py:134 |
+| `optim_cpu_offload` (optimizer state only) | False; mutually exclusive with fsdp_cpu_offload (trainer.py:238-242) | trainer.py:137 |
+| `reshard_after_forward` | **True** | trainer.py:140 |
+| `dp_replicate` (HSDP replication degree) | 1 | trainer.py:143 |
+| `ep` (expert parallel degree) + `ep_comm_backend` (`torch`/`deepep`) + `deepep_num_sms=20`, `deepep_token_chunk_size` | 1 / torch | trainer.py:146-156 |
+| `cp` (context parallel) + `cp_style` (`ring`/`ulysses`) | 1 / ring | trainer.py:158-162 |
+| `impl` (`hf`/`custom`/`auto`) | auto (custom if supported) | trainer.py:164 |
+| `optimization_dtype` / `reduce_dtype` | float32 / float32 (params compute in bf16 via FSDP mp_policy) | trainer.py:167-171 |
+| `moe_use_grouped_mm` | True (needs SM90+) | trainer.py:173 |
+| `fp8` (DeepGEMM blockwise FP8 training; SM90 + custom impl) | False | trainer.py:176 |
+| `freeze_moe_router` | False | trainer.py:182 |
+| `lora` — rank 16, alpha 32, dropout 0, target_modules covering attn+MLP+experts | None | trainer.py:79-104, :185 |
+| `fused_lm_head_token_chunk_size` | `"disabled"`; `"auto"` → **8192** for RL (validator trainer.py:656-661); ints rejected for SFT (sft.py:349-357) | trainer.py:191 |
+
+`TrainerConfig` extras: `matmul_precision="high"` (TF32; `"highest"` required on ROCm, trainer.py:532), `gc.interval=50` (deterministic synchronized GC to avoid stragglers, trainer.py:30-32), `dist_timeout_seconds=600` (trainer.py:553), `max_concurrent_runs=1` (multi-tenant LoRA training, trainer.py:562), `weight_broadcast` (filesystem default / nccl, trainer.py:454-490), `rollout_transport` (filesystem default / zmq with `hwm=10`, shared.py:243-264), optimizer union (`adamw` default lr=1e-6 wd=0.01 max_norm=1.0; `sgd`/`muon`/`sign_sgd`, trainer.py:310-360), scheduler union (constant default / linear / cosine).
+
+**Notable absence: the RL trainer has NO `micro_batch_size` and NO `gradient_accumulation` knob.** Both are *emergent* from sequence packing (§4): a micro-batch is one packed bin of ≤`seq_len` tokens at batch dim 1, and the number of micro-batches per rank per step (= grad-accum steps) is whatever the orchestrator's batch packs into.
+
+### 1.2 Orchestrator knobs (`configs/orchestrator.py`)
+
+| Knob | Default | Ref |
+|---|---|---|
+| `batch_size` (rollouts per trainer step) | None → resolved to **128** if neither batch knob set | orchestrator.py:594, :847-848 |
+| `token_batch_size` (tokens per trainer step; mutually exclusive with `batch_size`) | None | orchestrator.py:597, :843-845 |
+| `oversampling_factor` (rollout-mode only; multiplies batch_size to derive in-flight capacity) | None (=1.0) | orchestrator.py:600 |
+| `max_inflight_rollouts` | auto: `max(group_size, batch_size*oversampling_factor)`; **required explicit** for token-mode | orchestrator.py:603, :850-872 |
+| `group_size` (GRPO rollouts per example; alias `rollouts_per_example`) | 1 | orchestrator.py:606 |
+| `seq_len` (orchestrator-side cap; samples > this are dropped/truncated) | 2048 | orchestrator.py:609 |
+| `num_train_workers` (trainer DP ranks the packer shards for; "TODO should be automatic from ZMQ connections") | 1, auto-set by deployment (§3) | orchestrator.py:612-614 |
+| `max_off_policy_steps` (**the async/staleness dial**) | **8** | orchestrator.py:619-620 |
+| `tasks_per_minute` (per-env-worker rate limit) | None | orchestrator.py:591 |
+| `pool_size` (renderer tokenization slots) | None | orchestrator.py:522 |
+| Per-env: `num_workers="auto"`, `max_retries=3`, `ratio`, `max_total_completion_tokens=-1`, `timeout` | | orchestrator.py:162-178 |
+| Sampling: `temperature=1.0`, `max_completion_tokens` (None = generate to context limit) | | orchestrator.py:45-57 |
+| Filters: pre/post-batch `gibberish`/`repetition`/`zero_advantage` (monitor-mode by default) | | orchestrator.py:549-565 |
+
+Batching resolution invariants (`resolve_batching`, orchestrator.py:839-885): exactly one of `batch_size`/`token_batch_size`; `batch_size % group_size == 0`; `max_inflight_rollouts >= group_size`; conflict check between explicit `max_inflight_rollouts` and `oversampling_factor*batch_size`.
+
+### 1.3 Inference knobs (`configs/inference.py`) — direct vLLM passthrough
+
+| Knob | Default | Ref |
+|---|---|---|
+| `parallel.tp` / `parallel.dp` | 1 / 1 | inference.py:27-31 |
+| `gpu_memory_utilization` | **0.9** | inference.py:304 |
+| `model.max_model_len` | None (model config value) | inference.py:48 |
+| `model.dtype` | auto | inference.py:45 |
+| `model.enforce_eager` | False (hybrid cudagraphs) | inference.py:51 |
+| `enable_prefix_caching` | None (vLLM default; force-enabled by KV offload, inference.py:372-380) | inference.py:301 |
+| `api_server_count` | 1, heavily auto-adjusted (§2) | inference.py:307 |
+| `data_parallel_size_local` | None, auto-derived multi-node | inference.py:310 |
+| `enable_lora` / `max_loras=8` / `max_cpu_loras=100` / `max_lora_rank` | off | inference.py:283-296 (the 100 default is a deliberate workaround: adapters are added under new names, never swapped in-place, so stale in-flight requests don't crash — comment :289-291) |
+| `enable_expert_parallel`, `all2all_backend` (5 options, default `allgather_reducescatter`), `enable_eplb`, `enable_dbo`, `use_deep_gemm` | off | inference.py:319-332 |
+| `kv_cache_offload` — `native` (vLLM OffloadingConnector / TieringOffloadingSpec) or `mooncake` distributed store; `cpu.num_bytes` required, optional `disk.path` | None | inference.py:89-153, :336 |
+| `enable_fp32_lm_head` | **True** (monkey-patched fp32 logits GEMM for logprob precision under FP8/bf16 — matters for the importance-ratio KL) | inference.py:345-346 |
+| `logprobs_mode` | hardwired `processed_logprobs` | inference.py:518 |
+| `vllm_extra` (arbitrary vLLM namespace overrides, e.g. `headless`) | {} | inference.py:348 |
+| `deployment` — `single_node` / `multi_node{num_nodes}` / `disaggregated{num_prefill_nodes,num_decode_nodes,num_*_replicas,prefill/decode_env_overrides}` + router (`consistent_hash` default policy) | single_node | inference.py:187-265 |
+
+### 1.4 SFT trainer (`configs/sft.py`) — the only place with explicit micro-batch
+
+`data.batch_size=128` (global, in samples-worth-of-packed-sequences), `data.seq_len=128`, `data.micro_batch_size=1`, `pack_function = "cat"|"stack"` (sft.py:28-47). `grad_accum_steps = (batch_size * cp) / (world_size * micro_batch_size)`, asserted divisible (`src/prime_rl/trainer/sft/train.py:100-106`). CP forces `micro_batch_size==1` and `pack_function=="cat"` (sft.py:276-301). `loss_impl`: `liger | torch | liger_fused | quack_fused` (sft.py:228-229).
+
+---
+
+## 2. Auto-sizing: what is derived vs. user-set
+
+**Headline: prime-rl does essentially ZERO memory-based auto-sizing.** There is no GPU-VRAM introspection feeding config, no heuristic table keyed on model size, no OOM-retry loop. `torch.cuda.mem_get_info()` appears only in benchmark *reporting* (peak-mem as % of total, `src/prime_rl/trainer/utils.py:246,279-280`; `src/prime_rl/trainer/sft/train.py:334`), and the benchmark harness merely *recognizes* OOM in output for triage (`benchmarks/scripts/run_single_benchmark.py:36-46`: greps for `"torch.OutOfMemoryError: CUDA out of memory."`). Memory fitting is delegated to the human + the `--bench` workflow + example configs (§6). The docs say so outright: "You need to make sure that the model will fit into the available GPU memory. We will not go into the details on how to do this" (`docs/inference.md:75`).
+
+What IS auto-derived is **topology arithmetic** — a substantial validator network that fills in consistent parallelism/worker counts from a small set of user inputs:
+
+1. **FSDP shard degree is always derived**: `dp_shard = -1` → `world_size // (dp_replicate * cp * pp)` (`src/prime_rl/trainer/parallel_dims.py:62-64`, `get_parallel_dims` :273-292). The user only ever sets `dp_replicate`/`cp`/`ep`; world size comes from torchrun.
+2. **Trainer DP worker count → orchestrator packer**: single-node `orchestrator.num_train_workers = num_train_gpus // cp` (`configs/rl.py:467-471`); multi-node `= num_train_nodes * gpus_per_node` (rl.py:489).
+3. **Inference DP fill**: single-node, if `num_infer_gpus != dp*tp`, then `dp = num_infer_gpus // tp` (asserting divisibility) (`configs/rl.py:474-480`). Multi-node without EP: `dp_per_node = gpus_per_node // tp`; auto-sets `parallel.dp`, `data_parallel_size_local`, `api_server_count` (rl.py:537-548). With EP: validates `dp*tp == total inference GPUs` and derives `data_parallel_size_local = gpus_per_node // tp` (rl.py:501-531).
+4. **`api_server_count` auto**: raised to DP size so the NCCL broadcast group doesn't deadlock waiting for workers that don't exist (comment rl.py:481-486); forced to 1 when LoRA (vLLM limitation), 0 when headless (`configs/inference.py:428-446`).
+5. **NCCL broadcast world size**: `inference_world_size = total_infer_nodes * gpus_per_node` (with an explicit comment about a double-counting bug they fixed, rl.py:550-563; disaggregated path rl.py:594-598). Marked "TODO: Should not be configurable, but auto-inferred" (trainer.py:480-482).
+6. **`nodes_per_fsdp_group` → `trainer.model.dp_replicate = num_train_nodes / nodes_per_fsdp_group`** — HSDP island sizing from a node count (rl.py:491-499; same for SFT, sft.py:385-394).
+7. **LoRA cross-propagation**: trainer LoRA on → orchestrator student LoRA rank/alpha inherited, adapter name auto-generated `r{rank}-a{alpha}`, `inference.enable_lora=true`, `inference.max_lora_rank = rank` *rounded up to vLLM's legal set* `(8,16,32,64,128,256,320,512)` (`configs/rl.py:367-419`; rounding `configs/inference.py:410-426`, set at :158).
+8. **Env worker autoscaling — the one workload-derived heuristic**: `num_workers = "auto"` → **1 worker per 256 concurrent rollouts**: train envs `max(1, ceil(max_inflight_rollouts / 256))` (`configs/orchestrator.py:879-883`); eval envs `max(1, ceil(num_examples * group_size / 256))`, 4 if unbounded (:327-334). Doc on the field: "auto scales to 1 worker per 256 concurrent rollouts" (:162-163).
+9. **`max_inflight_rollouts` auto** = `max(group_size, int(batch_size * oversampling_factor))` (:858-869) — this is the inference concurrency knob, i.e. the orchestrator-side "batch size" presented to vLLM.
+10. **Disaggregated P/D auto-setup**: forces NIXL transfer, EP on, `dp = api_server_count = data_parallel_size_local = gpus_per_node/tp` (`configs/inference.py:382-400`); prefill/decode roles get different all2all backends *in the sbatch template* (prefill `deepep_high_throughput`, decode `deepep_low_latency`, `src/prime_rl/templates/multi_node_rl.sbatch.j2:268,282`); orchestrator P/D metrics roles auto-ordered (rl.py:585-593).
+11. **`fused_lm_head_token_chunk_size = "auto"` → 8192** (trainer.py:656-661) — the only "auto" that picks a numeric memory/perf value.
+12. **Parser/renderer auto**: tool-call & reasoning parsers resolved from the model name (`configs/inference.py:69-81`); renderer `"auto"` resolves via `MODEL_RENDERER_MAP` and hard-fails at config time when unmappable rather than silently degrading (`configs/orchestrator.py:803-837`).
+
+**Warnings / fail-fast in lieu of fitting checks**: every misfit is a `ValueError` at validation (`--dry-run` runs the full validator network: rl.py:227-228, docs/training.md:82). Examples: GPU budget overrun (`configs/rl.py:144-152` single-node, sft.py:147-151), NCCL needing ≥2 GPUs (rl.py:253-261), `seq_len % (2*cp) != 0` (`parallel_dims.py:262-266,285-291`), CP×attention-kernel compatibility (trainer.py:210-223), DeepEP auto-disabling grad clipping with a warning (trainer.py:567-576), VLM forcing bf16 (trainer.py:578-586). Runtime warnings: orchestrator warns when off-policy cancellation triggers ("Consider increasing it", `dispatcher.py:277-283`) and when <10% of a batch is trainable (orchestrator.py:552-556); packer warns on token-budget timeout (`packer.py:290-292`).
+
+---
+
+## 3. Async orchestration: GPU split, replicas, weight sync, staleness
+
+### 3.1 Trainer:inference GPU split — always user-set
+
+- **Single node**: `deployment.num_train_gpus` / `num_infer_gpus` (defaults **1/1**, `configs/rl.py:135-152`). The `rl` entrypoint slices `CUDA_VISIBLE_DEVICES` in order — *inference first, trainer next, teacher last* (`src/prime_rl/entrypoints/rl.py:87-104,155-163,240-255`; docs/scaling.md:44). No heuristic; the docs just show an example 6-infer/2-train split (`docs/scaling.md:35-43`).
+- **Multi-node (SLURM)**: `num_train_nodes` / `num_infer_nodes` / `num_infer_replicas` (`configs/rl.py:155-172`); total inference nodes = `num_infer_nodes * num_infer_replicas`. The generated sbatch (`templates/multi_node_rl.sbatch.j2:4-50`) allocates `num_train_nodes + num_infer_nodes*num_infer_replicas` nodes and exports the wiring (`INFERENCE_TP`, `INFERENCE_DP_LOCAL=$((GPUS_PER_NODE / INFERENCE_TP))`, router/prefill/decode ports). `num_infer_nodes = 0` is allowed for trainer-only benchmarking (requires fake data, rl.py:239-250).
+- **Inference replica count** = `num_infer_replicas` (independent vLLM stacks each behind its own `vllm-router`); within a replica, engine count = DP size. None of this is auto-tuned; the docs give qualitative guidance only ("High `dp` … highest throughput; higher `tp` … lower latency, saturates faster" `docs/inference.md:73`).
+
+### 3.2 Weight sync mechanics
+
+Two transports (discriminated union, trainer.py:454-490):
+
+- **`filesystem`** (default): trainer writes full HF-format weights to `<output>/broadcasts/step_N/` + `STABLE` marker each step (`trainer/rl/broadcast/filesystem.py:38-104`), orchestrator's `WeightWatcher` polls (1 s interval) and POSTs `/update_weights` to every inference server (`orchestrator/watcher.py:49-114`). Old broadcast dirs are GC'd (`filesystem.py:111`). LoRA: merged weights written, adapter loaded under a fresh name (`max_cpu_loras=100` exists because of this).
+- **`nccl`**: trainer rank-0 joins a `StatelessProcessGroup` of size `1 + inference_world_size` and broadcasts the state dict **layer-by-layer**, dtype-grouped and flattened (`trainer/rl/broadcast/nccl.py:34-110,141-162`), with optional **FP8 kernel-format quantized transfer** (`quantize_in_weight_transfer`, used for GLM-5 FP8 rollouts; gated to `nccl` + custom impl, rl.py:263-277). The final broadcast is skipped when it would have no receiver (train.py:262-275).
+
+### 3.3 Staleness control (their "async_level")
+
+Two mechanisms, both orchestrator-side:
+
+1. **Hard pipeline lead — `TARGET_LAG = 1` (constant, not user-configurable)**: "Maximum batches the orchestrator may run ahead of the trainer" (`orchestrator/orchestrator.py:106-109`). `update_dispatch_gate()` computes `lead = (progress.step + 1) - policy.version` and pauses the dispatcher (an asyncio Event) when `lead > 1`; resumed when the watcher advances the policy (`orchestrator.py:816-833`). This pins the pipeline to exactly one-step-off-policy *at the batch level* — documented as "asynchronous by default … inference is exactly one step behind the trainer" (`docs/algorithms.md:25-35`).
+2. **Per-rollout staleness — `max_off_policy_steps = 8` (user knob)**: each weight update bumps `off_policy_steps` on every in-flight rollout; groups exceeding the limit are cancelled mid-flight and re-queued as errors (`orchestrator/dispatcher.py:262-283`, drop logic :568-641). This is the dial for long agentic rollouts that span many policy versions ("bump for throughput, lower for tighter on-policyness", `docs/training.md:61`). Examples set 8 (math, 32k ctx) vs **16** (SWE agentic, 128k ctx).
+
+Supporting machinery: rollout groups pin a single inference client for prefix-cache reuse with a `cache_salt = policy_version` so caches invalidate on weight update (dispatcher.py:392-417); KV-cache-friendly sticky routing via `X-Session-ID: trajectory_id` header + `consistent_hash` router policy (orchestrator.py:729-733, docs/inference.md:177-188); the trainer-side loss compensates for staleness via importance-ratio clipping + mismatch-KL regularization with `mismatch_kl` as the monitored early-warning metric (docs/algorithms.md, docs/training.md:117).
+
+**None of the async split is auto-tuned.** The implicit feedback loop is human: `time/wait_for_batch` high → orchestrator (inference) is the bottleneck, `time/wait_for_ckpt` high → trainer is the bottleneck (`docs/training.md:122-127`).
+
+---
+
+## 4. Sequence packing / variable-length micro-batching (RL trainer)
+
+This is prime-rl's core throughput design and the answer to "how do micro-batches form from variable-length rollouts":
+
+1. **Trainer-side packer, master rank only.** The orchestrator ships raw variable-length `TrainingSample`s (prompt/completion token ids, logprobs, masks). The trainer's rank-0 `Packer` (`src/prime_rl/trainer/rl/packer.py`) converts them into per-DP-rank micro-batch lists and fans them out via the micro-batch transport.
+2. **Token-budget step sizing (multi-run mode)**: a step is ready when buffered tokens ≥ `token_budget = seq_len * dp_world_size` (`packer.py:224-228,296`); samples are selected round-robin across runs up to the budget (`packer.py:230-267`). Single-run mode packs the orchestrator's whole batch as one step (`packer.py:92-115`).
+3. **Bin packing = First-Fit-Decreasing**: `packed_samples_into_micro_bs` sorts samples by `(lora_idx, -length)` and FFD-packs them into bins of capacity `seq_len` — "minimize potential padding while never truncating" (`src/prime_rl/trainer/batch.py:144-214`). Each bin becomes one micro-batch of shape `[1, packed_len]` (sample count per bin is variable); position_ids restart per sample inside the bin and downstream attention uses `cu_seqlens` derived from position-id resets (`src/prime_rl/utils/sequence.py:6-35`, flash-attn varlen). Per-token temperatures let mixed-temperature samples share a bin (batch.py:152). Multimodal samples are never packed (one sample = one micro-batch, batch.py:163-167).
+4. **Padding is minimal and purposeful**: bins are padded only to `pad_to_multiple_of = cp` (DataLoader wiring `trainer/rl/train.py:233-241`, `pad_micro_batch` batch.py:217-259); CP additionally requires `seq_len % (2*cp) == 0` (`parallel_dims.py:262-266`).
+5. **DP distribution + FSDP lockstep**: micro-batch count is padded to a multiple of `num_train_workers` with zero-loss dummy batches, multimodal and text bins are grouped so all ranks see the same modality at each accumulation index (FSDP all-gather hang avoidance), then dealt round-robin (`batch.py:270-320`).
+6. **Implicit gradient accumulation**: the trainer just iterates `for micro_step, micro_batch in enumerate(micro_batches)` calling `loss.backward()` each time, one optimizer step per orchestrator batch (`trainer/rl/train.py:370-491,555`). Accum depth per step ≈ `total_batch_tokens / (seq_len * dp_world_size)` — emergent, never configured.
+7. **Global token-mean loss normalization**: loss is divided by the *global* (all-reduced over dp×cp) unmasked-token count, then FSDP's per-rank gradient averaging is undone by multiplying grads by `fsdp_gradient_divide_factor = dp_replicate*dp_shard*cp` (`train.py:353-361,537-541`; `parallel_dims.py:253-255`) — so unevenly-packed ranks don't skew the gradient.
+8. **Orchestrator-side token batching option**: `token_batch_size` makes the *step* itself token-defined — the sink cuts a cohort when cumulative `final_input_tokens + final_output_tokens` crosses the threshold (`orchestrator/train_sink.py:254-267`, readiness check :140-148). Pairs naturally with the token-budget packer; requires explicit `max_inflight_rollouts`.
+9. **Sample-size guard**: the packer evicts runs that ship samples exceeding `seq_len` or with inconsistent mask/logprob lengths (`packer.py:149-184`); `prepare_sample` truncates to `seq_len` as last resort (batch.py:80-94).
+
+SFT packing is simpler: stream-pack documents into `seq_len * micro_batch_size` windows via `CatDataset` (concat, default) or `StackDataset` (`trainer/sft/data.py:349-377,609-614`).
+
+---
+
+## 5. FSDP2 usage and exposed knobs
+
+Setup in `setup_fsdp` (`src/prime_rl/trainer/model.py:608-714`), per-transformer-block `fully_shard` (FSDP2):
+
+- **MixedPrecisionPolicy hardcoded**: `param_dtype=torch.bfloat16`, `reduce_dtype` from config (default fp32) (model.py:609). Master weights kept in `optimization_dtype` (default fp32).
+- **Offload**: `CPUOffloadPolicy(pin_memory=True)` iff `fsdp_cpu_offload` (model.py:610) — enabling it also turns on a gloo group for distributed ops (`train.py:111-113`). Separately, `optim_cpu_offload` keeps params on GPU and offloads only optimizer state (`trainer/optim.py`).
+- **`reshard_after_forward`** is user-exposed (default True) and applied per block and to the root (model.py:615,680); the **lm_head+final-norm group is always `reshard_after_forward=False`** as a last-layer optimization, skipped when embeddings are tied (model.py:654-673).
+- **HSDP**: `dp_replicate > 1` builds an `hsdp` mesh `(dp_replicate, dp_shard_cp)` (`parallel_dims.py:143-151,196-203`); multi-node convenience knob `nodes_per_fsdp_group` derives `dp_replicate` (§2.6).
+- **EP integration**: MoE expert modules are sharded on a separate `dp_shard_mod_ep` mesh (`ep` borrows from `dp_shard×cp`, constraint `ep % cp == 0 && (dp_shard*cp) % ep == 0`, parallel_dims.py:72-74; mesh build :82-152); with EP, FSDP forward/backward prefetch lists are wired manually because DeepEP d2h syncs break automatic prefetch (model.py:683-714).
+- **CP**: ring (ring-flash-attn substitution) or ulysses (all-to-all head-sharding; works with any kernel incl. mamba/linear-attn) (`train.py:188-216`, trainer.py:161-162).
+- Activation checkpointing full/selective per `freq`-th layer with fine-grained `targets`; activation *offloading* is a separate stream-overlapped CPU offload bounded by `max_inflight_activations` (`utils/act_offloading.py`, wrapped around forward `train.py:439`).
+
+Doc summary table of the four FSDP knobs + tradeoffs: `docs/scaling.md:82-89`; AC table :116-137 (full AC ≈ −25% throughput; selective small; ac_offloading "−30-40% peak memory for ~3-5% throughput"); the layered "memory-tight recipe" (`docs/scaling.md:168-189`) is their canonical knob ordering: **FSDP+EP shard weights → CP shards activations → AC+offload shrink activations → fused-LM-head chunks the loss → compile reduces fragmentation → optimizer offload moves Adam state to CPU**.
+
+---
+
+## 6. Implicit sizing tables: example configs keyed to hardware
+
+`examples/` is the canonical, maintained set (`docs/configuration.md:170`); `configs/` is internal/CI. The progression *is* their sizing table:
+
+| Example | Model | seq_len | Deployment (H100/H200-class nodes) | Trainer parallelism / memory knobs | Orchestrator | Inference |
+|---|---|---|---|---|---|---|
+| `reverse_text/rl.toml` | Qwen3-0.6B | 2k | 1 train + 1 infer GPU (default) | none | bs 128, gs 16 | defaults |
+| `alphabet_sort/rl.toml` | Qwen3-4B | 2k | 1 GPU each | LoRA r32, full AC | bs 512, gs 8 | defaults |
+| `wiki_search/rl.toml` | Qwen3-4B | 4k | **2 train + 6 infer GPUs** | LoRA r8 | bs 512, gs 16, oversampling 2.0, zero-adv filter enforced | dp 6 (implied) |
+| `configs/deepscaler/stage1.toml` | R1-Distill-1.5B | 8k | 2 train + 6 infer GPUs | full AC | bs 1024, gs 8 | dp = 6 |
+| `examples/multinode/rl.toml` | Qwen3-30B-A3B | 2k | 1 train + 1 infer node | custom impl, fa3, **optim_cpu_offload**, AC freq 1 + offload(5) | bs 512, gs 16 | tp 4, dp 2; NCCL broadcast |
+| `qwen30b_math/rl.toml` | Qwen3-30B-A3B | **32k** | 2 train + 2 infer nodes | **ep 8**, fa3, compile, AC freq 1 + offload(5) | bs 512, oversampling 2, off-policy 8 | **tp 8**; NCCL |
+| `qwen30b_swe/rl.toml` | Qwen3-30B-A3B | **128k** | 2 train + 2 infer nodes | ep 8 + **cp 2**, fa3, compile, AC+offload | bs 512, oversampling 2, **off-policy 16** | tp 8; NCCL |
+| `Intellect-3.1/rl.toml` | INTELLECT-3-Base (GLM-4.5-355B-A32B-based) | 128k | **4 train + 12 infer nodes** | ep 8 + cp 2, fa3, compile, AC+offload, **fused_lm_head 1024**, muon | **bs 2048**, oversampling 2, zero-adv enforced | tp 8; NCCL |
+| `minimax_m2.5_swe/rl.toml` | MiniMax-M2.5-bf16 | 128k | 4 train + 12 infer nodes | ep 8 + **cp 4**, fa3, fused_lm_head 1024, compile, AC+offload | bs 2048, oversampling 2, off-policy 16 | tp 8; NCCL |
+| `glm5_pd_disag/rl.toml` | GLM-5 (trainer bf16) / **GLM-5-FP8 (rollouts)** | 128k | **16 train + 2×8 infer nodes**, P/D disagg (4 prefill + 4 decode per replica) | ep 8, fused_lm_head **2048**, **optim_cpu_offload**, AC freq 1 + offload(**1**), compile, skip_optimizer ckpt, dist_timeout 7200 | **bs 4096, gs 16, oversampling 3, off-policy 16** | EP on, **gpu_memory_utilization 0.80** ("glm5 layers are too large for 0.85"), deep_gemm, **fp8 quantized NCCL weight transfer** |
+| `configs/nemotron_4node/rl.toml` | Nemotron-3-Super-120B-A12B | 2k | 4 train + 4 infer nodes | ep 8, optim_cpu_offload, fused_lm_head 8192, AC+offload, compile | bs 128, gs 8 | tp 8, dp 1 |
+
+Extracted pattern (the implicit auto-config policy):
+
+- **Trainer:infer GPU ratio** rises with workload decode-heaviness: 1:1 (toy) → 1:3 (single-node 4B multi-turn) → 1:1 (30B math/SWE) → **1:3 (355B+ 128k agentic)**; GLM-5 P/D run is 1:1 because the FP8 rollout engine is cheap relative to the bf16 trainer.
+- **Inference TP** scales with model size: ≤4B → tp1 (pure DP fill); 30B-A3B → tp4–8; 120B+ → tp8 (= full node), capacity then added as DP/replicas/EP-wide rather than deeper TP.
+- **Trainer memory ladder** tracks model×context: dense small → nothing; ~30B MoE → custom impl + EP8 + full AC + activation offload (+compile); +long context → CP 2–4; ≥120B or 128k → + fused LM head (1024–8192 chunk; *smaller* chunk for bigger vocab/ctx pressure) and/or optimizer CPU offload; extreme (GLM-5) → everything, with `max_inflight_activations` dropped to 1.
+- **Off-policy tolerance** 8 for single-turn/math, 16 for long agentic; `oversampling_factor` 2–3 on every serious run (over-provision rollouts so batch assembly never starves on stragglers; stragglers are cancelled by the off-policy cap).
+- **Prefill-vs-decode shaping** appears only at the extreme end as P/D disaggregation with role-split all2all backends + optional Mooncake shared KV pool; below that, the knobs are prefix-cache stickiness + KV offload.
+- **vLLM `gpu_memory_utilization`** is left at 0.9 everywhere except explicitly lowered for huge-layer models (0.80 for GLM-5).
+
+### Benchmark baselines = empirical hardware table
+
+`benchmarks/baselines/` holds ~60 JSON results named `benchmark-{1xa6000|1xh100|4xa6000|8xh100|8xh200|8xb200}-{model}-{rl|sft}-{lora-rank|full}-{ac-mode}-{attn}-{seq_len}-cp{N}-ep{N}.json`, each containing config (`num_gpus`, `lora_rank`, `seq_len`, `ac`, `micro_batches`, `device_name`) and measured `mfu`/`throughput`/`step_time`/`peak_memory{gib,pct}`, with OOM captured in `error_reason`. The harness (`benchmarks/scripts/run_single_benchmark.py`) sweeps {model × GPU type × seq_len 16k/64k × AC Recompute/Offload × LoRA/full}. This is the closest thing in the repo to a machine-readable (GPU, model, ctx) → (throughput, peak-mem) sizing table, and `--bench` (4 steps fake data, prints MFU/peak-mem table; `docs/scaling.md:255-275`, auto-setup trainer.py:597-605) is the prescribed manual fitting loop: "compare parallelism configs before committing a multi-day run."
+
+Also relevant: a per-GPU **peak-BF16-FLOPS lookup table** used for MFU (A100 312T, H100 SXM 989T / PCIe 756T / NVL 835T, B200 2.25P, MI300X/MI325X 1307.4T; fallback A100 with warning) at `src/prime_rl/trainer/perf.py:74-106`, plus an architecture-aware active-params/FLOPs-per-token estimator handling GQA/MLA/MoE/LoRA (`perf.py:108-210`) — reusable building blocks for analytic auto-sizing.
+
+---
+
+## 7. Misc relevant details
+
+- **Doc rules of thumb** (`docs/training.md:322-328`): batch_size ≥ 64 floor, 128–512 ablation range, "production RL often runs at 1024+"; group_size ≥ 8 floor, 16–32 common.
+- **Renderer pool** `orchestrator.pool_size` for client-side tokenization serialization on long multi-turn prompts (orchestrator.py:522-525).
+- **Router replay** (MoE): vLLM returns routed-expert ids per token; trainer replays them instead of re-routing, cutting trainer↔inference mismatch "by an order of magnitude" (`docs/inference.md:253-269`; trainer flag trainer.py:538, cross-auto-set rl.py:421-436); incompatible with KV offload (rl.py:438-449).
+- **Elastic inference pools**: DNS-based discovery (`ClientConfig.elastic`, shared.py:91-99,136-141) — inference capacity can grow/shrink without config changes (this is their answer to "how many inference replicas": make it elastic rather than computed).
+- **Transports**: rollouts orchestrator→trainer via filesystem (default) or ZMQ (`hwm=10` backpressure); micro-batches packer→ranks similarly (`src/prime_rl/transport/`).
+- **Packer watchdog**: rank-0 packer kills the process after 30 min without progress to trigger external restart (`packer.py:23-24,63-71`).
+- **Trainer step metrics** logged every step: throughput tokens/s, MFU, `peak_memory` (GiB), time breakdown incl. `wait_for_batch` (train.py:575-606,627-637) — the observability that substitutes for auto-tuning.
+- For multi-tenant serving of many concurrent LoRA runs there is `max_concurrent_runs` + `MultiPacker` round-robin fair token scheduling across runs with per-run eviction (packer.py:118-335).
+
+## 8. Takeaways for an auto-config design (AgileRL context)
+
+1. prime-rl shows that an async stack can ship with **zero memory-model**: they replace it with (a) hard validator arithmetic for everything topological, (b) a cheap standardized `--bench` probe + persisted baselines per (GPU, model, seq_len, AC, LoRA) cell, and (c) a curated example ladder. An auto-sizer could literally consume their baselines JSON schema.
+2. The strongest transferable mechanism is **token-budget packing replacing micro_batch_size/grad-accum entirely** (budget = `seq_len × dp_world`, FFD bins, global-token-count loss normalization with FSDP divide-factor correction). This makes trainer memory ~independent of rollout length distribution — the #1 thing that makes per-workload micro-batch auto-sizing unnecessary.
+3. Staleness needs only two knobs: a hard pipeline lead (their fixed `TARGET_LAG=1`) and a per-rollout `max_off_policy_steps` (8/16 by workload). Both gate the *dispatcher*, not the trainer.
+4. The GPU split (trainer:inference, TP depth, replica count) is the one thing they leave fully manual — their example ladder (§6 pattern) is the de-facto heuristic an auto-config tool would encode: ratio by decode-heaviness, TP by model size capped at one node, then DP/replicas, then EP-wide/P-D at the extreme.
+5. Knob *ordering* for memory fitting is explicitly documented (memory-tight recipe) and is a ready-made search order for an OOM-driven descent: EP/FSDP → CP → AC → AC-offload → LM-head chunk → compile → optimizer offload → fsdp_cpu_offload.

--- a/.research-reports/single-gpu-ft-libs.md
+++ b/.research-reports/single-gpu-ft-libs.md
@@ -1,0 +1,396 @@
+# Auto-sizing mechanisms in the single-GPU FT lib + FT-zoo lib
+
+**Slice:** the two single-GPU finetuning libraries (referred to throughout as **the FT lib** — the main training package with `models/`, `kernels/`, `studio/` — and **the FT-zoo lib** — its utility companion package). Both were read at local clones under `~/git/Misc/` (read-only). Naming note: per repo policy the project name is never written here; in file references below, `[zoo]/` means the FT-zoo lib's package root, `[ft]/` means the FT lib's package root, and `[studio]/` means the FT lib's `studio/backend/` tree. Env vars and identifiers that embed the project name are written with the placeholder `<FTLIB>` / `<ftlib>` (uppercase/lowercase project prefix).
+
+These libraries are the state of the art at fitting LLM-RL training **and** a vLLM rollout engine on one GPU (colocated, time-sliced). Their key architectural premise, which everything below assumes: **vLLM is loaded first, then the HF training model is constructed from references to vLLM's own weight tensors** (zero-copy; `get_vllm_state_dict` slices vLLM's fused projections back into HF layout — `[zoo]/vllm_utils.py:945-1064`, consumed in `[ft]/models/llama.py:2569-2580`). So weight memory is paid once, and the auto-sizing problem reduces to splitting the *rest* of VRAM between (a) vLLM KV cache + CUDA graphs and (b) trainer-side LoRA/optimizer/activations.
+
+---
+
+## 1. The master memory formula: `approximate_vllm_memory_usage`
+
+`[zoo]/vllm_utils.py:1487-1601`. Inputs: HF config, quantization flags, `max_seq_length`, requested `gpu_memory_utilization`, LoRA config, fp8-KV flag, `account_for_gradients` (= `training`), and two structural knobs (`parallel_sequences=64` is accepted but unused; `cuda_graph_overhead=True`). Returns `(max_num_batched_tokens, approx_max_num_seqs, actual_gpu_memory_utilization, memory_left_for_kv_cache_gb)`.
+
+### 1.1 Budget basis: fraction of *free* memory, not total
+
+```python
+free_memory, total_memory = get_mem_info()          # torch.cuda.mem_get_info()
+free_memory = gpu_memory_utilization * free_memory  # [zoo]/vllm_utils.py:1504-1506
+...
+actual_gpu_memory_utilization = free_memory / total_memory   # :1557
+```
+
+The user-facing `gpu_memory_utilization` (default 0.5 in `from_pretrained`) is interpreted as a fraction of **currently-free** VRAM, then converted into the fraction-of-total number vLLM actually wants (`actual_gpu_memory_utilization`), which is what gets passed as the engine arg (`[zoo]/vllm_utils.py:2199`). This makes the knob composable with whatever is already resident.
+
+### 1.2 Model-weight element counts (per config)
+
+`[zoo]/vllm_utils.py:1508-1524`:
+
+```python
+vocab_size = config.vocab_size
+hd  = config.hidden_size
+mlp_size = config.intermediate_size
+n_layers = config.num_hidden_layers
+n_kv_heads = getattr(config, "num_key_value_heads", 1)
+n_heads    = getattr(config, "num_attention_heads", 1)
+kv_size = hd // n_heads * n_kv_heads          # GQA-aware
+
+qkvo = (hd + kv_size + kv_size + hd) * hd     # per-layer attn elements
+mlp  = (hd * mlp_size) * 3                    # gate/up/down
+layernorms = 2 * hd
+embed_tokens = vocab_size * hd
+lm_head = 0 if tie_word_embeddings else vocab_size * hd
+```
+
+### 1.3 LoRA adapter elements (vLLM-side LoRA slots)
+
+`[zoo]/vllm_utils.py:1526-1535` — assumes LoRA on **all** of QKVO + MLP at `max_lora_rank`, times `max_loras`, **2 bytes (fp16)**:
+
+```python
+qkvo_A = hd * max_lora_rank * 4
+qkvo_B = max_lora_rank * (hd + kv_size + kv_size + hd)
+mlp_A  = hd * max_lora_rank * 2 + mlp_size * max_lora_rank
+mlp_B  = max_lora_rank * (mlp_size + mlp_size) + max_lora_rank * hd
+lora_elements = (qkvo_A + qkvo_B + mlp_A + mlp_B) * max_loras * n_layers * 2
+```
+
+(Two follow-on lines compute `gradient_lora_elements = 2×lora` and `parameter_lora_elements = 4×lora` for 8-bit-Adam state + fp32 master copy — `:1537-1541` — but they are **dead code**: never added to the budget. The training-side reservation is done purely via the activation term below.)
+
+### 1.4 Trainer activation reservation (the colocated "tax")
+
+`[zoo]/vllm_utils.py:1543-1556` — when `account_for_gradients=True` (i.e. `training=True`), a fixed-shape activation peak is estimated at **bsz=2** and `max_seq_length`:
+
+```python
+bsz = 2
+activation_qkv  = max_seq_length * bsz * (hd + kv_size + kv_size)
+residual_memory = (max_seq_length * bsz) * 2
+activation_mlp  = max_seq_length * bsz * (mlp_size + mlp_size)
+weights = mlp_size * hd                       # one layer's MLP weight as workspace proxy
+maximum_activation = (activation_qkv + residual_memory + activation_mlp + weights) * 1.25 * 2   # +25% slack, fp16
+if total_memory - free_memory < maximum_activation:
+    free_memory = total_memory - maximum_activation
+```
+
+i.e. *if the currently-used headroom is smaller than the projected training-activation peak, shrink vLLM's budget so that the peak fits*. Context length enters linearly here. This is a **single-layer** activation model — it implicitly assumes their offloaded gradient checkpointing (Section 7) keeps only ~1 layer of activations live.
+
+### 1.5 Quantization bytes-per-param factors
+
+`[zoo]/vllm_utils.py:1559-1567`:
+
+```python
+total_quantizable_elements = (qkvo + mlp) * n_layers * 2          # fp16 bytes
+total_float16_elements     = (layernorms + embed_tokens + lm_head) * 2
+factor = 1
+if load_in_4bit:   factor = 16/5    # = 3.2  (≈ 0.625 byte/param: nf4 + blockwise scales; "should be 4.5 but use 5")
+elif load_in_8bit: factor = 8/5     # = 1.6  ("very vague approximation")
+bytes_for_model = total_quantizable_elements / factor + total_float16_elements + lora_elements
+```
+
+Note `load_in_8bit` is overloaded: `load_vllm` passes `is_fp8` into it (`[zoo]/vllm_utils.py:1871`), so fp8 checkpoints are sized with the same 8/5 factor.
+
+### 1.6 KV-cache sizing and derived limits
+
+`[zoo]/vllm_utils.py:1569-1600`:
+
+```python
+float_bytes = 1.25 if float8_kv_cache else 2          # fp8 KV ≈ 1 byte + scale overhead
+kv_elements = (kv_size * 2 * n_layers) * float_bytes  # bytes per token of KV
+memory_left_for_kv_cache = free_memory - bytes_for_model
+
+# CUDA-graph overhead reservation (FULL_AND_PIECEWISE + LoRA ≈ 172 graphs)
+if cuda_graph_overhead:
+    num_cuda_graphs = 172          # "51 sizes x 2 lora + 35 x 2 decode"
+    per_graph_estimate = hd * n_layers * 4
+    _cuda_graph_overhead = num_cuda_graphs * per_graph_estimate
+    _cuda_graph_overhead = max(_cuda_graph_overhead, int(0.15 * 1024**3))   # floor 0.15 GiB
+    _cuda_graph_overhead = min(_cuda_graph_overhead, int(1.0  * 1024**3))   # cap 1.0 GiB
+    memory_left_for_kv_cache -= _cuda_graph_overhead
+
+max_num_batched_tokens = int(0.95 * (memory_left_for_kv_cache / kv_elements))  # 5% safety
+max_num_batched_tokens = (max_num_batched_tokens // 256) * 256                 # round down to 256
+approx_max_num_seqs = int(max_num_batched_tokens / max_seq_length)             # worst case: every seq at full length
+```
+
+So: **KV token capacity = 0.95 × (budget − weights − LoRA − cudagraphs) / (2·kv_size·n_layers·bytes)**, and the theoretical concurrent-sequence count assumes each request occupies `max_seq_length` tokens — a deliberately pessimistic decode-heavy assumption.
+
+### 1.7 How the analytical numbers are actually used
+
+Important subtlety in `load_vllm` (`[zoo]/vllm_utils.py:1866-1910, 2048-2059`): the *analytical* `max_num_batched_tokens` / `approx_max_num_seqs` are used only to (a) compute `memory_left_for_kv_cache_gb`, (b) clamp `max_seq_length` down when the GPU can't hold even one full sequence:
+
+```python
+if max_num_batched_tokens <= 0:
+    max_seq_length = 256; max_num_batched_tokens = 256
+if max_num_batched_tokens <= max_seq_length:
+    print("...Your GPU cannot handle sequence lengths of {max_seq_length}...")
+    max_seq_length = max_num_batched_tokens          # [zoo]/vllm_utils.py:1900-1909
+```
+
+— and then both are **overwritten by an empirical tier table keyed on KV-cache GB headroom** (Section 2.2). The analytic formula picks the regime; lookup tables pick the engine knobs.
+
+---
+
+## 2. `load_vllm`: the full auto-configuration pipeline
+
+`[zoo]/vllm_utils.py:1741-2373`. Signature defaults worth recording (`:1741-1767`): `gpu_memory_utilization=0.8`, `max_seq_length=8192`, `enable_lora=True`, `max_lora_rank=16`, `max_loras=1`, `enable_prefix_caching=True`, `compilation_config=3`, `conservativeness=1.0`, `max_logprobs=0` (logprob returns disabled to save memory), `max_num_seqs=256`, `enforce_eager=False`, `float8_kv_cache=False`. The FT lib's user-facing loaders default to `gpu_memory_utilization=0.5` and `max_lora_rank=64` (`[ft]/models/loader.py:262,265`) or `max_lora_rank=16` at the model-class level (`[ft]/models/llama.py:2224-2227`).
+
+### 2.1 Standby-mode GPU-utilization targets (total-VRAM-keyed tiers)
+
+When standby (sleep-mode time-slicing) is enabled, the lib **overrides the user's `gpu_memory_utilization` in both directions** to a per-GPU-size target (`[zoo]/vllm_utils.py:1778-1829`). Tiers are keyed on `ten_percent = 0.1 × total_GB`:
+
+For vLLM ≥ 0.11 (`:1795-1815`):
+
+```python
+if   ten_percent >= 4.0: standby_target_gpu_util = 0.925   # ≥ 40 GB GPUs
+elif ten_percent >= 2.5: standby_target_gpu_util = 0.9     # 25–40 GB
+elif ten_percent >= 2.0: standby_target_gpu_util = 0.825   # 20–25 GB (L4/4090 class)
+elif ten_percent >= 1.4: standby_target_gpu_util = 0.8     # 14–20 GB (T4 class)
+elif ten_percent >= 1.0: standby_target_gpu_util = 0.775   # 10–14 GB
+else:                    standby_target_gpu_util = 0.75
+standby_target_gpu_util *= 0.95     # extra headroom: "vLLM ≥0.11 uses more"
+```
+
+(So an A100-40GB lands at 0.925×0.95 ≈ **0.879**; a 24 GB card at ≈ 0.784.) For vLLM < 0.11 a slightly lower table is used (0.9 / 0.875 / 0.85 / 0.825 / 0.8 / 0.75 / 0.7, `:1785-1794`). The override is bidirectional — too-low user values are raised ("Standby mode is enabled. Changing gpu_memory_utilization"), too-high values are lowered ("your setting ... will OOM") (`:1820-1829`) — escape hatch env `<FTLIB>_VLLM_STANDBY_UTIL_OVERRIDE` (`:1776`). The comment block at `:1796-1803` documents *why* the ≤24 GB tiers were lowered: vLLM reserves `util × 0.95 × total` for weights+KV; the remainder must fit the HF training side, and an 8B model in 4-bit needs ~4–5 GB for weights alone, otherwise `wake_up(tags=["kv_cache"]) → create_and_map` fails at the CUDA VMM level with `cudaErrorIllegalAddress`.
+
+Pre-flight guard: if the analytic KV headroom is < 1 GB under standby, it warns before constructing `LLM()` ("may crash unrecoverably") (`:1881-1887`).
+
+### 2.2 `max_num_seqs` / `max_num_batched_tokens` tier table (KV-GB-keyed)
+
+`[zoo]/vllm_utils.py:2048-2059`, preceded by an in-source benchmark table (`:2029-2047`) showing non-KV memory vs `max_num_seqs` ("after max_num_seqs ≥ 64 we see linear increase in memory usage": 8.31 GiB at 64 → 9.14 at 256 → 18.80 GiB at 2048 for an 8B model):
+
+```python
+approx_max_num_seqs = max_num_seqs   # vLLM default 256
+max_num_batched_tokens = 2048        # vLLM default
+if   kv_gb <=  2: tokens, seqs = 2048, 8
+elif kv_gb <=  4: tokens, seqs = 2048, 16
+elif kv_gb <=  8: tokens, seqs = 4096, 32
+elif kv_gb <= 12: tokens, seqs = 4096, 48
+elif kv_gb <= 16: tokens, seqs = 6144, 64
+elif kv_gb <= 24: tokens, seqs = 6144, 80
+elif kv_gb <= 40: tokens, seqs = 8192, 96
+elif kv_gb <= 48: tokens, seqs = 8192, 112
+elif kv_gb <= 80: tokens, seqs = 8192, 128
+else:             tokens, seqs = 8192, 256
+```
+
+In vLLM V1, `max_num_batched_tokens` *is* the chunked-prefill token budget per scheduler step, so this table is effectively the **prefill-chunk size schedule**. A second, finer `chunked_prefill_tokens` table exists (`:2076-2085`: 1024/1536/2048/3072/4096/4608/8192 over the same GB tiers) but is immediately overwritten with `chunked_prefill_tokens = max_seq_length` (`:2088`, "vLLM errors out from max_seq_length being bigger than chunked_prefill_tokens") and afterwards is only printed, never passed to the engine — the engine receives the 2048–8192 table value.
+
+Modifiers:
+- **Vision models**: `approx_max_num_seqs = 1`, `max_num_batched_tokens = max(8192, max_seq_length)` (each sequence may carry a multi-thousand-token image; `:2061-2070`), plus `limit_mm_per_prompt = {"image": 1, "video": 0}` (`:2229-2232`).
+- **fp8 KV cache**: `approx_max_num_seqs ×= 1.05` (`:2072-2073`).
+- **`conservativeness`** ∈ [0,1] linearly scales `approx_max_num_seqs` (floor 1) for low-VRAM devices (`:2090-2092`).
+
+### 2.3 Swap space (host-RAM-keyed)
+
+`[zoo]/vllm_utils.py:2094-2104`: `swap_space = 0` for ≤16 GB available host RAM, 2 GB for ≤24, 4 GB for ≤48, else 6 GB.
+
+### 2.4 Engine args actually emitted
+
+`[zoo]/vllm_utils.py:2197-2228`:
+
+```python
+engine_args = dict(
+    model=..., gpu_memory_utilization=actual_gpu_memory_utilization,
+    max_model_len=max_seq_length,
+    quantization="bitsandbytes" if use_bitsandbytes else None,
+    load_format="bitsandbytes" if use_bitsandbytes else "auto",
+    kv_cache_dtype="fp8" if float8_kv_cache else "auto",
+    dtype=dtype,                      # bf16 on cc≥8.0/HIP/XPU else fp16 (:1912-1928)
+    max_num_batched_tokens=max_num_batched_tokens,
+    max_num_seqs=approx_max_num_seqs,
+    max_logprobs=max_logprobs,        # 0: disallow logprob returns
+    seed=random_state,
+    enable_lora=enable_lora, max_lora_rank=max_lora_rank, max_loras=max_loras,
+    enable_prefix_caching=enable_prefix_caching,
+    enable_chunked_prefill=enable_chunked_prefill,   # True except mllama
+    compilation_config=compilation_config,
+    enforce_eager=enforce_eager,
+    swap_space=swap_space,
+    enable_sleep_mode=<ftlib>_vllm_standby,
+)
+```
+
+Unknown keys are stripped against `inspect.signature(EngineArgs)` for cross-version safety (`:2275-2282`).
+
+Hardware-conditional extras:
+- **Cascade attention disabled** on cc < 9 with vLLM < 0.11 — flagged `[[CRITICAL for RL on policy]]`; cascade attention on A100/L40 corrupted on-policy sampling (`:2234-2249`).
+- **`block_size=32`** on Blackwell (cc ≥ 10) when `head_dim ≥ 256` to dodge a FlashInfer bug (`:2251-2260`).
+- **LoRA rank rounded up** to vLLM's supported set (`{8,16,32,64,128,256,320,512}`, introspected from vLLM source at runtime) via `determine_max_lora_rank` (`[zoo]/vllm_utils.py:1604-1637`).
+- **FlashInfer backend selection** with nvcc/ninja pre-flight, per-model support introspection (regex over the vLLM model source for attention-backend guards), `VLLM_USE_FLASHINFER_SAMPLER=1` on cc ≥ 8 (`:1941-1997`); `VLLM_USE_DEEP_GEMM=0` for fp8 on cc 10 (slower than triton, `:1856-1862`).
+- **Prefix caching disabled** on cc < 7.5 (`:2000-2010`).
+- On-the-fly **fp8 quantization** via torchao for vLLM ≥ 0.12 (`fp8_mode="row"|"block"` → `quantization="torchao"` + `hf_overrides` carrying a serialized `Float8DynamicActivationFloat8WeightConfig`, `:2263-2273`, config builder `:1717-1738`).
+
+### 2.5 CUDA-graph / compile configuration
+
+`compilation_config=3` expands into a `CompilationConfig` (`:2126-2195`): inductor backend, `cudagraph_num_of_warmups=1`, `use_cudagraph=True`, `cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE` when available; explicit `cudagraph_capture_sizes` / `max_capture_size` are deliberately left to vLLM defaults (commented out, `:2149-2151`). They do **not** shrink the capture-size list — instead they *budget* for it via the 172-graph reservation in the memory model (Section 1.6). `max_autotune`/`coordinate_descent_tuning` are off ("too slow"); combo kernels disabled below 80 GB GPUs (`:2135-2140`). GC is suppressed during graph capture for speed (`patch_vllm_graph_capture`, `:700-777`).
+
+### 2.6 OOM retry/backoff loop
+
+`[zoo]/vllm_utils.py:2287-2355`: engine construction retries once; on a memory-flavored error it backs off **`max_num_seqs ×= 0.75` and `gpu_memory_utilization ×= 0.85`** and retries. Under standby it never retries (the patched `CuMemAllocator` can't be re-instantiated in-process) and instead raises a `MemoryError` with ranked remediation advice: lower `gpu_memory_utilization` → disable standby → smaller model / 4-bit (`:2307-2320`).
+
+### 2.7 Rollout batching by total VRAM
+
+`generate_batches` (`[zoo]/vllm_utils.py:2632-2666`) splits generation requests so the engine never sees more than a VRAM-dependent slice of `llm.approx_max_num_seqs` (which `load_vllm` stamps on the engine object, `:2357`):
+
+```python
+if   total_memory_gb <=  8: n_batches = llm.approx_max_num_seqs // 10
+elif total_memory_gb <= 16: n_batches = llm.approx_max_num_seqs // 5
+elif total_memory_gb <= 24: n_batches = llm.approx_max_num_seqs // 2
+else:                       n_batches = llm.approx_max_num_seqs
+```
+
+Override env: `<FTLIB>_VLLM_BATCHES` (`:2636`). `create_batches` (`:2376-2385`) is the plain splitter (default 64/req batch).
+
+---
+
+## 3. Standby / sleep-mode time-slicing (sizing-relevant parts)
+
+Mechanism (`patch_vllm_enable_sleep_mode`, `[zoo]/vllm_utils.py:525-697`): `CuMemAllocator.sleep`/`wake_up` are replaced so any allocation tagged `"weights"` is **never** unmapped or remapped — base weights stay resident permanently because the trainer aliases them zero-copy. Everything else (notably the `"kv_cache"` tag and default-tag allocations) is `unmap_and_release`d on sleep; tags listed in `offload_tags` get a pinned-CPU backup first (`:589-614`). `wake_up` re-`create_and_map`s and restores CPU backups (`:617-645`). Net effect of `sleep(1)`: **weights stay on GPU; KV cache + scratch are freed back to the driver** — exactly the freed pool the trainer's optimizer/activations then use.
+
+Enablement & gating: env `<FTLIB>_VLLM_STANDBY=1` (checked in `patch_vllm` `:793-807`; hard version gates: vLLM 0.10.x raises "std::bad_alloc ... insufficient memory headroom", 0.14.x raises "cudaErrorIllegalAddress ... during sleep/wake cycles" — `:794-805`). The model loaders refuse `<ftlib>_vllm_standby=True` without the env var (`[ft]/models/llama.py:2258-2264`, `[ft]/models/vision.py:613-615`).
+
+### Triggers — when sleep/wake actually happens
+
+1. **Auto-wake on generate**: `vllm.LLM.generate` and `AsyncLLMEngine.generate` are wrapped to call `self.wake_up()` first whenever `enable_sleep_mode` is set (vLLM internally no-ops if awake) — `[zoo]/vllm_utils.py:674-691`.
+2. **GRPO trainer source rewrite** (for TRL versions without built-in sleep, i.e. < 0.23): every `self.llm.generate(...)` line in the trainer is wrapped with `wake_up()` before and `self.llm.sleep(os.environ.get('VLLM_SLEEP_MODE', 1))` after — `[ft]/models/rl_replacements.py:881-907`. So the duty cycle is: *wake → generate rollouts → sleep → grad steps → repeat*, with the sleep level controlled by env `VLLM_SLEEP_MODE` (default `1`).
+3. **TRL ≥ 0.23 built-in sleep compatibility**: TRL's `wake_up(tags=["kv_cache"])` is regex-rewritten to bare `wake_up()` ("wakes everything to set is_sleeping=False"; safe because the patched allocator skips weights anyway), and TRL's duplicate `collective_rpc("reload_weights")` is stripped — `[ft]/models/rl_replacements.py:1928-1999`.
+4. **Resume-from-checkpoint guard**: before `trainer.train(resume_from_checkpoint=...)`, the engine is put to sleep (`llm.sleep(1)`) so checkpoint loading has memory — `[ft]/models/rl.py:98-147`.
+5. For TRL configs, when standby env is set the patcher injects `args.vllm_enable_sleep_mode=True` and forces `args.vllm_mode='colocate'` plus `self.llm = model.vllm_engine` (TRL's own `LLM(...)` construction is regex-replaced) — `[ft]/models/rl.py:1907-1931, 2004-2015`.
+
+Sizing logic *around* standby is Section 2.1's tier table; the design contract restated: vLLM gets `util×0.95×total` for weights+KV, and `(1−util×0.95)×total` must cover LoRA params, optimizer states, activations and gradient-checkpoint buffers of the trainer. The allocator patch refuses `expandable_segments:True` in any `PYTORCH_*ALLOC_CONF` (`:536-544`).
+
+---
+
+## 4. Auto batch-size / chunking logic in training
+
+### 4.1 GRPO logprob mini-batch autotune (`autotune_batch_and_chunks`)
+
+`[zoo]/rl_replacements.py:281-330`. GRPO's expensive step is recomputing per-token logprobs over `(rows = bsz·num_generations, seq_len, vocab)`. The autotuner picks the **largest row-count B** whose hidden-state + chunked-logit memory fits in 80% of currently-free VRAM:
+
+```python
+final_m = max(4, seq_len // 4096) if multiplier is None else multiplier   # logit chunk multiplier
+free_bytes, _ = torch.cuda.mem_get_info()
+limit_gb = (free_bytes / 1024**3) * 0.80
+b_vals = arange(total_input_rows, 0, -1)
+hidden_gb = b_vals * seq_len * hidden_size * dtype_bytes / GB
+logits_gb = ((b_vals/total_rows) * b_vals * seq_len * vocab_size * dtype_bytes / GB) / final_m
+ok = (hidden_gb + logits_gb) <= limit_gb
+# first (largest) feasible B wins; if none: return (4, final_m)  ← "your GPU will OOM"
+```
+
+Notes: `dtype_bytes` is passed as 16 for fp16/bf16 (32 for fp32) — `[zoo]/rl_replacements.py:775` — i.e. an ~8× safety factor over the raw element size, absorbing autograd temporaries; the logit term scales *quadratically* in B (the `(B/total)·B` factor) and is divided by the chunk multiplier because logits are materialized `final_m` chunks at a time. The number of logit chunks grows with context (`seq_len // 4096`).
+
+Wiring (`[zoo]/rl_replacements.py:782-810`): runs once per accumulation window (`trainer._has_autotuned` flag), converts B to `args.<ftlib>_grpo_mini_batch = max(1, total_rows//B)` and stores the multiplier; user can pin both via config fields `<ftlib>_grpo_mini_batch` / `<ftlib>_logit_chunk_multiplier` (declared at `[ft]/models/rl.py:452-463`, validated ≤ generation batch at `:477-484`). A second, simpler chunking knob `<ftlib>_num_chunks` (default −1 → per-row chunking, snapped to a divisor of bsz via `factors`/`searchsorted` — `[zoo]/rl_replacements.py:763-766`) controls the fused-loss chunk count.
+
+### 4.2 Selective-log-softmax chunking
+
+All RL logprob computations run through fixed 4-way chunked log-softmax in fp32 (`chunked_selective_log_softmax`, `[zoo]/rl_replacements.py:44-67`) or hidden-states→lm_head chunked matmul (`chunked_hidden_states_selective_log_softmax`, `:70-114`) so the `(rows·seq, vocab)` logits never fully materialize.
+
+### 4.3 Trainer-config batch defaults & constraints (GRPO)
+
+The TRL-config patcher forcibly rewrites dataclass defaults (`[ft]/models/rl.py:1292-1330`): `per_device_train_batch_size=4`, `gradient_accumulation_steps=2`, `optim="adamw_8bit"`, `torch_empty_cache_steps=250`, `num_generations=8`, `vllm_mode="colocate"`, and **`auto_find_batch_size=False`** with the comment "Auto /2 batch size — too many people complained so removing" (`:1318`; re-asserted for GRPO "Cannot work on GRPO", `:1345`). Divisibility guard: `per_device_train_batch_size · grad_accum · world_size` must be a multiple of `num_generations`, else batch size is forcibly set to `num_generations` (`:1454-1486`). `dataset_num_proc` is auto-derived from CPU count and available host RAM (1 proc if <2 GB free; capped at `int(free_GB)`; `:1399-1412`).
+
+### 4.4 Auto sample-packing / padding-free
+
+The FT lib auto-enables padding-free batching for SFT when the user didn't set it (`_should_auto_padding_free`, `[ft]/trainer.py:72-79`), with a model blocklist (`gemma2`, `gpt_oss`; `:60-63`) and env kill-switch `<FTLIB>_DISABLE_AUTO_PADDING_FREE` (`:56-58`) — a token-throughput-per-VRAM optimization rather than a sizing formula, but it changes the effective tokens/step for a given batch size.
+
+---
+
+## 5. The "will it fit" estimator (studio backend)
+
+`[studio]/utils/hardware/vram_estimation.py` (1308 lines) + spec `[studio]/utils/hardware/VRAM_ESTIMATION.md`. This is their most complete predictive model: **Total VRAM = weights + LoRA adapters + optimizer states + gradients + activations + CUDA overhead**, "all constants empirically calibrated against Llama-3.2-1B on B200" (`vram_estimation.py:4-11`).
+
+### 5.1 Constants / bytes-per-param tables
+
+`vram_estimation.py:18-70`:
+
+```python
+QUANT_4BIT_FACTOR = 16 / 5                    # 3.2 — nf4 + blockwise scales
+DOUBLE_QUANT_4BIT_FACTOR = 3.6                # bnb double-quant repos (tighter)
+CUDA_OVERHEAD_BYTES = int(1.4 * 1024**3)      # driver + torch runtime, calibrated RTX 5070 Ti
+NON_FLASH_ATTENTION_FACTOR = 12.0             # eager attn score+workspace multiplier
+
+OPTIMIZER_BYTES_PER_PARAM = {
+    "adamw_8bit": 4,            # "BNB upcasts to fp32 during step"
+    "paged_adamw_8bit": 4, "adamw_bnb_8bit": 4,
+    "paged_adamw_32bit": 8,
+    "adamw_torch": 6,           # "fused, no master copy"
+    "adamw_torch_fused": 6,
+    "sgd": 4,
+}                                # unknown optimizers default to 4 (:1130-1133)
+
+GC_LAYER_MULTIPLIERS = {         # effective live layers under gradient checkpointing
+    "none":   (None, None),      # all L layers
+    "true":   (2.0, 1.0),        # HF GC: full-FT 2.0 layers, LoRA 1.0 layer
+    "<ftlib>": (1.5, 1.0),       # their offloaded GC: full-FT 1.5, LoRA 1.0
+}
+```
+
+Gradients: `trainable_params × 2` bytes (fp16, accumulated in place; `:1136-1137`). LoRA adapters: `lora_params × 2` (`:1126-1127`).
+
+### 5.2 Weights
+
+`compute_model_weights_bytes` (`:913-934`): QLoRA → `quantized_elements × 2 / quant_4bit_factor + skipped_modules × 2 + non_quantizable × 2`; LoRA/full → everything × 2. Element counting handles GQA, MoE (routed + shared experts, dense-layer interleaving via `first_k_dense_replace` / `decoder_sparse_step` / `mlp_layer_types` / `moe_layers`, `:189-241`), MLA low-rank attention (DeepSeek-style `q_lora_rank/kv_lora_rank`, `:795-809`), KV-shared layers, per-layer-input embeddings, double-wide MLPs, tied embeddings, and `llm_int8_skip_modules` exclusions matched against a full alias map of module paths (`:610-772`).
+
+### 5.3 LoRA parameter counting
+
+`compute_lora_params` (`:995-1123`): per selected target module `in_dim·r + r·out_dim`, MoE experts × `num_experts`, with the policy detail that **`all-linear` excludes routed (nn.Parameter) experts** because peft only attaches to `nn.Linear` (`:1029-1043`). MLA has its own LoRA shape table (`_lora_attn_elements`, `:943-973`).
+
+### 5.4 Activations (and the seq-len scaling law)
+
+Per layer (same shape as the FT-zoo vLLM formula, `:1192-1209`):
+
+```python
+Per_layer = (S·B·(qkv_size) + S·B·2 + S·B·(2·mlp_size) [+ PLE]) × 2 × 1.25
+```
+
+For MoE layers, `mlp_size` is multiplied by `num_experts_per_tok` (+ shared experts + parallel dense MLP) since all routed intermediates are live (`:1156-1189`). With gradient checkpointing, activations = `max_layer_bytes × gc_multiplier` (1.0–2.0 layers); without, the sum over all layers (`:1212-1245`). Non-flash attention adds a quadratic term and the total is `max(linear, B·heads·S²·2·12.0·effective_layers)` (`:1146-1153`, doc §5) — i.e. **seq-len scaling is linear under flash/SDPA/flex and quadratic otherwise**, and the attention implementation is resolved through the FT lib's own resolver with a conservative "eager" fallback (`[studio]/utils/hardware/hardware.py:1059-1072`).
+
+### 5.5 Floors (LoRA vs full-FT asymmetry)
+
+`estimate_training_vram` (`:1260-1308`):
+
+```python
+gradient_floor = int(model_weights * 0.15)                  # full FT: autograd + fragmentation
+if is_lora:
+    gradient_floor = min(gradient_floor, max(activations, optimizer_bytes))
+gradient_bytes = max(trainable_params * 2, gradient_floor)
+```
+
+— prevents the frozen 4-bit base from dominating overhead estimates in QLoRA (doc §6).
+
+### 5.6 Multi-GPU pooling and auto GPU selection
+
+`VramBreakdown.min_gpu_vram(n)` (`:145-158`): weights/LoRA/optimizer/gradients shard, **activations + CUDA overhead do not** — per-GPU need = `shardable/n + activations + overhead`. `auto_select_gpu_ids` (`[studio]/utils/hardware/hardware.py:1123-1272`) greedily adds GPUs ranked by free VRAM until both (a) pooled capacity fits, where each GPU after the first contributes only **85%** of its free VRAM (NCCL buffers/transfer/fragmentation discount, `:1204-1211`), and (b) the smallest selected GPU clears the precomputed `min_per_gpu_N` figure (`:1229-1235`). Inference-only fast path: 4-bit → `size/3.2 + max(30%, 2 GB)` buffer; 16-bit → `size × 1.3` (`hardware.py:1029-1036`). Config-less fallback ratios: full-FT `weights × 3.5 + 1.4 GB`; QLoRA `weights/3.2 + 4%·weights (LoRA) + 15%·weights·(B/4)·(S/2048) (activations) + 1.4 GB`; LoRA same but full-precision weights (`hardware.py:1104-1116`). Model size discovery order: HF safetensors metadata (`params × 2`) → config-derived param count → local weight-file bytes → a synthetic-1TB call into the FT-zoo's `approximate_vllm_memory_usage` to back out weight bytes (`hardware.py:948-986, 903-945`).
+
+---
+
+## 6. Activation-memory machinery that the sizing models assume
+
+These are why the activation estimates can assume ~1 live layer:
+
+- **Offloaded gradient checkpointing** (`[zoo]/gradient_checkpointing.py`): hidden states are checkpointed to pinned CPU buffers (`hidden_states.to("cpu", non_blocking=True)`, `:162`), with pre-allocated pools — `INITIAL_CPU_BUFFER_SIZE = 128·1024` elements × 200 buffers, `INITIAL_GPU_BUFFER_SIZE = 2·256·2048`, and **double-buffered H2D prefetch enabled only when free CUDA memory > `DOUBLE_BUFFER_HEADROOM = 512 MB`** (`:51-55`), with runtime self-disable on OOM ("Disabled double buffering due to insufficient VRAM", `:536-555`). Offload is skipped for tensors < 2 MB and for the last layer ("uses more VRAM and is slower", `:410-418`). Buffers grow on demand (`:515-517`).
+- **Tiled MLP** (`[zoo]/tiled_mlp.py`): chunks MLP forward across the flattened `B·S` axis. The chunk size has a closed-form solve from a target activation budget (`get_max_flat_qlen`, `:45-63`):
+  `max_flat_qlen = ceil((target_gb·2^30/nbytes − 3·hd·mlp) / (10·hd + 3·mlp + hd))`, padded to 64; when `target_gb` is unset it defaults to **50% of currently-free VRAM** (`:228-232`). The `10·hd` term models saved per-token tensors ("2 norms, 2 residual, 4 QKVO, 2 attention"). Patch selection by module-name suffix (`.mlp`, `.ffn`, `.feed_forward`, …, `:297-305`).
+
+---
+
+## 7. fp8 KV cache, quantized KV, decode-vs-prefill levers (consolidated)
+
+- `float8_kv_cache=True` → engine `kv_cache_dtype="fp8"` (`[zoo]/vllm_utils.py:2203`), guarded to cc ≥ 8.0 (`:1835-1837`); sized at **1.25 bytes/element** vs 2 (scale overhead included, `:1570`); rewarded with +5% `max_num_seqs` (`:2072-2073`). Exposed top-level as `float8_kv_cache=False` in every `from_pretrained` (`[ft]/models/llama.py:2225`, `[ft]/models/loader.py:263`).
+- Chunked prefill always on (except mllama) with the token budget from the GB-tier table (2048→8192) — this is their main prefill-vs-decode dial: small-KV GPUs take small prefill bites (2048) and few concurrent seqs (8), big GPUs take 8192-token bites with 96–256 seqs.
+- `enable_prefix_caching=True` default — directly exploits GRPO's prompt-replication (num_generations× identical prompts) so prefill cost is paid ~once per prompt group.
+- `max_num_seqs` is the decode-concurrency dial; their benchmark table (`:2029-2047`) justifies the 8–256 schedule by the measured ~linear non-KV memory growth past 64 seqs.
+- `max_logprobs=0` default avoids logprob buffer allocation; GRPO importance-sampling logprobs default off (`vllm_importance_sampling_correction=False`, `[ft]/models/rl.py:1348`).
+- fp8 *weights*: native fp8 checkpoints route through `is_fp8` (sized as 8/5 compression), and on-the-fly torchao fp8 (`load_in_fp8='row'|'block'`) for vLLM ≥ 0.12 (`:2263-2273`).
+- No fp8/quantized **KV** on the training side — only the vLLM engine.
+
+---
+
+## 8. Transferable design lessons for AgileRL auto-config
+
+1. **Hybrid analytic + lookup**: they compute an analytic weights/KV/activation budget (Section 1) but deliberately let *empirical tier tables* (keyed on KV-headroom GB and total-VRAM GB) choose the actual engine knobs (`max_num_seqs`, `max_num_batched_tokens`, util targets). The analytics decide feasibility and regime; benchmarks decide values.
+2. **Budget from free memory, convert to fraction-of-total** for vLLM; reserve trainer activations *before* giving vLLM its share (Section 1.4) — this is the exact knob AgileRL needs for the colocated trainer/rollout split.
+3. **Reserve explicitly for CUDA graphs** (~0.15–1.0 GiB, count×`hd·layers·4`) — an easily-missed term that otherwise eats the KV budget.
+4. **Standby util must be GPU-size-tiered, not constant**: the (1−util) remainder must cover the *absolute* trainer footprint (4-bit weights ≈ params/3.2 + opt + activations), so bigger GPUs can run higher util (0.879 effective at 40 GB; 0.71–0.78 below 14 GB).
+5. **Graceful degradation ladder**: clamp `max_seq_length` to what fits → retry with seqs×0.75/util×0.85 → raise actionable `MemoryError`; never silently retry under standby.
+6. **Autotune the training mini-batch once per accumulation window from live `mem_get_info`** with a quadratic logit-memory model and a chunk multiplier that scales with context (`max(4, seq_len//4096)`) — cheap, dynamic, and avoids static worst-casing.
+7. The studio's calibrated bytes-per-param tables (optimizer 4/6/8 B/param; 4-bit 3.2–3.6× compression; GC layer multipliers 1.0/1.5/2.0; 1.4 GB CUDA overhead; 15% gradient floor; 0.85 multi-GPU discount; activations-don't-shard rule) are directly liftable as priors for a "will it fit" pre-flight check.

--- a/.research-reports/trl-verl-web.md
+++ b/.research-reports/trl-verl-web.md
@@ -1,0 +1,563 @@
+# Auto-config research — TRL (local code) + verl & the broader field (web)
+
+Research slice for AgileRL's "auto right-size LLM RL training configuration" effort.
+
+- **Part A** is read from the local TRL checkout at `/Users/michaeldoherty/git/Misc/trl`
+  (commit `56cbcda1dc83af81cbc1c45359449934620af207`, 2026-06-01, version `1.6.0.dev0`).
+  All `file:line` references are against that commit.
+- **Part B** is web research; every claim carries a URL. Web content was retrieved via
+  search/fetch summarization on 2026-06-11, so treat paraphrased numbers as
+  high-confidence-but-verify; direct quotes are marked.
+
+---
+
+# PART A — TRL GRPOTrainer's vLLM integration
+
+## A.1 Topology modes: `colocate` (default) vs `server`
+
+`GRPOConfig.vllm_mode` defaults to `"colocate"` (`trl/trainer/grpo_config.py:502-511`):
+
+- **`colocate`** — a full vLLM `LLM` engine is constructed *inside every trainer rank's
+  process* and shares the training GPUs. There is **one vLLM engine replica per training
+  rank** (or per TP group, see A.3). No HTTP, no separate process.
+- **`server`** — the trainer is an HTTP client (`VLLMClient`) to a standalone server
+  launched with `trl vllm-serve` on **separate GPUs**. The docs are explicit that server
+  and trainer **must not share CUDA devices** — TRL raises
+  `RuntimeError: Attempting to use the same CUDA device for multiple distinct roles/ranks...`
+  if they do (`docs/source/vllm_integration.md:190-195`).
+
+There is additionally an experimental fully-async mode (`trl/experimental/async_grpo/`,
+see A.9) that decouples rollout from training against a *stock* `vllm serve` instance.
+
+### Colocate engine construction (`trl/generation/vllm_generation.py:348-365`)
+
+```python
+self.llm = LLM(
+    model=model.name_or_path,
+    tensor_parallel_size=self.tensor_parallel_size,
+    gpu_memory_utilization=self.gpu_memory_utilization,
+    max_model_len=self.max_model_length,
+    max_num_seqs=self.max_num_seqs,
+    enable_sleep_mode=self.enable_sleep_mode,
+    model_impl=self.model_impl,
+    distributed_executor_backend="external_launcher",
+    # Feed identical seed for tp groups to ensure sampling results are the same across workers
+    seed=accelerator.process_index // self.tensor_parallel_size,
+    # Latest vLLM v1 memory profiler is misled by the high default value (i.e., 32768) - thinking there's not enough memory
+    max_num_batched_tokens=4096,
+    # Important so temperature scaling/logit tweaking affects the TIS log probs
+    logprobs_mode="processed_logprobs",
+    quantization=quantization,
+)
+```
+
+Notable auto-set details:
+
+- `distributed_executor_backend="external_launcher"` — vLLM piggybacks on the
+  accelerate-launched process group instead of spawning its own workers; TRL sets
+  `RANK/LOCAL_RANK/WORLD_SIZE` env vars itself (`vllm_generation.py:332-337`).
+- **`max_num_batched_tokens` is hard-pinned to 4096** in colocate mode with the comment
+  that vLLM v1's memory profiler is "misled" by the default 32768 when memory is shared
+  with a trainer (`vllm_generation.py:361`). This is a knob AgileRL would want to derive
+  rather than pin (verl's rule of thumb differs sharply — see B.1).
+- `logprobs_mode="processed_logprobs"` so the returned sampling logprobs reflect
+  temperature/top-p processing — required for the truncated-importance-sampling (TIS)
+  correction (A.8).
+- **bnb quantization auto-detection**: if any module is `bnb.nn.Linear4bit`, vLLM is
+  initialized with `quantization="bitsandbytes"`; an 8-bit `Linear8bitLt` raises
+  `ValueError("vLLM does not support in-flight 8-bit quantization.")`
+  (`vllm_generation.py:339-346`).
+- After construction, if sleep mode is on, the engine is immediately put to sleep:
+  `self.llm.sleep(level=2)` (`vllm_generation.py:366-367`).
+
+### Server mode plumbing
+
+- Client connects to `http://{vllm_server_host}:{vllm_server_port}` (defaults
+  `0.0.0.0:8000`, timeout 240 s, weight-sync group port 51216;
+  `grpo_config.py:533-561`), only on the **main process**
+  (`vllm_generation.py:302-311`).
+- Weight sync joins the client as one extra rank into a `StatelessProcessGroup` of size
+  `tensor_parallel_size * data_parallel_size + 1` and NCCL-broadcasts each named tensor
+  from the client (`trl/generation/vllm_client.py:426-434, 489-511`;
+  `trl/scripts/vllm_serve.py:1139`).
+- The server CLI exposes the classic vLLM knobs with defaults:
+  `--gpu_memory_utilization 0.9`, `--tensor_parallel_size 1`, `--data_parallel_size 1`,
+  `--max_model_len None`, `--enable_prefix_caching None`, `--enforce_eager False`,
+  `--kv_cache_dtype auto` (`trl/scripts/vllm_serve.py:223-331`). Note the server default
+  GPU fraction is **0.9** (dedicated GPUs) vs the trainer-side colocate default **0.3**
+  (shared GPUs) — TRL encodes the topology split directly in these two defaults.
+- Generation requests are gathered to the main process, deduplicated
+  (`all_prompts[::num_generations]`, then `n=num_generations` server-side), sent once,
+  and the result is `broadcast_object_list`-scattered back so each rank receives exactly
+  its slice (`vllm_generation.py:576-634`). Server-side, prompts are chunked evenly
+  across DP workers (`vllm_serve.py:632-649`).
+- The vllm-serve docstring warns that from vLLM 0.14.0 **offline DP scaling for dense
+  models is unsupported** — "For dense models, keep this at 1"
+  (`vllm_serve.py:234-241`, `docs/source/vllm_integration.md:260-261`).
+
+## A.2 `vllm_gpu_memory_utilization` handling
+
+- `GRPOConfig.vllm_gpu_memory_utilization` **defaults to 0.3** and *only applies in
+  colocate mode*; in server mode you pass `--gpu_memory_utilization` (default 0.9) to
+  `trl vllm-serve` separately (`grpo_config.py:564-571`; trainer stores it at
+  `grpo_trainer.py:564` with the comment "only applies to colocation mode").
+- The value is forwarded verbatim to vLLM's `LLM(gpu_memory_utilization=...)`
+  (`vllm_generation.py:352`). **There is no auto-derivation, no probing, no validation**
+  against trainer footprint — the 0.3 default is the entirety of TRL's "memory split"
+  policy for colocated mode.
+- `vllm_max_model_length` (default `None` → inferred from model config) is the second
+  half of the KV budget story; the doc string tells users to set it to "at least the
+  maximum prompt length in the dataset plus `max_completion_length`"
+  (`grpo_config.py:572-578`). The async-GRPO doc repeats the same heuristic for
+  `--max-model-len` ("A good starting point is the prompt length plus
+  `max_completion_length`", `docs/source/async_grpo_trainer.md`).
+- HF's co-located vLLM blog used `vllm_gpu_memory_utilization=0.5` for the
+  Qwen2.5-Math-72B run on 8 GPUs with DeepSpeed ZeRO-3 + sleep mode
+  (https://huggingface.co/blog/vllm-colocate).
+
+## A.3 Batch arithmetic: `per_device_train_batch_size`, `num_generations`, `steps_per_generation`, `generation_batch_size`
+
+This is TRL's only real "auto-derivation": closing the over-determined system in
+`GRPOConfig.__post_init__` (`grpo_config.py:907-927`):
+
+```python
+num_processes = self.world_size
+if self.generation_batch_size is None and self.steps_per_generation is None:
+    self.steps_per_generation = self.gradient_accumulation_steps
+    self.generation_batch_size = self.per_device_train_batch_size * num_processes * self.steps_per_generation
+elif self.generation_batch_size is not None and self.steps_per_generation is None:
+    if self.generation_batch_size % (self.per_device_train_batch_size * num_processes) != 0:
+        raise ValueError(...)
+    self.steps_per_generation = self.generation_batch_size // (self.per_device_train_batch_size * num_processes)
+elif self.generation_batch_size is None and self.steps_per_generation is not None:
+    self.generation_batch_size = self.per_device_train_batch_size * num_processes * self.steps_per_generation
+else:
+    raise ValueError("'generation_batch_size' and 'steps_per_generation' can not be both configured at the same time")
+```
+
+So the invariant is:
+
+```
+generation_batch_size == per_device_train_batch_size * world_size * steps_per_generation
+steps_per_generation  defaults to gradient_accumulation_steps
+```
+
+Validation (all hard errors):
+
+1. `generation_batch_size % (per_device_train_batch_size * world_size) == 0`
+   (`grpo_config.py:914-918`).
+2. `generation_batch_size % num_generations == 0` — "The generation batch must contain
+   full prompt groups (no partials)" (`grpo_config.py:940-946`).
+3. `num_generations >= 2` (advantages need a group) (`grpo_config.py:948-952`).
+4. Eval: `(per_device_eval_batch_size * world_size) % num_generations_eval == 0`
+   (`grpo_config.py:929-938`).
+5. Sequence/context parallel is rejected outright: GRPO "builds model inputs after
+   generation inside the trainer" so cp/sp sharding can't apply
+   (`grpo_config.py:889-897`).
+
+Defaults: `num_generations=8`, `max_completion_length=256`
+(`grpo_config.py:392-398, 406-409`).
+
+### How generation and optimization batches relate at runtime
+
+- `get_train_dataloader` loads a **generation batch** of
+  `per_device_train_batch_size * steps_per_generation` per rank instead of a per-step
+  batch (`grpo_trainer.py:906-913`, the one-line change is `:910`).
+- `RepeatSampler` (`grpo_trainer.py:942-949`) is built with
+  `mini_repeat_count=num_generations`,
+  `batch_size=generation_batch_size // num_generations` (number of *unique prompts* per
+  generation round), and `repeat_count=num_iterations * steps_per_generation` so the
+  same generations can be re-consumed across optimizer steps. The ASCII diagram at
+  `grpo_trainer.py:924-939` documents the slicing.
+- `_prepare_inputs` (`grpo_trainer.py:1139-1168`) regenerates only every
+  `generate_every = steps_per_generation * num_iterations` steps; otherwise it slices
+  `self._buffered_inputs[self._step % steps_per_generation]`. I.e. one big vLLM call
+  amortized over `steps_per_generation` gradient-accumulation micro-steps ×
+  `num_iterations` GRPO inner epochs.
+- For loss-side forward passes (old logps / ref logps over the *whole* generation
+  batch), computation is chunked back down to `per_device_train_batch_size`
+  (`grpo_trainer.py:1934`, used at `:2050-2058, 2096-2104`) — "Chunk inputs into smaller
+  batches to reduce memory peak" (`grpo_trainer.py:1064`).
+- **`max_num_seqs` auto-derivation** for the colocate engine:
+  `per_device_train_batch_size * vllm_tensor_parallel_size * steps_per_generation`
+  (`grpo_trainer.py:784-786`) — i.e. exactly the number of sequences a rank (or TP
+  group) will submit per generation round, capping vLLM's scheduler to the real
+  concurrency. This is a good template for AgileRL: derive engine concurrency from the
+  training batch geometry instead of leaving vLLM's default (usually 1024+).
+
+### Colocate TP sub-groups
+
+`vllm_tensor_parallel_size` (default 1) must divide world size
+(`vllm_generation.py:316-320`). For TP>1, ranks are partitioned into contiguous
+subgroups via `torch.distributed.new_subgroups_by_enumeration`
+(`vllm_generation.py:322-330`); each rank `all_gather_object`s its prompts to the TP
+group, every rank generates the full group batch (deterministic because each group
+shares a seed, `:359`), then keeps only its own slice
+(`vllm_generation.py:661-675, 701-709`). Generation uses `n=1` in colocate mode ("vLLM
+on each GPU generates only 1", `:639`) because prompt duplication is done by the sampler.
+
+## A.4 Sleep/wake usage
+
+Controlled by `vllm_enable_sleep_mode` (default `False`, `grpo_config.py:520-526`).
+Sequence in colocate mode:
+
+1. **Init**: `llm.sleep(level=2)` right after engine build (`vllm_generation.py:366-367`).
+2. **Weight sync** (`sync_weights`, `vllm_generation.py:447-449`): `empty_cache()` then
+   `llm.wake_up(tags=["weights"])` — *weights only*, KV stays asleep, so weight-load and
+   KV allocation never coexist with peak trainer memory. Comment cites Ascend NPU crash
+   issue trl#5142 for why wake-before-load is mandatory.
+3. **Generate** (`vllm_generation.py:564-573`): `empty_cache()`,
+   `wake_up(tags=["weights"])` (idempotent), then a workaround for vLLM issue #29341 —
+   `llm.collective_rpc("reload_weights")` (wrapped in try/except for non-CUDA backends).
+   Then `wake_up(tags=["kv_cache"])` just before submitting prompts (`:680-681`).
+4. **After generation**: `llm.sleep(level=2)` (`vllm_generation.py:716-717`) — so the
+   optimizer step runs with vLLM fully offloaded.
+
+Docs framing: sleep "offload[s] vLLM parameters and cache to CPU RAM during the
+optimization step" at the cost of host–device transfer latency on wake
+(`docs/source/reducing_memory_usage.md:320-345`). The HF colocate blog states they use
+**level 2** for GRPO specifically because "the model is updated after every step" so
+discarding weights costs nothing (https://huggingface.co/blog/vllm-colocate).
+
+(NB for AgileRL: this two-tag staged wake — weights first, KV later — plus level-2 sleep
+is precisely the pattern your bnb-4bit experiments showed to be broken for in-place
+quantized reload; TRL avoids the bnb problem because `sync_weights()` rewrites every
+weight via `load_weights` after each optimizer step anyway.)
+
+## A.5 FSDP / DeepSpeed handling around generation & weight sync
+
+`VLLMGeneration.sync_weights()` (`vllm_generation.py:439-526`) is called once per
+optimizer step, gated by `self.state.global_step != self._last_loaded_step`
+(`grpo_trainer.py:1343-1348`, `:799`), so grad-accum micro-steps never re-sync.
+
+Per-backend strategy:
+
+- **DeepSpeed ZeRO-3, non-PEFT**: per-parameter
+  `deepspeed.zero.GatheredParameters([param])` context, then
+  `vllm_client.update_named_param` (server) or
+  `llm_engine.model_executor.driver_worker.model_runner.model.load_weights([(name, p)])`
+  (colocate) (`vllm_generation.py:455-463, 512-520`). Memory-light: one param
+  materialized at a time.
+- **DeepSpeed ZeRO-3 + PEFT**: must gather **the full model at once**
+  (`GatheredParameters(list(model.parameters()))`) because "merging adapters in a
+  sharded manner is not supported"; then `model.merge_adapter()` → push merged base
+  weights (skipping PEFT-prefixed params, stripping `base_model.model.`/`.base_layer`)
+  → `model.unmerge_adapter()` inside the same context
+  (`vllm_generation.py:465-501`). This is the peak-memory hot spot for PEFT+ZeRO-3.
+- **FSDP1**: memory-efficient **post-order traversal** — recurse children first, then
+  `FSDP.summon_full_params(module, recurse=False, writeback=False)` per FSDP module,
+  pushing each full param and tracking `visited` to skip re-gathered subtrees
+  (`vllm_generation.py:384-411`).
+- **FSDP2**: iterate `module.state_dict()`, `param.full_tensor()` on each DTensor (CPU
+  params are moved to CUDA first), with PEFT name fixups
+  (`vllm_generation.py:413-437`).
+- After any sync: `reset_prefix_cache()` on server or colocate engine
+  (`vllm_generation.py:522-526`) so stale-cached prefixes from the old policy can't be
+  reused.
+
+Non-vLLM generation paths also reveal the gathering knobs:
+
+- `ds3_gather_for_generation` (default `True`, `grpo_config.py:410-418`) — gathers
+  ZeRO-3 weights for `model.generate`; disabling allows models larger than one GPU but
+  is "not compatible with vLLM generation".
+- `unwrap_model_for_generation(..., gather_deepspeed3_params=args.ds3_gather_for_generation)`
+  plus `FSDP.summon_full_params(self.model_wrapped, recurse=False)` for FSDP
+  (`grpo_trainer.py:1361-1411`; `trl/models/utils.py:196-231`).
+- Reference model prep: `prepare_deepspeed` / `prepare_fsdp` / plain
+  `accelerator.prepare_model(evaluation_mode=True)` (`grpo_trainer.py:828-834`).
+
+## A.6 What TRL does NOT auto-configure (gaps relevant to AgileRL)
+
+- No derivation of `vllm_gpu_memory_utilization` from model size/VRAM — fixed 0.3.
+- No OOM-retry on the training step (TRL does not use accelerate's
+  `find_executable_batch_size`; transformers' `auto_find_batch_size` exists in
+  `TrainingArguments` but interacts badly with GRPO's generation-batch arithmetic and is
+  not mentioned anywhere in the GRPO code/docs).
+- No workload-profile awareness (prefill- vs decode-heavy): `max_num_batched_tokens`
+  is pinned at 4096, `max_model_len` left to the user.
+- No trainer-vs-inference GPU ratio guidance for server mode beyond "separate devices".
+- TP choice is manual; the colocate blog's empirical finding: TP sharding *hurts* a
+  1.5B model and gives up to 1.73× for 7B (https://huggingface.co/blog/vllm-colocate).
+
+## A.7 The TIS correction (config-relevant side effect of vLLM)
+
+Because vLLM logprobs ≠ trainer logprobs, TRL defaults
+`vllm_importance_sampling_correction=True` with `vllm_importance_sampling_mode="sequence_mask"`
+and cap `C=3.0` (`grpo_config.py:792-820`); ratios are computed from
+`old_per_token_logps - sampling_per_token_logps` and clamped/masked
+(`grpo_trainer.py:2044-2091`). Consequence for auto-config: when vLLM is enabled, the
+trainer must *always* run an extra full forward pass over the generation batch to get
+`old_per_token_logps` (`grpo_trainer.py:2047-2058`) — generation-batch-sized forward
+memory must be budgeted even when `num_iterations=1`.
+
+## A.8 Experimental async GRPO (`trl/experimental/async_grpo/`)
+
+Decoupled topology against a stock `vllm serve` (requires
+`VLLM_SERVER_DEV_MODE=1`, `--logprobs-mode processed_logprobs`,
+`--weight-transfer-config '{"backend":"nccl"}'`; FSDP2 only, no DeepSpeed —
+`docs/source/async_grpo_trainer.md`). Knobs:
+
+- `max_staleness` (default 4): discard samples older than N weight updates
+  (`async_grpo_config.py:175-176`).
+- `weight_sync_steps` (default 1): NCCL weight push frequency (`:186`).
+- **Auto-derivation**: `max_inflight_tasks` default `-1` →
+  `max_staleness * per_device_train_batch_size * gradient_accumulation_steps * num_processes`
+  — "Generating more than this is wasteful since the excess samples will be discarded"
+  (`async_grpo_config.py:165-169`; doc).
+
+---
+
+# PART B — verl, the field, and OOM-retry semantics (web)
+
+## B.1 verl performance tuning guide
+
+Source: https://verl.readthedocs.io/en/latest/perf/perf_tuning.html (authors Guangming
+Sheng, Jiali Zheng). Section order **is** the recommended tuning order:
+
+1. **Rollout generation tuning**
+2. **Enable remove padding (sequence packing)** — `use_remove_padding=True`
+3. **Batch size tuning**
+4. **Tuning for dynamic batch size** — `use_dynamic_bsz`
+5. **Ulysses sequence parallel for long context**
+6. **LigerKernel** (`use_liger: True`)
+7. **FSDP forward prefetch** (`fsdp_config.forward_prefetch=True`)
+8. **Migrate to FSDP2** (`actor_rollout_ref.*.strategy="fsdp2"`)
+9. **Entropy-calc memory optimization** (`entropy_from_logits_with_chunking=True`,
+   `entropy_checkpointing=True`)
+
+### Rollout knobs (vLLM/SGLang)
+
+- `gpu_memory_utilization`: for vLLM ≥0.7 it is a fraction of **total** GPU memory; for
+  SGLang it is the fraction of **free** memory for *static* allocations (weights+KV) and
+  the remainder is still used at runtime — semantics differ per backend. Recommended:
+  **"A value between 0.5 and 0.7 often strikes a good balance between high throughput
+  and avoiding OOM"** (colocated hybrid engine).
+- "If the GPU cache utilization is relatively low in the log, increase `max_num_seqs`
+  or `max_num_batched_tokens` [to] enlarge the effective batch size in the decoding
+  stage"; set `max_num_batched_tokens > 2048` for throughput.
+- **"Use a smaller `tensor_parallel_size`. When GPU resources allow, a smaller tensor
+  parallel size spawns more vLLM replicas. Data parallelism (DP) can yield higher
+  throughput than tensor parallelism (TP)."**
+- CUDA graphs: `enforce_eager=False` required to use `cudagraph_capture_sizes`; smaller
+  capture sizes reduce OOM risk at slight throughput cost (graph memory cannot be
+  offloaded, so it lingers into the training phase).
+- `free_cache_engine=True` (default): offload KV cache after the rollout stage
+  (https://verl.readthedocs.io/en/latest/examples/config.html).
+
+### Batch-size doctrine (the key conceptual split)
+
+- **Algorithmic, global** knobs (affect convergence): `data.train_batch_size`,
+  `actor.ppo_mini_batch_size`.
+- **Performance, local (per-GPU)** knobs (throughput only):
+  `*micro_batch_size_per_gpu`, and under dynamic batching `*_max_token_len_per_gpu`.
+- Rule: "Increase the `*micro_batch_size_per_gpu` as much as possible till equals to
+  normalized `mini_batch_size`" — i.e. grow micro-batch until grad accumulation
+  disappears or OOM.
+
+### Dynamic batching (token-budget batching)
+
+`use_dynamic_bsz=True` replaces micro-batch counts with **token budgets per GPU**:
+
+- `actor_rollout_ref.actor.ppo_max_token_len_per_gpu`: **at least
+  `2 × (max_prompt_length + max_response_length)`** (example config: 16384, annotated
+  `n * (max_prompt_length + max_response_length)`).
+- Forward-only budgets (`log_prob_max_token_len_per_gpu`,
+  `ref.log_prob_max_token_len_per_gpu`, critic `forward_max_token_len_per_gpu`, RM
+  equivalents) can be set higher than fwd+bwd budgets; critic/RM ≈ 2× actor's.
+- This is verl's answer to padding waste + variable-length rollouts and is the single
+  most transferable mechanism for AgileRL: micro-batching by *token count* rather than
+  *sequence count* makes the decode-heavy vs prefill-heavy distinction mostly moot on
+  the training side.
+
+### Long context & memory
+
+- `ulysses_sequence_parallel_size > 1` for long context; for >32k also decrease
+  micro-batch/token budgets.
+- `enable_gradient_checkpointing=True`, `enable_activation_offload=True` (FSDP only);
+  FSDP `param_offload`/`optimizer_offload` default False
+  (https://verl.readthedocs.io/en/latest/examples/config.html).
+
+### verl example-config defaults (config explanation page)
+
+https://verl.readthedocs.io/en/latest/examples/config.html — `max_num_batched_tokens:
+8192`, `max_num_seqs: 1024`, `enforce_eager: True` (CUDA graph disabled by default),
+`free_cache_engine: True`, `log_prob_micro_batch_size_per_gpu: 16`,
+`use_dynamic_bsz: False`, `ulysses_sequence_parallel_size: 1`.
+
+### verl best-practices (DAPO + Qwen3-235B)
+
+https://verl.readthedocs.io/en/latest/perf/best_practices.html — large-model addendum:
+
+- Rollout: push `gpu_memory_utilization` to **0.8–0.9 when offload is enabled**; sizing
+  rule **`(memory_per_gpu × gpu_memory_utilization × TP) > 2 × model_parameters`**
+  (bf16 weights); `max_num_batched_tokens =
+  max(8192, max_prompt_length + max_response_length, max_model_len)`;
+  `enable_chunked_prefill` for utilization.
+- Training (Megatron): "Prefer increasing TP first, add PP when necessary, extend
+  sequence capacity with CP"; enable `param_offload`/`grad_offload`/`optimizer_offload`
+  under memory pressure (`optimizer_offload_fraction: 1` for DeepSeek-scale); offload
+  ref params whenever actor does.
+- Monitor `clip_ratio` (>0.1 ⇒ `max_response_length` too small — a workload-profile
+  signal AgileRL could consume automatically).
+
+### verl "auto" settings
+
+verl has **no shipped auto-tuner**. Feature request
+https://github.com/volcengine/verl/issues/1845 ("Auto-tune batch size / max_token_len",
+open) asks for exactly the AgileRL goal: derive `mini_batch_size`/`max_token_len` from
+available GPU memory per Ray actor, "similar to transformers Trainer"
+(`auto_find_batch_size`). No maintainer-shipped implementation as of fetch date. verl's
+only auto-ish behaviors are dynamic token-budget batching (`use_dynamic_bsz`) and
+`free_cache_engine`/offload toggles — thresholds remain manual.
+
+## B.2 HF accelerate `find_executable_batch_size` (OOM-retry decorator)
+
+Read directly from the installed accelerate 1.7.0:
+`/Users/michaeldoherty/git/AgileRL/.venv/lib/python3.13/site-packages/accelerate/utils/memory.py:119-182`.
+Semantics:
+
+- Decorator wraps a function whose **first arg is `batch_size`**; starts at
+  `starting_batch_size` (default 128).
+- On exception, `should_reduce_batch_size(e)` (`memory.py:100-116`) string-matches
+  RuntimeError messages: `" out of memory."` (CUDA/HIP/XPU), CUDNN_STATUS_NOT_SUPPORTED,
+  CPU allocator failure, HPU devmem failure. Anything else re-raises.
+- Default policy: **halve** (`batch_size // 2`), `clear_device_cache(garbage_collection=True)`
+  between attempts, raise `RuntimeError("No executable batch size found, reached zero.")`
+  at 0. A custom `reduce_batch_size_fn` can replace halving.
+- Retry is whole-function: the wrapped body restarts from scratch each attempt — so in
+  an RL trainer the candidate unit must be idempotent (e.g. a probe step), and partial
+  state (optimizer, dataloader position) must be reset by the caller.
+- transformers exposes this as `TrainingArguments.auto_find_batch_size`; caveat known in
+  the field: in distributed settings every rank must shrink in lockstep or collectives
+  desync — one reason verl issue #1845 frames it as a per-actor profiling problem
+  instead.
+
+## B.3 OpenRLHF
+
+Sources: https://openrlhf.readthedocs.io/en/latest/performance.html,
+https://openrlhf.readthedocs.io/en/latest/hybrid_engine.html,
+https://blog.vllm.ai/2025/04/23/openrlhf-vllm.html.
+
+- Topology flags: `--colocate_all_models` (hybrid engine: vLLM + actor + ref + critic +
+  RM share GPUs) plus `--vllm_enable_sleep` and `--deepspeed_enable_sleep`; partial
+  colocation via `--colocate_critic_reward`, `--colocate_actor_ref`. Recommendation:
+  prefer hybrid engine + both sleep flags over distributed placement "when there are
+  enough GPU memory".
+- `--vllm_gpu_memory_utilization`: docs recommend **0.5 on 8×A100** for hybrid engine;
+  OOM-troubleshooting ladder is "lower progressively 0.6 → 0.5 → 0.4".
+- Batch heuristics: "Maximize `micro_batch_size` and minimize vLLM TP size" (prefer more
+  DP engine replicas — same doctrine as verl); packing samples always on;
+  `train.batch_size = rollout.batch_size × n_samples_per_prompt` is the common choice;
+  gradient checkpointing first OOM mitigation, then ZeRO stage 2→3, then
+  `adam_offload`; ring attention for >8k contexts.
+- Ray fine-grained sharing: `VLLM_RAY_PER_WORKER_GPUS` / `VLLM_RAY_BUNDLE_INDICES`
+  let multiple components share a GPU bundle (vLLM blog post). No auto-config; "start
+  from a known-good recipe ... adjust one knob at a time".
+
+## B.4 NeMo-RL
+
+Sources: https://docs.nvidia.com/nemo/rl/latest/design-docs/generation.html,
+https://docs.nvidia.com/nemo/rl/latest/guides/async-grpo.html,
+https://github.com/NVIDIA-NeMo/RL/blob/main/examples/configs/grpo_math_1B.yaml.
+
+- Topology is a first-class config: `policy.generation.colocated.enabled: true|false`
+  with `colocated.resources.{num_nodes,gpus_per_node}` for the dedicated-inference case.
+  Colocated mode uses sleep/wake ("wake up workers during prepare_for_generation");
+  non-colocated only resets prefix cache after generation.
+- Memory contract: when stages share a GPU, **the sum of their `gpu_memory_utilization`
+  values must not exceed 1.0** (per their vllm config docs). Example colocated value:
+  `vllm_cfg.gpu_memory_utilization: 0.6` (grpo_math_1B.yaml).
+- Example batch geometry (grpo_math_1B.yaml): `train_global_batch_size: 512`,
+  `train_micro_batch_size: 4`, `generation_batch_size: 32`,
+  `logprob_batch_size: ${policy.train_micro_batch_size}`, `num_prompts_per_step: 32` ×
+  `num_generations_per_prompt: 16`; `sequence_packing.enabled: True`
+  (modified_first_fit_decreasing) with token budget
+  `train_mb_tokens = max_total_sequence_length × train_micro_batch_size`;
+  `dynamic_batching.enabled: False` when packing is on.
+- Async GRPO: requires `colocated.enabled: false`; staleness knob
+  `grpo.async_grpo.max_trajectory_age_steps` ("start with 1 and increase if needed");
+  `in_flight_weight_updates: true` with the vLLM async engine; replay buffer auto-sized
+  `buffer_size = num_prompts_per_step × max_trajectory_age_steps × 2`. **No recommended
+  generation:training GPU ratio is published.**
+
+## B.5 Async RL GPU-split heuristics (AReaL, SkyRL, slime)
+
+### AReaL (decoupled, fully async)
+
+https://arxiv.org/abs/2505.24298 (HTML: https://arxiv.org/html/2505.24298v1):
+
+- "For AReaL, we maintain a fixed ratio between inference and training devices,
+  allocating **three-quarters of the devices for inference**." Chosen "against an equal
+  50-50 partition based on our early experiments, where the 75-25 partition demonstrated
+  higher training throughput."
+- Caveat from the authors: "the optimal partition may vary across different settings and
+  could potentially benefit from dynamic adjustment during training."
+- Staleness bound η=4; interruptible rollout workers + decoupled-PPO objective make the
+  staleness tolerable; up to 2.57× throughput vs synchronous baselines (1.5B–32B models,
+  H800 cluster, 64×8 GPUs).
+- Follow-up AReaL-Hex (https://arxiv.org/abs/2511.00796) optimizes the *placement
+  itself* over heterogeneous GPUs — evidence the ratio is workload-dependent and worth
+  auto-deriving.
+
+### SkyRL
+
+https://docs.skyrl.ai/docs/configuration/config and
+https://docs.skyrl.ai/docs/tutorials/one_step_off_async:
+
+- Placement keys: `trainer.placement.colocate_all` (default true),
+  `colocate_policy_ref`, `policy_num_nodes`, `policy_num_gpus_per_node`, etc.
+- Hard constraint when colocated: `policy_num_gpus_per_node × policy_num_nodes ==
+  num_inference_engines × inference_engine_tensor_parallel_size ×
+  inference_engine_data_parallel_size` (validated in
+  `utils/utils.py::validate_batch_sizes`-adjacent checks).
+- Generator defaults: `gpu_memory_utilization: 0.8`, `max_num_batched_tokens: 8192`,
+  `max_num_seqs: 1024`, `enable_prefix_caching: true`, `async_engine: true`.
+- Batch defaults: `train_batch_size: 1024`, `policy_mini_batch_size: 256`,
+  `micro_train_batch_size_per_gpu: 1`, `micro_forward_batch_size_per_gpu: 1`.
+- One-step-off async example splits 8 GPUs **4:4** (trainer:generator) with
+  `colocate_all=false`, generation N+1 overlapping training N via an asyncio queue —
+  i.e. one-step staleness, the mildest async variant.
+
+### slime (THUDM; GLM-4.5/4.6 post-training)
+
+https://github.com/THUDM/slime,
+https://github.com/THUDM/slime/blob/main/docs/en/get_started/usage.md,
+https://lmsys.org/blog/2025-07-09-slime/:
+
+- Single-flag topology: `--colocate` "ignores `--rollout-num-gpus` and makes the number
+  of GPUs for training and inference equal" (time-sliced Megatron↔SGLang); otherwise
+  decoupled with explicit budgets: total = `actor_num_nodes × actor_num_gpus_per_node +
+  rollout_num_gpus`; `--rollout-num-gpus-per-engine` ≈ SGLang TP size.
+- Colocated memory rule: "although Megatron and SGLang will offload sequentially, they
+  still need to leave some memory for each other" — tune by **reducing
+  `--sglang-mem-fraction-static`**.
+- PPO adds a separate parallel critic pool (`--critic-num-nodes`,
+  `--critic-num-gpus-per-node`).
+
+## B.6 Cross-framework synthesis for AgileRL's auto-config
+
+**Colocated GPU-fraction defaults observed** (all for the vLLM/SGLang share):
+TRL 0.3 (trainer-heavy, full-model HF training in the remainder) · OpenRLHF 0.5 ·
+verl 0.5–0.7 (0.8–0.9 only with training offload enabled) · NeMo-RL 0.6 with an
+explicit "fractions must sum ≤1.0" contract · SkyRL 0.8 (but defaults to dedicated
+engines). Dedicated/server-mode default is uniformly 0.9.
+
+**Auto-derivations that actually exist in the wild** (candidates to copy):
+1. TRL: close the batch system from
+   {per_device_bs, world, grad_accum} → {steps_per_generation, generation_batch_size},
+   with divisibility-by-`num_generations` validation (A.3).
+2. TRL: engine `max_num_seqs` from training batch geometry (A.3).
+3. TRL async: `max_inflight_tasks` from staleness × global batch (A.8).
+4. NeMo-RL: replay buffer from `num_prompts_per_step × max_trajectory_age_steps × 2` (B.4).
+5. verl best-practices inequality for minimum TP:
+   `TP ≥ 2 × params_bytes / (mem_per_gpu × gpu_mem_util)` (B.1).
+6. verl dynamic token budgets: `ppo_max_token_len_per_gpu ≥ 2×(max_prompt+max_response)`,
+   forward-only budgets ~2× that (B.1).
+7. accelerate: halving OOM-retry as last-resort safety net, with the distributed-lockstep
+   caveat (B.2).
+8. AReaL: start async splits at 75:25 inference:training; treat as tunable, not truth (B.5).
+
+**Shared doctrine** across verl/OpenRLHF/TRL-blog: prefer more inference engine
+replicas (DP) over deeper TP until the model stops fitting (with the vLLM ≥0.14 caveat
+that offline DP for dense models is gone — replicas must be separate engines, which is
+what TRL colocate does naturally, one engine per rank).

--- a/.research-reports/vllm-knobs.md
+++ b/.research-reports/vllm-knobs.md
@@ -1,0 +1,309 @@
+# vLLM engine knobs for RL rollout workloads: defaults, auto-sizing, and what to override
+
+**Source repo:** `/Users/michaeldoherty/git/Misc/vllm` at commit `a10d69116cb25c8137eeb3f320add71d4e04fda9` (2026-05-20). This is the V1 engine era — V0 is gone; everything below is the V1 (`vllm/v1/`) code path. All file paths are relative to the repo root; line numbers are from this commit.
+
+> **Caveat for AgileRL:** the vLLM pinned in AgileRL's `pyproject` may be older than this checkout. The big behavioral facts (V1 scheduler, profile-run memory accounting, sleep-mode tags, prefix caching default-on) have been stable since ~v0.8–0.10, but several *defaults* quoted here are newer (e.g. `gpu_memory_utilization=0.92` was 0.90 for a long time; CUDA-graph memory now charged against the KV budget since v0.21.0; sleep "level 0" and `mode=` are new). Verify against the pinned version before hard-coding numbers.
+
+---
+
+## 1. EngineArgs / VllmConfig: defaults and derivations
+
+### 1.1 `gpu_memory_utilization` — default **0.92**, fraction of *TOTAL* GPU memory
+
+`vllm/config/cache.py:66`:
+
+```python
+gpu_memory_utilization: float = Field(default=0.92, gt=0, le=1)
+```
+
+Semantics (docstring, cache.py:67-73): per-vLLM-instance budget; two instances on one GPU can each use 0.5. Critically, it is a fraction of **total** device memory, not free memory — `vllm/v1/worker/utils.py:403-423`:
+
+```python
+requested_memory = math.ceil(init_snapshot.total_memory * cache_config.gpu_memory_utilization)
+if init_snapshot.free_memory < requested_memory:
+    raise ValueError("Free memory on device ... is less than desired GPU memory utilization ...")
+```
+
+So in a **colocated** setup (trainer already holding memory), the constraint at vLLM init is `total * util <= free_at_init`, and the error above is the failure mode if the trainer's footprint pushes free below the request. The right auto-config formula is `util ≈ (free_after_trainer − headroom) / total`.
+
+### 1.2 `kv_cache_memory_bytes` — the precise alternative (bypasses `gpu_memory_utilization`)
+
+`vllm/config/cache.py:158-165`: when set, vLLM **skips memory profiling entirely** and reserves exactly this many bytes for KV cache — `vllm/v1/worker/gpu_worker.py:366-384` ("Note that kv_cache_memory_bytes (when not-None) **ignores gpu_memory_utilization**"). This is the most deterministic knob for a config auto-sizer: compute KV bytes yourself and hand them over. The profile run still executes (for compilation warm-up) but its measurement is unused.
+
+Related: `num_gpu_blocks_override` (`cache.py:85-87`) pins the block count directly; `get_kv_cache_configs` adjusts the planning memory to `override * bytes_per_block` so admission checks stay consistent (`vllm/v1/core/kv_cache_utils.py:2007-2027`).
+
+### 1.3 `max_model_len` — derived from HF config when unset; `-1` = auto-fit to memory
+
+Default is `None` (`vllm/config/model.py:199`). Resolution in `_get_and_verify_max_len` (`model.py:2103-2239`):
+
+- Derived from the HF config's max-position keys (`derived_max_model_len_and_key`, model.py:2114-2116), clamped by `tokenizer_config.model_max_length` (2129-2133), multiplied by RoPE scaling factor for non-su/longrope/llama3 rope types (2164-2188; Gemma3 explicitly skipped because its 128K is pre-scaled, 2162-2164), and for yarn it resets to `original_max_position_embeddings`.
+- If nothing found: warns and falls back to **2048** (model.py:2147).
+- `max_model_len = -1` means **auto-fit**: after profiling, `_auto_fit_max_model_len` (`vllm/v1/core/kv_cache_utils.py:1839-1900`) binary-searches the largest length whose worst-case single-request KV fits in available memory across all workers, and rewrites `model_config.max_model_len`. Triggered at `kv_cache_utils.py:2029-2032` when `original_max_model_len == -1`.
+- User value > derived raises unless `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` (model.py:2233-2238).
+
+**RL relevance:** `max_model_len` should be set to `max_prompt_len + max_completion_len` (or the multi-turn total). It is the single biggest lever on the "fits at all" check (§2.4) and on `estimate_max_model_len`. Auto-fit (`-1`) is a viable "don't think about it" mode but lets vLLM silently shrink context below what the env needs — an RL auto-configurer should instead compute the required length and validate.
+
+### 1.4 `max_num_seqs` and `max_num_batched_tokens` — V1 defaults are usage-context + hardware dependent
+
+The dataclass defaults (`vllm/config/scheduler.py:42-44`) are only test conveniences:
+
+```python
+DEFAULT_MAX_NUM_BATCHED_TOKENS: ClassVar[int] = 2048
+DEFAULT_MAX_NUM_BATCHED_TOKENS_FOR_BATCHED_DP: ClassVar[int] = 256
+DEFAULT_MAX_NUM_SEQS: ClassVar[int] = 128
+```
+
+Real defaults come from `EngineArgs.get_batch_defaults` (`vllm/engine/arg_utils.py:2263-2345`), keyed on usage context and device:
+
+| Hardware | Context | `max_num_batched_tokens` | `max_num_seqs` |
+|---|---|---|---|
+| ≥70 GiB GPU, **not** A100 (H100/H200/MI300X) | `LLM` class (offline) | **16384** | **1024** |
+| ≥70 GiB, not A100 | OpenAI API server | **8192** | **1024** |
+| Everything else (**A100 included**, by explicit name check — arg_utils.py:2290-2293, "Setting large max_num_batched_tokens for A100 reduces throughput, see PR #17885") | `LLM` class | **8192** | **256** |
+| Everything else | API server | **2048** | **256** |
+| CPU | `LLM`/API | 4096·ws / 2048·ws | 256·ws / 128·ws |
+
+Post-processing in `_set_default_max_num_seqs_and_batched_tokens_args` (`arg_utils.py:2424-2494`):
+- `performance_mode == "throughput"` **doubles both** (when not user-set) (2456-2461). `performance_mode` is a top-level knob, default `"balanced"` (`vllm/config/vllm.py:86,358`); `"interactivity"` instead changes cudagraph capture granularity (§1.7).
+- If chunked prefill is *disabled*, `max_num_batched_tokens = max(max_model_len, default)` (2467-2472), because without chunking a prompt must fit in one step (`config/scheduler.py:259-271` raises otherwise).
+- Clamp `max_num_batched_tokens = min(max_num_seqs * max_model_len, …)` (2477-2480) and `max_num_seqs = min(max_num_seqs, max_num_batched_tokens)` (2488-2490).
+- Validation: `max_num_batched_tokens >= max_num_seqs` required (`config/scheduler.py:273-278`).
+
+**RL relevance:** GRPO-style rollouts via the `LLM` class on an A100 get 8192/256; on an H100, 16384/1024. These defaults are tuned for serving throughput, not for a colocated engine sharing VRAM with a trainer — `max_num_batched_tokens` directly sizes the profile-run activation peak (§2.2) and the LoRA static buffers (§5), so on a 40 GB card it is often worth *lowering* it to free KV/trainer memory.
+
+### 1.5 `enable_chunked_prefill` — default **True** (generative models)
+
+EngineArgs default `None` (`arg_utils.py:594`); resolved in `_set_default_chunked_prefill_and_prefix_caching_args` (`arg_utils.py:2347-2415`) from `model_config.is_chunked_prefill_supported` (`config/model.py:1759-1802`) — **True for all generative decoder models**, False for encoder-decoder and some poolers. Disabling it manually on a generative model logs "may cause the engine to crash or produce incorrect outputs" (arg_utils.py:2360-2369). Treat chunked prefill as always-on in V1.
+
+### 1.6 `enable_prefix_caching` — default **True** (generative models)
+
+Same resolution path: `model_config.is_prefix_caching_supported` (`config/model.py:1805+`) → True for generative decoders. `CacheConfig.enable_prefix_caching: bool = True` (`cache.py:91`). Hash algo default `"sha256"`; `"xxhash"` available for speed (`cache.py:93-108`).
+
+Prefix-cache keys include **LoRA adapter name** (`vllm/v1/core/kv_cache_utils.py:462-475`, `_gen_lora_extra_hash_keys` returns `request.lora_request.lora_name`) — so in an async/decoupled RL setup where each weight-sync bumps the adapter, stale-adapter KV is never silently reused *if the LoRA name changes*; if the adapter is updated **in place under the same name**, cached prefixes computed with old weights WILL be reused — you must call `reset_prefix_cache()` after each weight update (`vllm/entrypoints/llm.py:987-992`). Sleep/wake also clears KV (§4), which handles this for the colocated path.
+
+### 1.7 CUDA graphs + compilation
+
+- Top-level `optimization_level` default **O2** (`vllm/config/vllm.py:352`), which maps to `cudagraph_mode = FULL_AND_PIECEWISE` + inductor compilation (`vllm.py:229-249`, `OPTIMIZATION_LEVEL_TO_CONFIG` at 272-277). O0 = no compile/no graphs, O1 = PIECEWISE.
+- `enforce_eager: bool = False` (`config/model.py:226`). Setting it forces `CompilationMode.NONE` + `CUDAGraphMode.NONE` (`vllm.py:1020-1026`) and zeroes capture sizes (`vllm.py:1221-1226`). It is the "fast startup / low extra memory / slower decode" switch.
+- **Capture sizes** (`VllmConfig._set_cudagraph_sizes`, `vllm.py:1585-1755`):
+  ```python
+  max_cudagraph_capture_size = min(max_num_seqs * decode_query_len * 2, 512)   # vllm.py:1638-1647
+  # decode_query_len = 1 + num_speculative_tokens
+  sizes = [1, 2, 4] + range(8, 256, 8) + range(256, max+1, 16)                 # vllm.py:1676-1688
+  ```
+  capped by `max_num_batched_tokens` (1648-1649). `performance_mode="interactivity"` instead captures every size 1..min(max,32) (1670-1674). User `cudagraph_capture_sizes` / `max_cudagraph_capture_size` override (compilation.py:631, 675-686).
+- **Memory accounting:** since v0.21.0 the profile run *estimates CUDA-graph memory and subtracts it from the KV budget* by default (`VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1`, `vllm/envs.py:272`; applied at `gpu_worker.py:398-447`). The worker logs equivalent-utilization suggestions (`gpu_worker.py:467-504`). So cudagraph cost is no longer a hidden OOM source — but it *does* shrink KV. Fewer capture sizes (or eager) = more KV blocks.
+
+### 1.8 `swap_space` — **gone**; `cpu_offload_gb`; preemption is recompute
+
+- `swap_space` is deprecated and **ignored** (`vllm/entrypoints/llm.py:242-248`). V1 has no CPU swap of preempted sequences.
+- V1 **preemption = recompute**: when `allocate_slots` fails, the lowest-priority running request is preempted and its `num_computed_tokens` reset to 0 (`vllm/v1/core/sched/scheduler.py:929-941`); it re-prefills from scratch on resume (prefix cache can rescue most of that if enabled).
+- `cpu_offload_gb: float = 0` (`vllm/config/offload.py:23-32`) — UVA zero-copy *weights* offload ("virtually increases GPU memory"; weights streamed from pinned CPU each forward). Heavy decode-throughput cost; not recommended for RL rollouts, but it's the lever of last resort to fit a model.
+- New: KV offload to CPU via `kv_offloading_size` GiB + `kv_offloading_backend` ("native"/"lmcache") (`cache.py:167-176`) — extends effective KV space at PCIe cost; potentially interesting for very long multi-turn envs.
+
+### 1.9 `kv_cache_dtype` — default `"auto"` (model dtype); fp8 halves KV
+
+`vllm/config/cache.py:18-34,74-81`: options include `fp8` (=`fp8_e4m3`), `fp8_e5m2`, per-token-head int8/fp8, `nvfp4`, turboquant variants. `"auto"` uses model dtype (bf16 → 2 bytes/elem). `fp8` → 1 byte/elem → **2× KV capacity ≈ 2× max concurrency** for decode-heavy workloads; scales are loaded from checkpoint or default 1.0 (`calculate_kv_scales` deprecated, cache.py:109-113). Per-token-head modes additionally budget 2×4 bytes/token/head of scales out of the same allocation (`vllm/v1/kv_cache_interface.py:152-164`).
+
+### 1.10 `block_size` — default **16**, backend may override
+
+`CacheConfig.DEFAULT_BLOCK_SIZE = 16` (`cache.py:45`); applied only if the user didn't pass `--block-size` (`cache.py:223-236` sets `user_specified_block_size`). The platform then asks the chosen attention backend for a preferred size (`vllm/platforms/interface.py:484-500` → `get_preferred_block_size`); e.g. some MLA-sparse backends force 256 (`vllm/v1/attention/backends/mla/sparse_swa.py:106-107`), ROCm AITER unified forces 64. Block size matters mainly for prefix-cache hit granularity (smaller = finer reuse) and per-block page bytes; leave it to vLLM unless profiling says otherwise.
+
+### 1.11 Scheduler policy & async scheduling
+
+- `policy: "fcfs" | "priority"`, default **fcfs** (`config/scheduler.py:109-115`). RL rollout batches are homogeneous; fcfs is fine. `priority` could front-run eval/bootstrap requests if you ever mix.
+- `async_scheduling` default `None` → **enabled** unless pooling model / incompatible spec-decode / unsupported executor (`vllm/config/vllm.py:899-963`). Overlaps CPU scheduling with GPU execution; keep on.
+- `scheduler_reserve_full_isl: bool = True` (`config/scheduler.py:140-144`) — admission requires the **full input length** to fit in KV, not just the first chunk; prevents chunked-prefill thrashing with long prompts. Good default for prefill-heavy RL.
+- `stream_interval` (`scheduler.py:151-155`) — batching of streamed tokens; irrelevant for offline `LLM.generate`-style rollouts.
+
+---
+
+## 2. The profile run: how `gpu_memory_utilization` becomes KV blocks
+
+### 2.1 Sequence
+
+`Worker.init_device` (`vllm/v1/worker/gpu_worker.py:239-309`): init NCCL **first** (so its buffers are in the baseline), snapshot memory, compute `requested_memory = ceil(total * gpu_memory_utilization)` and fail if `free < requested` (utils.py:403-423). Then `load_model` (weights, under the `"weights"` cumem tag when sleep mode is on, gpu_worker.py:338-345), then `determine_available_memory`.
+
+### 2.2 `determine_available_memory` (`gpu_worker.py:353-506`)
+
+```python
+with memory_profiling(self.init_snapshot, weights_memory=...) as profile_result:
+    self.model_runner.profile_run()                       # dummy forward
+    profile_torch_peak = torch.accelerator.memory_stats(...)["allocated_bytes.all.peak"]
+    cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()  # if graphs enabled
+
+profile_result.non_kv_cache_memory = (
+    non_torch_increase + torch_peak_increase + weights_memory)
+
+self.available_kv_cache_memory_bytes = (
+    self.requested_memory
+    - profile_result.non_kv_cache_memory
+    - cudagraph_memory_estimate_applied)                  # gpu_worker.py:443-447
+```
+
+The **dummy batch**: `profile_run` (`vllm/v1/worker/gpu_model_runner.py:6073-6146`) runs `_dummy_run(self.max_num_tokens, is_profile=True)` where `max_num_tokens = scheduler_config.max_num_batched_tokens` (`gpu_model_runner.py:464`), with tokens spread **evenly across `min(num_tokens, max_num_seqs)` requests** (`gpu_model_runner.py:5599-5603`), plus a dummy sampler run, plus (for multimodal) a max-size encoder batch. So the activation peak reserved forever scales with `max_num_batched_tokens` — another reason that knob trades against KV space.
+
+Memory taxonomy (excellent docstring at `vllm/utils/mem_utils.py:191-246`): (1) other processes' memory, (2) torch memory of this instance (weights + activation peak), (3) non-torch memory of this instance (NCCL, attention backend workspaces, CUDA context). `available_kv = requested − weights − activation_peak − non_torch − cudagraph_estimate`.
+
+### 2.3 Blocks from bytes
+
+`get_num_blocks` (`vllm/v1/core/kv_cache_utils.py:935-952`):
+
+```python
+num_blocks = int(available_memory // page_size // num_layers)
+num_blocks = max(num_blocks, 0)
+```
+
+(uniform single-group case at kv_cache_utils.py:1268-1271 divides by `page_size_bytes` of the merged spec; hybrid case divides by per-group page size × group layer count, §3.3).
+
+### 2.4 Why too-low `gpu_memory_utilization` → 0 blocks / errors
+
+`available_kv` can go **negative** because `requested_memory` (util × total) can be smaller than the fixed costs (weights + activations + non-torch + graphs). Then `_check_enough_kv_cache_memory` (`kv_cache_utils.py:691-728`) raises:
+
+```python
+if available_memory <= 0:
+    raise ValueError("No available memory for the cache blocks. Try increasing `gpu_memory_utilization` ...")
+```
+
+and even with positive memory, a second check requires room for **one full-`max_model_len` request**:
+
+```python
+needed_memory = max_memory_usage_bytes(...)   # one request at max_model_len, all layers
+if needed_memory > available_memory:
+    raise ValueError("To serve at least one request with the model's max seq len (...) ...")
+```
+
+with `estimate_max_model_len` (binary search, kv_cache_utils.py:740-791) included in the error message. Plus the early init check: `free < total*util` → ValueError at startup (utils.py:412-421). These three are the canonical failure modes a config auto-sizer must avoid: (a) util too high for colocated free memory, (b) util too low to cover fixed costs, (c) KV remainder too small for one max-length sequence.
+
+After sizing, vLLM logs `"GPU KV cache size: N tokens"` and `"Maximum concurrency for L tokens per request: X.XXx"` (`kv_cache_utils.py:1733-1736`, computed by `get_max_concurrency_for_kv_cache_config` at 877-895) — `max_concurrency = num_blocks / blocks_per_max_len_request`. For RL you want this ≥ the number of concurrent rollout sequences (e.g. `num_envs × group_size`), or accept queueing.
+
+---
+
+## 3. KV cache math
+
+### 3.1 Bytes per token per layer
+
+`AttentionSpec.real_page_size_bytes` (`vllm/v1/kv_cache_interface.py:166-184`):
+
+```python
+2 * block_size * num_kv_heads * head_size * get_dtype_size(dtype)   # 2 = K + V
+```
+
+⇒ **bytes/token/layer = 2 × num_kv_heads × head_size × dtype_size**. Total = × num_layers × max_model_len per max-length request (`FullAttentionSpec.max_memory_usage_bytes`, kv_cache_interface.py:210-218: `cdiv(max_model_len, block_size) * page_size_bytes`, divided by dcp×pcp context-parallel size when used).
+
+- **GQA**: `num_kv_heads` is the (small) KV head count, and it's the *per-worker* value — TP divides KV heads across ranks, so per-GPU KV cost scales 1/TP. Example: Qwen2.5-7B (28 layers, 4 KV heads, head 128, bf16) = 2·4·128·2 = 2 KiB/token/layer = 57344 B/token ≈ **18.3 GiB at 32K context for one sequence**... (×: 28 layers · 2048 B · 32768 tok = 1.75 GiB). Per 1000 tokens: 1.75 MiB × num_layers-equivalent — concretely 57344 B/token ≈ 56 KiB/token total.
+- **dtype_size**: bf16/fp16 = 2, fp8 = 1 (via `get_dtype_size`), nvfp4 packs fp4 + per-16 fp8 scales (`nvfp4_kv_cache_full_dim`, kv_cache_interface.py:168-177).
+- **Per-token-head quant** adds `2 * block_size * num_kv_heads * 4` bytes of scales per page (kv_cache_interface.py:157-160).
+
+### 3.2 Sliding window (Gemma) — pool sized like full attention, but per-request usage is bounded
+
+`SlidingWindowSpec` (`kv_cache_interface.py:434-494`): page bytes = `block_size * num_kv_heads * (head_size + head_size_v) * dtype_size` (identical to 2× when K/V head dims match). The per-request **admission bound** is what differs:
+
+```python
+num_tokens = min(sliding_window - 1 + max_num_batched_tokens, max_model_len)
+blocks = cdiv(num_tokens, block_size) + 1                  # kv_cache_interface.py:463-483
+```
+
+so a Gemma-style SWA layer holds only ~window+chunk tokens per request regardless of context length; blocks behind the window are freed during decode. `ChunkedLocalAttentionSpec` (Llama-4 local) analogous with `attention_chunk_size` (407-431).
+
+**Hybrid models (Gemma2/3: 5:1 SWA:full)**: layers are grouped by spec into KV-cache groups with equal layer counts (`_get_kv_cache_groups_uniform_page_size`, `kv_cache_utils.py:1057-1176` — the docstring walks the Gemma case). All groups must share a uniform page size; block tables are allocated per group; total blocks = `available // (page_size * group_size)` where group_size = layers per group (1304-1306). The hybrid manager means **full-attention layers dominate per-request KV cost** while SWA layers stay cheap — naive `2·heads·dim·layers·len` over-estimates Gemma KV by ~6×. `disable_hybrid_kv_cache_manager` (`config/scheduler.py:132-138`) collapses everything to full-attention accounting (wasteful; only for debugging/unsupported combos). `mamba_block_size`/`mamba_cache_mode` (`cache.py:120-140`) cover SSM-hybrid models similarly.
+
+### 3.3 MLA (DeepSeek)
+
+`MLAAttentionSpec` (`kv_cache_interface.py:337-396`): effectively `num_kv_heads=1` with a single latent `head_size` (576 = 512 kv_lora_rank + 64 rope for V3), and **no 2× K+V factor** — `real_page_size_bytes = block_size * num_kv_heads * head_size * dtype_size` (363-368). `fp8_ds_mla` uses fixed custom layouts: 656 B/token (V3.2) or 584 B/token (V4) (354-362). MLA KV is ~10-50× smaller per token than equivalent GQA — relevant if AgileRL ever fine-tunes DeepSeek-family models.
+
+### 3.4 Auto-estimation utilities worth reusing
+
+- `estimate_max_model_len(vllm_config, kv_cache_spec, available_memory)` — binary search, `kv_cache_utils.py:740-791`.
+- `get_max_concurrency_for_kv_cache_config` — `kv_cache_utils.py:877-895`.
+- `max_memory_usage_bytes` — `kv_cache_utils.py:731-737` (sums per-spec worst case).
+These embody vLLM's own KV arithmetic including hybrid/SWA/MLA corner cases; an auto-configurer can import them rather than reimplementing.
+
+---
+
+## 4. Prefill vs decode tuning
+
+### 4.1 How the V1 scheduler spends its token budget
+
+`Scheduler.schedule()` (`vllm/v1/core/sched/scheduler.py:336-830`): one global budget `token_budget = max_num_scheduled_tokens` (= `max_num_batched_tokens` unless spec decode shrinks it, `config/scheduler.py:56-61`). **RUNNING requests are scheduled first** (line 364-498) — i.e. decodes (1 token each, + draft tokens) and in-flight chunked prefills — then WAITING requests consume the *remainder* (548-802). There is no separate prefill/decode phase: chunked prefill mixes both in every step. Consequences:
+
+- **`max_num_batched_tokens` is the chunked-prefill chunk size.** A waiting prompt is admitted with `num_new_tokens = min(prompt_len_remaining, token_budget_left)` (scheduler.py:654-669). Bigger budget = faster prefill completion, but each step's forward is bigger, so **inter-token latency for concurrently decoding sequences degrades** — and in RL that latency is pure rollout wall-clock only if decodes dominate the tail.
+- **`long_prefill_token_threshold`** (`config/scheduler.py:80-82`, default 0=off) caps tokens scheduled per request per step (applied at scheduler.py:390-391 for running and 655-657 for waiting). It defaults to `0.04 * max_model_len` only when `max_num_partial_prefills > 1` is set (`config/scheduler.py:244-246`). It is the knob to stop one giant prompt monopolizing steps.
+- **`max_num_partial_prefills` / `max_long_partial_prefills` are vestigial in V1**: defined in config (`config/scheduler.py:70-78`) and CLI, but **nothing in `vllm/v1/` consumes them** (grep confirms only config + arg_utils references). Their only effect is triggering the long-threshold default above. Do not surface them as real knobs.
+- `max_num_seqs` caps concurrent scheduled requests per step (`config/scheduler.py:63-68`); the real decode concurrency limit is usually KV space (§2.4 max-concurrency log), whichever is smaller.
+
+### 4.2 Decode-heavy RL envs (short prompts, long multi-turn generations)
+
+What matters, in order:
+1. **KV capacity** — decode throughput saturates when `num_running ≈ max_concurrency`; everything in §2/§3 (util, kv_cache_dtype=fp8, max_model_len right-sizing) feeds this. Preemption (recompute, §1.8) is the failure mode when KV runs out mid-rollout — for grouped GRPO rollouts all sequences grow together, hitting KV pressure simultaneously; budget for `group_size × num_prompts × expected_len`, not average.
+2. **`max_num_seqs`** — must be ≥ desired concurrent rollouts; default 256 (A100-class) is usually plenty; raising it costs cudagraph captures (max capture = `min(max_num_seqs·2, 512)`) and bigger persistent batch buffers.
+3. **CUDA graphs** — decode steps are small-batch and Python-overhead-bound; `FULL_AND_PIECEWISE` (default O2) matters most here. `enforce_eager=True` for faster startup is a meaningful *decode* throughput sacrifice (commonly 10-30% at small batch).
+4. **Prefix caching** — multi-turn envs resubmit the conversation each turn; with prefix caching on (default), turns t<n hit cache and only the new turn is prefilled. Shared system prompts across a GRPO group dedupe similarly (group of N samples from one prompt: 1 prefill + N-1 cache hits). Remember the LoRA-name key and `reset_prefix_cache()` on in-place weight updates (§1.6).
+5. **`max_num_batched_tokens` can be modest** (4-8K): prompts are short, so prefill admission isn't the bottleneck.
+
+### 4.3 Prefill-heavy RL envs (long prompt, short completion — e.g. reasoning-over-context)
+
+1. **`max_num_batched_tokens` is the throughput knob** — it bounds prefill tokens/step. The H100 default (16384 offline) vs A100 (8192) reflects exactly this trade (arg_utils.py:2290-2312). Raising it raises the profile-run activation reservation (§2.2) and compile time; on colocated 40 GB cards measure before raising.
+2. Chunked prefill is on by default; with mostly-prefill traffic the budget is spent almost entirely on prefill anyway.
+3. `scheduler_reserve_full_isl=True` (default) prevents admitting prompts whose full ISL can't fit — keep it.
+4. Prefix caching still pays if prompts share long templates/few-shot prefixes; otherwise it's near-free overhead (hashing).
+5. `long_prefill_token_threshold` only if you need decode latency fairness while giant prompts stream in — for batch RL rollouts, leave 0 (max throughput).
+
+---
+
+## 5. Sleep mode and LoRA serving
+
+### 5.1 Sleep levels (`vllm/entrypoints/llm.py:994-1032`, `vllm/v1/worker/gpu_worker.py:160-199`, `vllm/device_allocator/cumem.py:171-243`)
+
+Requires `enable_sleep_mode=True` (`config/model.py:305`; implies/forces `enable_cumem_allocator`, model.py:530-538; CUDA-only). Weights are allocated under the cumem tag `"weights"` (gpu_worker.py:338-345), KV cache under `"kv_cache"` (gpu_worker.py:553).
+
+- **Level 0** (new in this version): pause scheduling only; nothing freed (llm.py:1002-1003). Resume with `wake_up(tags=["scheduling"])`.
+- **Level 1**: `allocator.sleep(offload_tags=("weights",))` — weights **copied to pinned CPU memory** and GPU pages unmapped; everything else (KV cache, cudagraph pools, workspaces in the pool) **discarded** (gpu_worker.py:173; cumem.py:192-207). Wake restores weights from CPU. Needs CPU RAM ≥ weights size.
+- **Level 2**: `offload_tags=tuple()` — **everything discarded**, including weights; only module buffers (small) are saved/restored Python-side (gpu_worker.py:165-170, 190-196). Wake leaves weight memory mapped-but-uninitialized; caller must reload weights.
+- `wake_up(tags=["weights"])` then later `wake_up(tags=["kv_cache"])` enables the RLHF two-phase pattern: map weights, copy in new weights, then re-create KV — avoids holding both at peak (llm.py:1019-1032). KV contents are **always lost** on sleep (both levels): prefix cache resets, in-flight requests must be drained (`mode="abort"|"wait"|"keep"` param, llm.py:994,1014-1016).
+
+**AgileRL-specific caveat (from prior validation work, not this repo):** for bnb-4bit (QLoRA) bases, level 2 is unusable (weights can't be re-quantized in place on reload) and level 1 frees little of what the trainer needs; the working colocated pattern is the "standby" patch keeping `"weights"`-tagged allocations resident and freeing only KV — i.e. effectively a custom level between 1 and 0. The native tags machinery above is exactly the seam that patch hooks (`CuMemAllocator.sleep/wake_up`).
+
+### 5.2 LoRA knobs (`vllm/config/lora.py`)
+
+- `max_lora_rank: 16` default; allowed `{1,8,16,32,64,128,256,320,512}` (lora.py:26,34). Must be ≥ the training LoRA r — **GPU LoRA weight buffers are statically sized `max_loras × max_lora_rank × hidden` per target module**, so setting it above the actual rank wastes VRAM proportionally.
+- `max_loras: 1` default (concurrently batched adapters, lora.py:36); RL with a single policy adapter needs exactly 1. `max_cpu_loras` defaults to `max_loras` (lora.py:43-45,110-116).
+- Punica index buffers are sized by `max_num_batched_tokens` (`vllm/lora/punica_wrapper/punica_base.py:133-148`; also why `max_num_batched_tokens` is in the compile hash, `config/scheduler.py:204-213`).
+- `fully_sharded_loras=False` (lora.py:38-42) — turn on for high TP/rank/seq-len; irrelevant at TP=1.
+- `target_modules` (lora.py:48-51) can restrict LoRA application for speed.
+- `specialize_active_lora` (lora.py:67-73) — extra cudagraphs per active-LoRA count; skip for single-adapter RL.
+
+---
+
+## 6. Speculative decoding for RL rollouts
+
+Config: `vllm/config/speculative.py`. Methods: `ngram`, `ngram_gpu`, `suffix`, `draft_model`, `medusa`, `mlp_speculator`, EAGLE/MTP family, `custom_class` (speculative.py:59-68).
+
+- **ngram** (`prompt_lookup`): drafts by matching the last n-gram against prior context. Defaults when unset: `prompt_lookup_min = prompt_lookup_max = 5` (speculative.py:587-590, "arbitrarily chosen"); `num_speculative_tokens` required. Zero extra GPU memory for a draft model; CPU-side numba matcher, currently capped at **1 thread** per rank (`vllm/v1/spec_decode/ngram_proposer.py:36-53`, threshold 8192 batch tokens for multithreading). Cost: each accepted-or-not draft token occupies scheduler budget (`num_lookahead_tokens` reserved in `allocate_slots`, scheduler.py:213-220,447) and KV blocks for lookahead; rejected tokens are wasted compute.
+- **Benefit profile for RL:** ngram only pays when outputs **copy spans from the context** — code editing, retrieval-grounded answers, multi-turn envs that echo state. For free-form math/reasoning generation (typical GRPO), acceptance is low and it can net-lose. **Sampling caveat:** RL rollouts run temperature ~1.0; rejection sampling (`rejection_sample_method="standard"`, speculative.py:191-194) preserves the target distribution exactly, so logprob-correctness for importance ratios is maintained — but acceptance rates drop sharply at high temperature, further shrinking the win. The `"synthetic"` acceptance mode does NOT preserve the distribution — never use for RL.
+- **suffix decoding** (Arctic Inference required, speculative.py:808-815) — adaptive ngram-on-steroids over a suffix tree of prior outputs; promising for repetitive RL envs but adds a pip dependency.
+- EAGLE/draft-model: needs trained head / extra VRAM for the drafter; weights go stale as the policy trains — impractical for on-policy RL unless the head is also synced. Skip.
+- Interaction: spec tokens inflate `max_cudagraph_capture_size` (`decode_query_len = 1 + num_speculative_tokens`, vllm.py:1639-1647); async scheduling stays enabled only for EAGLE/MTP/draft/ngram-GPU kinds (vllm.py:935-945) — plain CPU `ngram` **disables async scheduling**, an often-overlooked hidden cost.
+- **Recommendation for the auto-configurer:** default OFF; expose `ngram` (k=3-5, lookup 2-5) as an opt-in for envs flagged as copy-heavy, and only with measured acceptance.
+
+---
+
+## 7. Override vs trust — summary for the AgileRL auto-configurer
+
+**Trust vLLM (leave default):** chunked prefill (on), prefix caching (on, but call `reset_prefix_cache()` on in-place weight updates), block_size (16/backend), async scheduling (on), scheduler policy (fcfs), cudagraph capture-size list, hybrid KV grouping for Gemma/SWA/MLA, `scheduler_reserve_full_isl`.
+
+**Always set explicitly:**
+- `max_model_len` = prompt+completion budget from the env profile (never let it default to the model's 128K — KV "one full request" check will eat the budget).
+- `gpu_memory_utilization` — computed from *free-after-trainer* memory in colocated mode (fraction-of-total semantics!), or generous (0.85-0.92) in decoupled mode. Or skip the guesswork with `kv_cache_memory_bytes`.
+- `enable_sleep_mode=True` in colocated mode (and the standby patch for QLoRA).
+- LoRA: `max_lora_rank` = training r exactly, `max_loras=1`.
+
+**Tune from the workload profile:**
+- `max_num_batched_tokens`: prefill-heavy ↑ (8-16K), decode-heavy ↓ (2-8K, freeing activation+LoRA-buffer memory for KV); remember the A100-vs-H100 default split.
+- `max_num_seqs`: ≥ concurrent rollout count; check against logged "Maximum concurrency".
+- `kv_cache_dtype="fp8"`: decode-heavy lever for 2× concurrency (validate logprob sensitivity for importance-ratio algorithms first).
+- `enforce_eager`: only for debugging/startup-time; costs decode throughput.
+- `long_prefill_token_threshold`: only if mixing live decodes with huge prompt streams.
+- Speculative ngram: opt-in for copy-heavy envs only.
+
+**Sanity formulas** (per GPU, TP-divided): `kv_bytes_per_token = 2 · (num_kv_heads/TP) · head_dim · dtype_size · num_full_attn_layers` (+ bounded SWA-layer term `≈ window` tokens for Gemma-like models); `available_kv ≈ total·util − weights/TP − activation_peak(max_num_batched_tokens) − NCCL/workspace (~1-2 GiB) − cudagraph_pool`; `max_concurrency = available_kv / (kv_bytes_per_token · max_model_len)`. vLLM's own implementations of these live in `vllm/v1/core/kv_cache_utils.py` (§3.4) and are importable.

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -4778,8 +4778,9 @@ class LLMAlgorithm(EvolvableAlgorithm, ABC):
             "max_model_len": self.max_model_len,
             "distributed_executor_backend": "external_launcher",
             "seed": process_index // self.vllm_config.tensor_parallel_size,
-            "max_num_batched_tokens": self.vllm_config.max_num_seqs
-            * self.max_model_len,
+            "max_num_batched_tokens": self.vllm_config.resolve_max_num_batched_tokens(
+                self.max_model_len
+            ),
             "model_impl": "vllm",
             "enable_sleep_mode": self.vllm_config.sleep_mode,
         }
@@ -4787,6 +4788,10 @@ class LLMAlgorithm(EvolvableAlgorithm, ABC):
             llm_kwargs["dtype"] = self.vllm_config.dtype
         if self.vllm_config.quantization is not None:
             llm_kwargs["quantization"] = self.vllm_config.quantization
+        if self.vllm_config.enforce_eager is not None:
+            llm_kwargs["enforce_eager"] = self.vllm_config.enforce_eager
+        if self.vllm_config.enable_prefix_caching is not None:
+            llm_kwargs["enable_prefix_caching"] = self.vllm_config.enable_prefix_caching
         if self.vllm_config.kv_cache_memory_bytes is not None:
             # Forwards to vLLM's ``CacheConfig.kv_cache_memory_bytes``. When set,
             # vLLM's ``determine_available_memory`` returns early and skips the
@@ -4810,7 +4815,7 @@ class LLMAlgorithm(EvolvableAlgorithm, ABC):
             raise
 
         if self.vllm_config.sleep_mode:
-            self.llm.sleep(level=2)
+            self.llm.sleep(level=self.vllm_config.sleep_level)
 
         if self.accelerator is not None:
             self.accelerator.wait_for_everyone()
@@ -4914,7 +4919,7 @@ class LLMAlgorithm(EvolvableAlgorithm, ABC):
             self.accelerator is None or self.accelerator.is_main_process
         ):
             torch.cuda.empty_cache()
-            self.llm.sleep(level=2)
+            self.llm.sleep(level=self.vllm_config.sleep_level)
             self._vllm_awake = False
 
         if self.use_vllm:

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -1425,10 +1425,29 @@ class VLLMConfig:
     :param max_num_seqs: Maximum number of sequences processed concurrently.  For GRPO,
         set this to at least ``group_size`` to avoid request queuing, defaults to 8.
     :type max_num_seqs: int, optional
+    :param max_num_batched_tokens: Maximum number of tokens processed in a single engine
+        step — vLLM V1's chunked-prefill token budget.  ``None`` falls back to
+        ``max_num_seqs * max_model_len``.  Prefill-heavy workloads benefit from larger
+        values; decode-heavy workloads can lower it to free memory for KV cache, defaults
+        to None.
+    :type max_num_batched_tokens: int | None, optional
+    :param enable_prefix_caching: Forwarded to vLLM's ``enable_prefix_caching``.  ``None``
+        uses vLLM's own default (on for generative models in V1).  Benefits grouped or
+        multi-turn rollouts that share long prompt prefixes, defaults to None.
+    :type enable_prefix_caching: bool | None, optional
+    :param enforce_eager: Forwarded to vLLM's ``enforce_eager``.  ``True`` disables
+        CUDA-graph capture (lower memory, slower decode); ``None`` uses vLLM's default
+        (``False``), defaults to None.
+    :type enforce_eager: bool | None, optional
     :param sleep_mode: Put vLLM to sleep between ``get_action`` calls to free GPU memory
         for training.  Cannot be used with agent populations on a single device,
         defaults to False.
     :type sleep_mode: bool, optional
+    :param sleep_level: vLLM sleep level used when ``sleep_mode`` is enabled.  Level 2
+        discards weights and KV cache; level 1 offloads weights to CPU and frees KV.
+        Quantized (e.g. bnb-4bit) engines require a level that keeps weights resident,
+        defaults to 2.
+    :type sleep_level: int, optional
     :param dtype: Model weight dtype passed to the vLLM ``LLM`` constructor
         (e.g. ``"bfloat16"``, ``"float16"``).  ``None`` lets vLLM choose,
         defaults to None.
@@ -1474,9 +1493,11 @@ class VLLMConfig:
     tensor_parallel_size: int = 1
     gpu_memory_utilization: float = 0.3
     max_num_seqs: int = 8
-    swap_space: float | None = None
+    max_num_batched_tokens: int | None = None
+    enable_prefix_caching: bool | None = None
     enforce_eager: bool | None = None
     sleep_mode: bool = False
+    sleep_level: int = 2
     dtype: str | None = None
     quantization: str | None = None
     stop_sequences: list[str] | None = None
@@ -1487,12 +1508,30 @@ class VLLMConfig:
     kv_cache_memory_bytes: int | None = None
 
     def __post_init__(self) -> None:
+        if self.sleep_level not in (0, 1, 2):
+            msg = f"sleep_level must be 0, 1 or 2, got {self.sleep_level}."
+            raise ValueError(msg)
         if self.sleep_mode:
             warnings.warn(
                 """VLLM sleep mode cannot be used with populations of agents on a single device. To use sleep mode, ensure,
                 you are training a single agent or, alternatively, use a different device for each agent.""",
                 stacklevel=2,
             )
+
+    def resolve_max_num_batched_tokens(self, max_model_len: int) -> int:
+        """Resolve the vLLM prefill token budget.
+
+        Returns the explicit ``max_num_batched_tokens`` when set, otherwise the
+        ``max_num_seqs * max_model_len`` default.
+
+        :param max_model_len: Engine context length.
+        :type max_model_len: int
+        :return: Token budget to pass to vLLM's ``max_num_batched_tokens``.
+        :rtype: int
+        """
+        if self.max_num_batched_tokens is not None:
+            return self.max_num_batched_tokens
+        return self.max_num_seqs * max_model_len
 
 
 def create_warmup_cosine_scheduler(

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -362,7 +362,6 @@ def generate_grpo(
             kv_cache_memory_bytes=32 * 1024 * 1024,
             max_num_seqs=1,
             sleep_mode=sleep_mode,
-            swap_space=0,
             enforce_eager=False,
         )
 

--- a/tests/test_utils/test_algo_utils.py
+++ b/tests/test_utils/test_algo_utils.py
@@ -1469,6 +1469,40 @@ def test_vllm_config_sleep_mode_warns():
         VLLMConfig(sleep_mode=True)
 
 
+def test_vllm_config_engine_knob_defaults():
+    """New engine knobs default to behaviour-preserving values."""
+    config = VLLMConfig()
+    assert config.max_num_batched_tokens is None
+    assert config.enable_prefix_caching is None
+    assert config.enforce_eager is None
+    assert config.sleep_level == 2
+
+
+def test_vllm_config_swap_space_removed():
+    """The dead ``swap_space`` field is gone (it was never forwarded to vLLM)."""
+    with pytest.raises(TypeError):
+        VLLMConfig(swap_space=4)
+
+
+def test_vllm_config_resolve_max_num_batched_tokens_default():
+    """Unset token budget falls back to ``max_num_seqs * max_model_len``."""
+    config = VLLMConfig(max_num_seqs=8)
+    assert config.resolve_max_num_batched_tokens(1024) == 8192
+
+
+def test_vllm_config_resolve_max_num_batched_tokens_override():
+    """Explicit token budget is returned verbatim, ignoring the default product."""
+    config = VLLMConfig(max_num_seqs=8, max_num_batched_tokens=4096)
+    assert config.resolve_max_num_batched_tokens(1024) == 4096
+
+
+@pytest.mark.parametrize("level", [-1, 3, 99])
+def test_vllm_config_invalid_sleep_level_raises(level):
+    """``sleep_level`` outside {0, 1, 2} is rejected at construction."""
+    with pytest.raises(ValueError, match="sleep_level"):
+        VLLMConfig(sleep_level=level)
+
+
 def test_concatenate_experiences_into_batches():
     """concatenate_experiences_into_batches."""
     space = spaces.Box(0, 1, (3,))


### PR DESCRIPTION
## What

**Phase 0 of the auto-config initiative** (knob hygiene). Makes the colocated vLLM engine knobs real and derivable. Every change is **behaviour-preserving at its default** — a run that pins values explicitly is unaffected.

Implements items from §3.2 of the [design doc](https://github.com/AgileRL/AgileRL/blob/feature/auto-config-llm-batch/docs/llm_finetuning/auto_config_design.md).

## Changes

| Knob | Before | After |
|---|---|---|
| `max_num_batched_tokens` | hardcoded `max_num_seqs × max_model_len` | new `VLLMConfig` field; `None` falls back to the same product via `resolve_max_num_batched_tokens()` |
| `enable_prefix_caching` | never passed to `LLM()` | new field; forwarded only when set, else vLLM's default |
| `sleep_level` | two hardcoded `llm.sleep(level=2)` calls | new field (default `2`); validated ∈ {0,1,2} |
| `enforce_eager` | declared on `VLLMConfig` but **never forwarded** (dead) | forwarded to `LLM()` when set |
| `swap_space` | declared but **never forwarded** (dead) | **removed** — vLLM V1 ignores it (preemption is recompute) |

`max_num_batched_tokens` is the most workload-sensitive engine knob: prefill-heavy envs want it large, decode-heavy envs want it small to free memory for KV cache. `sleep_level` matters because quantized (bnb-4bit) engines need a level that keeps weights resident.

## Why these are safe

- The new fields default to `None`/`2`, reproducing today's exact engine kwargs.
- `enforce_eager` was already accepted by `VLLMConfig` (just ignored), so existing callers that set it now get the behaviour they expected — and `False` (the only value in our tests) is vLLM's default anyway.
- `swap_space` removal is the one breaking change, but it only ever no-op'd; the single test passing it is updated.

## Tests

Adds locally-runnable `VLLMConfig` dataclass tests (no GPU/vLLM needed): new-field defaults, the token-budget resolver (fallback + override), `sleep_level` validation, and `swap_space` removal. Updates the GPU/CI grpo test that passed the removed arg.

> **Validation note:** authored and checked against local non-GPU tests + pre-commit. The engine-construction path itself (`_configure_vllm`) requires vLLM and is exercised by the GPU/CI suite, not locally — worth a confirming run on the A100 box before merge.

Stacked on #556 (design doc).
