### PR TITLE
Auto-config Phase 0: expose Liger GRPO chunk_size

### DIFF
--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -185,6 +185,10 @@ class GRPO(LLMAlgorithm):
         ``(B, T, V)`` and fusing only the rollout doesn't lower overall
         peak.
     :type use_fused_linear_logprobs: bool, optional
+    :param liger_chunk_size: Number of sequences per chunk in the Liger fused GRPO
+        loss.  Larger values trade memory for fewer kernel launches; only used when
+        ``use_liger_loss=True``, defaults to 1
+    :type liger_chunk_size: int, optional
     """
 
     def __init__(
@@ -239,6 +243,7 @@ class GRPO(LLMAlgorithm):
         reduce_memory_peak: bool = False,
         use_fused_linear_logprobs: bool = False,
         cast_logprobs_to_fp32: bool = True,
+        liger_chunk_size: int = 1,
     ) -> None:
         resolved_device = (
             f"cuda:{accelerator.process_index}"
@@ -325,6 +330,7 @@ class GRPO(LLMAlgorithm):
         self.beta = beta
         self.temperature = temperature
         self.eval_temperature = eval_temperature
+        self.liger_chunk_size = liger_chunk_size
         self.repetition_penalty = repetition_penalty
         self.top_p = top_p
         self.top_k = top_k
@@ -1087,7 +1093,7 @@ class GRPO(LLMAlgorithm):
             self.temperature,
             None,
             reference_log_probs is not None,  # use_ref_model
-            1,  # chunk_size
+            self.liger_chunk_size,  # chunk_size
             None,
         )
 

--- a/tests/test_algorithms/test_llms/test_liger_chunk_size.py
+++ b/tests/test_algorithms/test_llms/test_liger_chunk_size.py
@@ -1,0 +1,23 @@
+"""Signature-level checks for the GRPO-family ``liger_chunk_size`` knob.
+
+Asserts the constructor plumbing without building a model, so it runs without
+vLLM/DeepSpeed (the heavier LLM suites ``importorskip`` those).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from agilerl.algorithms.cispo import CISPO
+from agilerl.algorithms.grpo import GRPO
+from agilerl.algorithms.gspo import GSPO
+
+
+@pytest.mark.parametrize("algo", [GRPO, GSPO, CISPO])
+def test_liger_chunk_size_defaults_to_one(algo):
+    """GRPO and its variants expose ``liger_chunk_size`` defaulting to 1."""
+    params = inspect.signature(algo.__init__).parameters
+    assert "liger_chunk_size" in params
+    assert params["liger_chunk_size"].default == 1


### PR DESCRIPTION
## What

**Phase 0 of the auto-config initiative** (knob hygiene). Exposes the Liger fused-GRPO loss `chunk_size`, which was a hardcoded `1` positional arg into `LigerFusedLinearGRPOFunction.apply(...)`.

Implements §3.2 item 9 of the [design doc](https://github.com/AgileRL/AgileRL/blob/feature/auto-config-llm-batch/docs/llm_finetuning/auto_config_design.md).

## Changes

`GRPO` gains a `liger_chunk_size: int = 1` constructor arg, stored and passed into the Liger loss. `GSPO`/`CISPO` inherit it through GRPO's signature rebuild.

Behaviour-preserving: default `1` reproduces today's value, and it only takes effect under `use_liger_loss=True` (default off). Larger chunks trade memory for fewer kernel launches — a VRAM-headroom knob the auto-config resolver will want to set.

## Scope note

The PPO and DPO fused-loss paths (`agilerl/llm_ops/fused_loss.py:226,457`) hardcode the same chunk size. Threading the knob there changes those function signatures and the kernel call sites, so it wants GPU validation — left as a follow-up rather than bundled here.

## Tests

Adds `tests/test_algorithms/test_llms/test_liger_chunk_size.py` — signature-level assertions for GRPO/GSPO/CISPO that run without vLLM/DeepSpeed.

> **Validation note:** the Liger loss path itself requires `liger-kernel` + GPU and is exercised by the GPU/CI suite, not locally. Signature plumbing is locally verified.

Stacked on #558 (eval_temperature).
