### PR TITLE
Auto-config Phase 0: expose eval_temperature

### DIFF
--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -87,6 +87,10 @@ class GRPO(LLMAlgorithm):
     :type group_size: int, optional
     :param temperature: Temperature, controls randomness of text generation
     :type temperature: float, optional
+    :param eval_temperature: Sampling temperature used during evaluation
+        (``training=False``).  A small value gives near-deterministic eval rollouts,
+        defaults to 0.01
+    :type eval_temperature: float, optional
     :param repetition_penalty: Repetition penalty used during generation, defaults to 1.0
     :type repetition_penalty: float, optional
     :param top_p: Top-p nucleus sampling threshold, defaults to 0.95
@@ -200,6 +204,7 @@ class GRPO(LLMAlgorithm):
         update_epochs: int = 1,
         group_size: int = 8,
         temperature: float = 0.9,
+        eval_temperature: float = 0.01,
         repetition_penalty: float = 1.0,
         top_p: float = 0.95,
         top_k: int = 50,
@@ -319,6 +324,7 @@ class GRPO(LLMAlgorithm):
         self.group_size = group_size
         self.beta = beta
         self.temperature = temperature
+        self.eval_temperature = eval_temperature
         self.repetition_penalty = repetition_penalty
         self.top_p = top_p
         self.top_k = top_k
@@ -504,9 +510,7 @@ class GRPO(LLMAlgorithm):
                 completion_ids, completion_masks = self._generate_with_vllm_colocate(
                     prompt_batch,
                     group_size,
-                    temperature=self.temperature
-                    if training
-                    else 0.01,  # Almost deterministic for evaluation
+                    temperature=self.temperature if training else self.eval_temperature,
                 )
 
         return completion_ids, completion_masks

--- a/agilerl/algorithms/ppo_llm.py
+++ b/agilerl/algorithms/ppo_llm.py
@@ -91,6 +91,10 @@ class PPO(LLMAlgorithm):
     :type update_epochs: int, optional
     :param temperature: Sampling temperature for generation.
     :type temperature: float, optional
+    :param eval_temperature: Sampling temperature used during evaluation
+        (``training=False``).  A small value gives near-deterministic eval rollouts,
+        defaults to 0.01
+    :type eval_temperature: float, optional
     :param repetition_penalty: Repetition penalty used during generation.
     :type repetition_penalty: float, optional
     :param top_p: Nucleus sampling threshold.
@@ -173,6 +177,7 @@ class PPO(LLMAlgorithm):
         max_grad_norm: float = 1.0,
         update_epochs: int = 1,
         temperature: float = 1.0,
+        eval_temperature: float = 0.01,
         repetition_penalty: float = 1.0,
         top_p: float = 1.0,
         top_k: int = 50,
@@ -298,6 +303,7 @@ class PPO(LLMAlgorithm):
         self.gae_lambda = gae_lambda
         self.update_epochs = update_epochs
         self.temperature = temperature
+        self.eval_temperature = eval_temperature
         self.repetition_penalty = repetition_penalty
         self.top_p = top_p
         self.top_k = top_k
@@ -408,9 +414,7 @@ class PPO(LLMAlgorithm):
                 completion_ids, completion_masks = self._generate_with_vllm_colocate(
                     prompt_batch,
                     1,
-                    temperature=self.temperature
-                    if training
-                    else 0.01,  # Almost deterministic for evaluation
+                    temperature=self.temperature if training else self.eval_temperature,
                 )
 
         return completion_ids, completion_masks

--- a/agilerl/algorithms/reinforce_llm.py
+++ b/agilerl/algorithms/reinforce_llm.py
@@ -86,6 +86,10 @@ class REINFORCE(LLMAlgorithm):
     :type update_epochs: int
     :param temperature: Sampling temperature for generation.
     :type temperature: float
+    :param eval_temperature: Sampling temperature used during evaluation
+        (``training=False``).  A small value gives near-deterministic eval rollouts,
+        defaults to 0.01
+    :type eval_temperature: float, optional
     :param repetition_penalty: Repetition penalty for generation.
     :type repetition_penalty: float
     :param top_p: Top-p (nucleus) sampling parameter.
@@ -154,6 +158,7 @@ class REINFORCE(LLMAlgorithm):
         max_grad_norm: float = 1.0,
         update_epochs: int = 1,
         temperature: float = 1.0,
+        eval_temperature: float = 0.01,
         repetition_penalty: float = 1.0,
         top_p: float = 1.0,
         top_k: int = 50,
@@ -258,6 +263,7 @@ class REINFORCE(LLMAlgorithm):
         self.action_granularity = action_granularity
         self.update_epochs = update_epochs
         self.temperature = temperature
+        self.eval_temperature = eval_temperature
         self.repetition_penalty = repetition_penalty
         self.top_p = top_p
         self.top_k = top_k
@@ -366,9 +372,7 @@ class REINFORCE(LLMAlgorithm):
                 completion_ids, completion_masks = self._generate_with_vllm_colocate(
                     prompt_batch,
                     1,
-                    temperature=self.temperature
-                    if training
-                    else 0.01,  # Almost deterministic for evaluation
+                    temperature=self.temperature if training else self.eval_temperature,
                 )
 
         return completion_ids, completion_masks

--- a/tests/test_algorithms/test_llms/test_eval_temperature.py
+++ b/tests/test_algorithms/test_llms/test_eval_temperature.py
@@ -1,0 +1,36 @@
+"""Signature-level checks for the ``eval_temperature`` knob.
+
+These assert the constructor plumbing without building a model, so they run
+without vLLM/DeepSpeed (the heavier LLM suites ``importorskip`` those).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from agilerl.algorithms.cispo import CISPO
+from agilerl.algorithms.grpo import GRPO
+from agilerl.algorithms.gspo import GSPO
+from agilerl.algorithms.ppo_llm import PPO
+from agilerl.algorithms.reinforce_llm import REINFORCE
+
+LLM_ALGOS = [GRPO, GSPO, CISPO, PPO, REINFORCE]
+
+
+@pytest.mark.parametrize("algo", LLM_ALGOS)
+def test_eval_temperature_param_defaults_to_eval_value(algo):
+    """Every LLM RL algorithm exposes ``eval_temperature`` defaulting to 0.01."""
+    params = inspect.signature(algo.__init__).parameters
+    assert "eval_temperature" in params
+    assert params["eval_temperature"].default == 0.01
+
+
+@pytest.mark.parametrize("algo", [GSPO, CISPO])
+def test_eval_temperature_survives_signature_rebuild(algo):
+    """GSPO/CISPO rebuild their signature to hide ``loss_type``; the new knob
+    must come through that rebuild and ``loss_type`` must stay hidden."""
+    params = inspect.signature(algo.__init__).parameters
+    assert "eval_temperature" in params
+    assert "loss_type" not in params


### PR DESCRIPTION
## What

**Phase 0 of the auto-config initiative** (knob hygiene). Exposes the eval-time sampling temperature, which was hardcoded to `0.01` in the generation path of every LLM RL algorithm.

Implements §3.2 item 5 of the [design doc](https://github.com/AgileRL/AgileRL/blob/feature/auto-config-llm-batch/docs/llm_finetuning/auto_config_design.md).

## Changes

`GRPO`, `PPO` (LLM) and `REINFORCE` (LLM) gain an `eval_temperature: float = 0.01` constructor arg. The generation path now uses `self.temperature if training else self.eval_temperature` instead of the literal `0.01`. `GSPO`/`CISPO` inherit it automatically through GRPO's signature rebuild.

Behaviour-preserving: the default reproduces today's near-deterministic eval. Eval temperature is genuinely workload-dependent — some envs want greedy eval, others need a little entropy to avoid degenerate ties — and was previously unreachable.

## Tests

Adds `tests/test_algorithms/test_llms/test_eval_temperature.py` — signature-level assertions across all five algorithms (incl. the GSPO/CISPO `loss_type`-hiding signature rebuild). These run **without** vLLM/DeepSpeed, so they execute locally and in non-GPU CI.

> **Validation note:** the runtime generation path that consumes `eval_temperature` is gated behind vLLM/DeepSpeed and is exercised by the GPU/CI suite, not locally. Signature plumbing is locally verified.

Stacked on #557 (vLLM engine knob hygiene).
