### PR TITLE
Infer encoder architecture from the observation space

### DIFF
--- a/agilerl-arena/agilerl/arena/auth.py
+++ b/agilerl-arena/agilerl/arena/auth.py
@@ -11,9 +11,10 @@ import webbrowser
 from pathlib import Path
 from typing import Any
 
-from agilerl.arena.exceptions import ArenaAuthError, ArenaTimeoutError
 from keycloak import KeycloakOpenID
 from keycloak.exceptions import KeycloakError
+
+from agilerl.arena.exceptions import ArenaAuthError, ArenaTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +128,9 @@ class ArenaOAuth2:
     CREDENTIALS_DIR = Path.home() / ".arena"
     CREDENTIALS_FILE = CREDENTIALS_DIR / "credentials.json"
 
-    KEYCLOAK_URL = "https://auth.arena.agilerl.com"
+    # KEYCLOAK_URL = "https://auth.arena.agilerl.com"
+    # KEYCLOAK_URL = "https://arena-dev-auth.agilerl.rlops.ai/"
+    KEYCLOAK_URL = "http://localhost:8023"
     REALM = "arena"
     CLIENT_ID = "arena-cli"
 

--- a/agilerl-arena/agilerl/arena/auth.py
+++ b/agilerl-arena/agilerl/arena/auth.py
@@ -11,10 +11,9 @@ import webbrowser
 from pathlib import Path
 from typing import Any
 
+from agilerl.arena.exceptions import ArenaAuthError, ArenaTimeoutError
 from keycloak import KeycloakOpenID
 from keycloak.exceptions import KeycloakError
-
-from agilerl.arena.exceptions import ArenaAuthError, ArenaTimeoutError
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/agilerl/arena/client.py
+++ b/agilerl-arena/agilerl/arena/client.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Any, ClassVar, TypedDict
 
 import httpx
-from typing_extensions import Self
-
 from agilerl.arena.auth import (
     ArenaOAuth2,
     is_oauth_access_token_valid,
@@ -42,6 +40,7 @@ from agilerl.arena.utils import (
     prepare_env_upload,
     prepare_file_upload,
 )
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/agilerl/arena/client.py
+++ b/agilerl-arena/agilerl/arena/client.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any, ClassVar, TypedDict
 
 import httpx
+from typing_extensions import Self
+
 from agilerl.arena.auth import (
     ArenaOAuth2,
     is_oauth_access_token_valid,
@@ -40,7 +42,6 @@ from agilerl.arena.utils import (
     prepare_env_upload,
     prepare_file_upload,
 )
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,9 @@ class ArenaClient:
     :rtype: None
     """
 
-    BASE_URL: ClassVar[str] = "https://arena.agilerl.com"
+    # BASE_URL: ClassVar[str] = "https://arena.agilerl.com"
+    # BASE_URL: ClassVar[str] = "https://arena-dev.agilerl.rlops.ai"
+    BASE_URL: ClassVar[str] = "http://localhost:3001"
     CONFIG_DIR: ClassVar[Path] = Path.home() / ".arena"
     CONFIG_FILE: ClassVar[Path] = CONFIG_DIR / "config.json"
 

--- a/agilerl-arena/agilerl/arena/models/algorithms/dqn.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/dqn.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from pydantic import Field
+
 from agilerl.arena.models.algo import RLAlgorithmSpec, register
 from agilerl.arena.models.networks import QNetworkSpec
-from pydantic import Field
 
 
 @register()
@@ -15,6 +16,3 @@ class DQNSpec(RLAlgorithmSpec):
     double: bool = Field(default=False)
     lr: float = Field(default=0.0001, ge=0.0)
     net_config: QNetworkSpec | None = Field(default=None)
-
-    # NOTE: Don't support cudagraphs on Arena yet
-    cudagraphs: bool = Field(default=False, exclude=True)

--- a/agilerl-arena/agilerl/arena/models/algorithms/dqn.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/dqn.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from pydantic import Field
-
 from agilerl.arena.models.algo import RLAlgorithmSpec, register
 from agilerl.arena.models.networks import QNetworkSpec
+from pydantic import Field
 
 
 @register()

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args
 
-import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 import yaml
+from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer, model_validator
+from typing_extensions import Self
+
+import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 from agilerl.arena.models.algo import (
     ARENA_REGISTRY,
     AlgoSpecT,
@@ -18,8 +21,6 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
-from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer, model_validator
-from typing_extensions import Self
 
 _MANIFEST_ENCODER_ARCHS = ("mlp", "cnn", "lstm", "simba", "multiinput")
 
@@ -67,8 +68,10 @@ def _normalize_network_arch(
     but :class:`NetworkSpec` (a discriminated union) expects it nested
     under ``encoder_config``.  This helper bridges the two representations.
 
-    :raises ValueError: If ``arch`` is missing from both the network root and
-        ``encoder_config``.
+    If ``arch`` is missing from both the network root and ``encoder_config``,
+    the data is returned unchanged: the Arena backend performs its own
+    obs-space-aware ``arch`` resolution server-side, so the client defers to
+    it instead of rejecting the manifest.
     """
     # If passing a network spec we already have the correct structure
     if not isinstance(data, dict):
@@ -82,14 +85,9 @@ def _normalize_network_arch(
     )
     arch = top_level_arch or nested_arch
 
-    # If arch is not found in the network or encoder_config, raise an error
+    # If arch is not found, defer resolution to the server (obs-space-aware).
     if arch is None:
-        supported = ", ".join(_MANIFEST_ENCODER_ARCHS)
-        msg = (
-            "Missing encoder architecture in the manifest. "
-            f"Set 'arch' at the top level of 'network'. Supported values: {supported}."
-        )
-        raise ValueError(msg)
+        return data
 
     if encoder_config is None:
         data["encoder_config"] = {"arch": arch}
@@ -98,6 +96,25 @@ def _normalize_network_arch(
         data["encoder_config"].setdefault("arch", arch)
 
     return data
+
+
+def _network_has_arch(network: dict[str, Any]) -> bool:
+    """Whether a raw network dict declares a resolvable ``arch``.
+
+    Checks both the network root and ``encoder_config`` (the two places a
+    manifest may place it). Used to decide whether the network section can be
+    validated client-side, or must be deferred to the Arena backend's own
+    obs-space-aware resolution.
+
+    :param network: Raw network section dict.
+    :type network: dict[str, Any]
+    :returns: ``True`` if ``arch`` is present at either location.
+    :rtype: bool
+    """
+    if network.get("arch"):
+        return True
+    encoder_config = network.get("encoder_config")
+    return isinstance(encoder_config, dict) and bool(encoder_config.get("arch"))
 
 
 def _resolve_algorithm(data: Any) -> AlgoSpecT:
@@ -156,6 +173,12 @@ def _resolve_network(data: dict[str, Any] | BaseModel) -> dict[str, Any]:
 
     Raw dicts are validated through :class:`NetworkSpec` so that default values are included in the serialized output.
 
+    If the raw dict has no resolvable ``arch`` (at the network root or nested
+    in ``encoder_config``), the network section is returned unchanged: the
+    Arena backend performs its own obs-space-aware ``arch`` resolution
+    server-side, so the client passes the raw section through rather than
+    validating (and rejecting) it.
+
     :param data: Network config dict or spec instance.
     :type data: Any
     :returns: A plain dictionary suitable for manifest storage.
@@ -171,6 +194,10 @@ def _resolve_network(data: dict[str, Any] | BaseModel) -> dict[str, Any]:
 
     if isinstance(data, dict) and "pretrained_model_name_or_path" in data:
         return FinetuningNetworkSpec.model_validate(data).model_dump(mode="json")
+
+    if isinstance(data, dict) and not _network_has_arch(data):
+        # Deferred: hand the raw network section to the server to validate.
+        return data
 
     normalized = _normalize_network_arch(data)
     spec = NetworkSpec.model_validate(normalized)
@@ -240,7 +267,10 @@ class TrainingManifest(BaseModel):
                     ),
                     None,
                 )
-                if spec_cls is not None:
+                # Skip when the network has no resolvable `arch`: the client
+                # defers to the Arena backend's obs-space-aware resolution
+                # rather than validating (and rejecting) the raw section.
+                if spec_cls is not None and _network_has_arch(self.network):
                     self.algorithm.net_config = spec_cls.model_validate(self.network)
             # LLM algorithms expect a pretrained model
             elif issubclass(algo_spec_cls, LLMAlgorithmSpec):

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -292,6 +292,27 @@ class TrainingManifest(BaseModel):
             )
             raise ValueError(msg)
 
+        recurrent = bool(getattr(self.algorithm, "recurrent", False))
+        net_config = getattr(self.algorithm, "net_config", None)
+        if isinstance(net_config, dict):
+            simba = bool(net_config.get("simba", False))
+        elif net_config is not None:
+            simba = bool(getattr(net_config, "simba", False))
+        elif isinstance(self.network, dict):
+            # Deferred path: unlike core, `net_config` is left unset (None)
+            # here when the network section has no resolvable `arch` (see
+            # `_resolve_network`/`_network_has_arch`), so fall back to the raw
+            # `network` dict which still carries the manifest's `simba` flag.
+            simba = bool(self.network.get("simba", False))
+        else:
+            simba = False
+        if recurrent and simba:
+            msg = (
+                "`simba` and `recurrent` cannot both be set: a network cannot use "
+                "both a SimBa and a recurrent (LSTM) encoder. Enable only one."
+            )
+            raise ValueError(msg)
+
         return self
 
     @staticmethod

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import copy
+import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args
 
 import yaml
-from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
 from typing_extensions import Self
 
 import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
@@ -21,6 +30,8 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
+
+logger = logging.getLogger(__name__)
 
 _MANIFEST_ENCODER_ARCHS = ("mlp", "cnn", "lstm", "simba", "multiinput")
 
@@ -227,6 +238,64 @@ EnvironmentFromManifest = Annotated[
 NetworkFromManifest = Annotated[dict[str, Any], BeforeValidator(_resolve_network)]
 
 
+def _known_field_names(model: BaseModel) -> set[str]:
+    """Return every accepted input key for *model*: field names plus aliases.
+
+    Includes declared-but-excluded fields and every
+    :class:`~pydantic.AliasChoices` option so aliased keys are not mistaken
+    for unknown fields.
+    """
+    names: set[str] = set()
+    for field_name, field in type(model).model_fields.items():
+        names.add(field_name)
+        if isinstance(field.alias, str):
+            names.add(field.alias)
+        validation_alias = field.validation_alias
+        if isinstance(validation_alias, str):
+            names.add(validation_alias)
+        elif isinstance(validation_alias, AliasChoices):
+            names.update(c for c in validation_alias.choices if isinstance(c, str))
+    return names
+
+
+def _collect_unknown_fields(
+    raw: dict[str, Any], validated: TrainingManifest
+) -> list[str]:
+    """Collect dotted paths of manifest keys dropped during validation.
+
+    Only sections that resolve to a concrete Pydantic model are inspected;
+    ``environment`` (a raw passthrough dict) and ``network`` (normalized
+    before validation) are skipped to avoid false positives.
+    """
+    if not isinstance(raw, dict):
+        return []
+
+    dumped = validated.model_dump(mode="json", exclude_none=True)
+
+    unknown: list[str] = []
+    top_known = _known_field_names(validated) | set(dumped)
+    unknown.extend(str(key) for key in raw if key not in top_known)
+
+    sections: dict[str, Any] = {
+        "algorithm": validated.algorithm,
+        "training": validated.training,
+        "mutation": validated.mutation,
+        "replay_buffer": validated.replay_buffer,
+        "tournament_selection": validated.tournament_selection,
+    }
+    for section, model in sections.items():
+        raw_section = raw.get(section)
+        if not isinstance(raw_section, dict) or not isinstance(model, BaseModel):
+            continue
+        known = _known_field_names(model)
+        dumped_section = dumped.get(section)
+        if isinstance(dumped_section, dict):
+            known |= set(dumped_section)
+        unknown.extend(f"{section}.{key}" for key in raw_section if key not in known)
+
+    return unknown
+
+
 class TrainingManifest(BaseModel):
     """Pydantic model that validates a full training manifest.
 
@@ -341,7 +410,13 @@ class TrainingManifest(BaseModel):
         :rtype: dict[str, Any] | TrainingManifest
         """
         data = TrainingManifest._load_yaml(manifest)
+        raw_snapshot = copy.deepcopy(data) if isinstance(data, dict) else {}
         validated = cls.model_validate(data)
+
+        unknown = _collect_unknown_fields(raw_snapshot, validated)
+        if unknown:
+            formatted = "[" + ", ".join(f'"{name}"' for name in unknown) + "]"
+            logger.warning("Ignoring unrecognized manifest field(s): %s", formatted)
 
         if mode == "python":
             return validated

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -7,8 +7,18 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args
 
-import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 import yaml
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
+from typing_extensions import Self
+
+import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 from agilerl.arena.models.algo import (
     ARENA_REGISTRY,
     AlgoSpecT,
@@ -20,15 +30,6 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    model_validator,
-)
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -362,15 +363,9 @@ class TrainingManifest(BaseModel):
 
         recurrent = bool(getattr(self.algorithm, "recurrent", False))
         net_config = getattr(self.algorithm, "net_config", None)
-        if isinstance(net_config, dict):
-            simba = bool(net_config.get("simba", False))
-        elif net_config is not None:
+        if net_config is not None:
             simba = bool(getattr(net_config, "simba", False))
         elif isinstance(self.network, dict):
-            # Deferred path: unlike core, `net_config` is left unset (None)
-            # here when the network section has no resolvable `arch` (see
-            # `_resolve_network`/`_network_has_arch`), so fall back to the raw
-            # `network` dict which still carries the manifest's `simba` flag.
             simba = bool(self.network.get("simba", False))
         else:
             simba = False

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -7,18 +7,8 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args
 
-import yaml
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    model_validator,
-)
-from typing_extensions import Self
-
 import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
+import yaml
 from agilerl.arena.models.algo import (
     ARENA_REGISTRY,
     AlgoSpecT,
@@ -30,6 +20,15 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -73,16 +73,8 @@ def _ensure_platform_run_spec_keys(data: dict[str, Any]) -> None:
 def _normalize_network_arch(
     data: dict[str, Any] | BaseModel,
 ) -> dict[str, Any] | BaseModel:
-    """Move a top-level ``arch`` key into ``encoder_config.arch``.
-
-    Raw YAML/JSON manifests place ``arch`` at the network section root,
-    but :class:`NetworkSpec` (a discriminated union) expects it nested
-    under ``encoder_config``.  This helper bridges the two representations.
-
-    If ``arch`` is missing from both the network root and ``encoder_config``,
-    the data is returned unchanged: the Arena backend performs its own
-    obs-space-aware ``arch`` resolution server-side, so the client defers to
-    it instead of rejecting the manifest.
+    """Move a top-level ``arch`` key into ``encoder_config.arch`` for proper
+    Pydantic validation client-side. If missing, resolution is deferred to the server.
     """
     # If passing a network spec we already have the correct structure
     if not isinstance(data, dict):
@@ -96,7 +88,7 @@ def _normalize_network_arch(
     )
     arch = top_level_arch or nested_arch
 
-    # If arch is not found, defer resolution to the server (obs-space-aware).
+    # If arch is not found, defer resolution to the server.
     if arch is None:
         return data
 
@@ -114,8 +106,7 @@ def _network_has_arch(network: dict[str, Any]) -> bool:
 
     Checks both the network root and ``encoder_config`` (the two places a
     manifest may place it). Used to decide whether the network section can be
-    validated client-side, or must be deferred to the Arena backend's own
-    obs-space-aware resolution.
+    validated client-side, or must be deferred to the server.
 
     :param network: Raw network section dict.
     :type network: dict[str, Any]
@@ -185,10 +176,7 @@ def _resolve_network(data: dict[str, Any] | BaseModel) -> dict[str, Any]:
     Raw dicts are validated through :class:`NetworkSpec` so that default values are included in the serialized output.
 
     If the raw dict has no resolvable ``arch`` (at the network root or nested
-    in ``encoder_config``), the network section is returned unchanged: the
-    Arena backend performs its own obs-space-aware ``arch`` resolution
-    server-side, so the client passes the raw section through rather than
-    validating (and rejecting) it.
+    in ``encoder_config``), the network section is returned unchanged.
 
     :param data: Network config dict or spec instance.
     :type data: Any
@@ -207,7 +195,6 @@ def _resolve_network(data: dict[str, Any] | BaseModel) -> dict[str, Any]:
         return FinetuningNetworkSpec.model_validate(data).model_dump(mode="json")
 
     if isinstance(data, dict) and not _network_has_arch(data):
-        # Deferred: hand the raw network section to the server to validate.
         return data
 
     normalized = _normalize_network_arch(data)
@@ -224,7 +211,7 @@ def _serialize_algorithm(spec: AlgoSpecT) -> dict[str, Any]:
     return dumped
 
 
-# NOTE: Use of PlainSerializer here I believe results in not being able to serialize a
+# NOTE: Use of PlainSerializer here results in not being able to serialize the
 # TrainingManifest's algorithm section in "python" mode, which is fine since we only serialize
 # when submitting jobs to Arena.
 AlgorithmFromManifest = Annotated[
@@ -336,9 +323,7 @@ class TrainingManifest(BaseModel):
                     ),
                     None,
                 )
-                # Skip when the network has no resolvable `arch`: the client
-                # defers to the Arena backend's obs-space-aware resolution
-                # rather than validating (and rejecting) the raw section.
+                # Skip when the network has no resolvable `arch`
                 if spec_cls is not None and _network_has_arch(self.network):
                     self.algorithm.net_config = spec_cls.model_validate(self.network)
             # LLM algorithms expect a pretrained model

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,6 +6,13 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
+
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -25,12 +32,6 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -116,8 +117,9 @@ def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
 
 
 def test_known_field_names_includes_all_alias_forms() -> None:
-    from agilerl.arena.models.manifest import _known_field_names
     from pydantic import AliasChoices, BaseModel, Field
+
+    from agilerl.arena.models.manifest import _known_field_names
 
     class _M(BaseModel):
         plain: int = Field(default=0)
@@ -180,10 +182,7 @@ def test_get_validated_normalizes_network_for_platform() -> None:
 
 
 def test_get_validated_passes_network_raw_when_arch_missing() -> None:
-    """When `arch` is absent, the client defers to the Arena backend's own
-    obs-space-aware resolution instead of validating/rejecting the network
-    section.
-    """
+    """When `arch` is absent, the client defers to the server."""
     network = {
         "encoder_config": {"hidden_size": [64], "activation": "ReLU"},
         "head_config": {"hidden_size": [64], "activation": "ReLU"},

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,13 +6,6 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
-
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -32,6 +25,12 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,6 +6,13 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
+
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -25,12 +32,6 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -105,6 +106,52 @@ def test_get_validated_no_warning_for_aliased_fields() -> None:
             )
         )
     mock_logger.warning.assert_not_called()
+
+
+def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
+    from agilerl.arena.models.manifest import _collect_unknown_fields
+
+    validated = TrainingManifest.get_validated(_manifest(), mode="python")
+    assert _collect_unknown_fields("not-a-dict", validated) == []
+    assert _collect_unknown_fields(None, validated) == []
+
+
+def test_known_field_names_includes_all_alias_forms() -> None:
+    from pydantic import AliasChoices, BaseModel, Field
+
+    from agilerl.arena.models.manifest import _known_field_names
+
+    class _M(BaseModel):
+        plain: int = Field(default=0)
+        aliased: int = Field(default=0, alias="aliased_in")
+        val_str: int = Field(default=0, validation_alias="val_str_in")
+        val_choices: int = Field(
+            default=0, validation_alias=AliasChoices("choice_a", "choice_b")
+        )
+
+    names = _known_field_names(_M())
+    assert {
+        "plain",
+        "aliased",
+        "aliased_in",
+        "val_str",
+        "val_str_in",
+        "val_choices",
+        "choice_a",
+        "choice_b",
+    } <= names
+
+
+def test_deferred_simba_recurrent_conflict_raises() -> None:
+    # arch omitted -> net_config stays None; the simba flag is read from the raw
+    # network dict, and simba + recurrent must be rejected.
+    with pytest.raises(ValidationError, match="simba"):
+        TrainingManifest.get_validated(
+            _manifest(
+                algorithm={"name": "PPO", "recurrent": True},
+                network={"latent_dim": 64, "simba": True},
+            )
+        )
 
 
 def test_get_validated_accepts_env_spec_objects() -> None:

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,6 +6,13 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
+
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -25,12 +32,6 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -103,16 +104,17 @@ def test_get_validated_normalizes_network_for_platform() -> None:
     assert "arch" not in network["encoder_config"]
 
 
-def test_get_validated_raises_for_missing_network_arch() -> None:
-    with pytest.raises(ValidationError, match="Missing encoder architecture"):
-        TrainingManifest.get_validated(
-            _manifest(
-                network={
-                    "encoder_config": {"hidden_size": [64], "activation": "ReLU"},
-                    "head_config": {"hidden_size": [64], "activation": "ReLU"},
-                }
-            )
-        )
+def test_get_validated_passes_network_raw_when_arch_missing() -> None:
+    """When `arch` is absent, the client defers to the Arena backend's own
+    obs-space-aware resolution instead of validating/rejecting the network
+    section.
+    """
+    network = {
+        "encoder_config": {"hidden_size": [64], "activation": "ReLU"},
+        "head_config": {"hidden_size": [64], "activation": "ReLU"},
+    }
+    payload = TrainingManifest.get_validated(_manifest(network=network))
+    assert payload["network"] == network
 
 
 def test_get_validated_raises_for_unknown_algorithm() -> None:

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -68,13 +68,44 @@ def test_training_and_replay_buffer_aliases() -> None:
 
 def test_get_validated_inserts_empty_platform_sections() -> None:
     payload = TrainingManifest.get_validated(
-        _manifest(algorithm={"name": "DQN", "lr": 3e-4, "cudagraphs": True})
+        _manifest(algorithm={"name": "DQN", "lr": 3e-4})
     )
     assert payload["mutation"] == {}
     assert payload["tournament_selection"] == {}
     assert payload["network"] == {}
     assert payload["algorithm"]["name"] == "DQN"
-    assert "cudagraphs" not in payload["algorithm"]
+
+
+def test_get_validated_warns_on_unknown_algorithm_field() -> None:
+    with patch("agilerl.arena.models.manifest.logger") as mock_logger:
+        TrainingManifest.get_validated(
+            _manifest(algorithm={"name": "DQN", "lr": 3e-4, "bogus_algo_field": 1})
+        )
+    mock_logger.warning.assert_called_once()
+    template, formatted = mock_logger.warning.call_args.args
+    assert "unrecognized manifest field" in template
+    assert "algorithm.bogus_algo_field" in formatted
+
+
+def test_get_validated_warns_on_unknown_top_level_field() -> None:
+    with patch("agilerl.arena.models.manifest.logger") as mock_logger:
+        TrainingManifest.get_validated(_manifest(bogus_top_level=123))
+    mock_logger.warning.assert_called_once()
+    assert "bogus_top_level" in mock_logger.warning.call_args.args[1]
+
+
+def test_get_validated_no_warning_for_aliased_fields() -> None:
+    # population_size / metrics_interval / memory_size are validation aliases,
+    # not unknown fields.
+    with patch("agilerl.arena.models.manifest.logger") as mock_logger:
+        TrainingManifest.get_validated(
+            _manifest(
+                algorithm={"name": "DQN", "lr": 3e-4},
+                training={"population_size": 4, "metrics_interval": 123},
+                replay_buffer={"memory_size": 4096},
+            )
+        )
+    mock_logger.warning.assert_not_called()
 
 
 def test_get_validated_accepts_env_spec_objects() -> None:
@@ -177,12 +208,6 @@ def test_generated_manifest_validates(algo_name: str, tmp_path) -> None:
     assert validated["environment"]["name"]
     assert "mutation" in validated
     assert "tournament_selection" in validated
-
-
-def test_dqn_generated_manifest_omits_cudagraphs(tmp_path) -> None:
-    _path, validated = write_arena_manifest("DQN", tmp_path)
-    assert validated["algorithm"]["name"] == "DQN"
-    assert "cudagraphs" not in validated["algorithm"]
 
 
 def test_llm_env_type_str() -> None:

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,13 +6,6 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
-
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -32,6 +25,12 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -117,9 +116,8 @@ def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
 
 
 def test_known_field_names_includes_all_alias_forms() -> None:
-    from pydantic import AliasChoices, BaseModel, Field
-
     from agilerl.arena.models.manifest import _known_field_names
+    from pydantic import AliasChoices, BaseModel, Field
 
     class _M(BaseModel):
         plain: int = Field(default=0)

--- a/agilerl-arena/tests/test_cli.py
+++ b/agilerl-arena/tests/test_cli.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-from click.testing import CliRunner
-
 from agilerl.arena.cli import (
     _redact_agent_rows_for_display,
     arena_client,
@@ -16,6 +14,7 @@ from agilerl.arena.cli import (
 )
 from agilerl.arena.config import CommandConfig, build_client
 from agilerl.arena.exceptions import ArenaAPIError
+from click.testing import CliRunner
 
 
 @pytest.fixture

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -600,6 +600,76 @@ class TestArenaArchOptional:
         assert "arch" not in out["network"]["encoder_config"]
 
 
+class TestArenaSimbaRecurrentConflict:
+    """``simba`` and ``recurrent`` are contradictory encoder requests.
+
+    A network cannot simultaneously be a SimBa encoder and a recurrent
+    (LSTM) encoder. Mirrors the core guard in
+    ``agilerl.models.manifest.TrainingManifest._process_manifest``.
+    """
+
+    def test_deferred_raises(self) -> None:
+        """No ``arch``: the network section stays a raw dict when the conflict fires."""
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO", "recurrent": True},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {"simba": True, "head_config": {"hidden_size": [64]}},
+        }
+        with pytest.raises(ValueError, match="cannot both be set"):
+            TrainingManifest.model_validate(raw)
+
+    def test_eager_raises(self) -> None:
+        """``arch: simba`` declared: ``net_config`` is a validated ``NetworkSpec``."""
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO", "recurrent": True},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {
+                "arch": "simba",
+                "encoder_config": {"hidden_size": 128, "num_blocks": 2},
+                "head_config": {"hidden_size": [64]},
+            },
+        }
+        with pytest.raises(ValueError, match="cannot both be set"):
+            TrainingManifest.model_validate(raw)
+
+    def test_only_simba_validates(self) -> None:
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO"},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {"simba": True, "head_config": {"hidden_size": [64]}},
+        }
+        manifest = TrainingManifest.model_validate(raw)
+        assert manifest.network.get("simba") is True
+
+    def test_only_recurrent_validates(self) -> None:
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO", "recurrent": True},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {"head_config": {"hidden_size": [64]}},
+        }
+        manifest = TrainingManifest.model_validate(raw)
+        assert manifest.algorithm.recurrent is True
+
+    def test_neither_validates(self) -> None:
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO"},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {"head_config": {"hidden_size": [64]}},
+        }
+        manifest = TrainingManifest.model_validate(raw)
+        assert manifest.algorithm.recurrent is False
+
+
 class TestAttachManifestTree:
     def test_warns_on_unknown_node_type(self) -> None:
         group = click.Group(name="root")

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from click.testing import CliRunner
+
 from agilerl.arena.cli_manifest import (
     _manifest_spec_to_click_option,
     _parse_json_cli_value,
@@ -18,7 +20,6 @@ from agilerl.arena.cli_manifest import (
 from agilerl.arena.client import ArenaClient
 from agilerl.arena.config import CommandConfig
 from agilerl.arena.exceptions import ArenaValidationError
-from click.testing import CliRunner
 
 
 def _command_config() -> CommandConfig:
@@ -561,6 +562,42 @@ class TestManifestCommandCallbackBinary:
         assert res.exit_code == 0
         sent_args = client._invoke_manifest_command.call_args.args[1]
         assert sent_args["extra"] == {"nested": True}
+
+
+class TestArenaArchOptional:
+    def test_arch_present_validates(self) -> None:
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO"},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {
+                "arch": "mlp",
+                "encoder_config": {"hidden_size": [64]},
+                "head_config": {"hidden_size": [64]},
+            },
+        }
+        out = TrainingManifest.get_validated(raw, mode="json")
+        # _ensure_platform_run_spec_keys promotes arch to the network root
+        # (and adds `name`) for the Arena platform run-spec payload shape.
+        assert out["network"]["arch"] == "mlp"
+        assert "arch" not in out["network"]["encoder_config"]
+
+    def test_arch_absent_passes_network_raw(self) -> None:
+        from agilerl.arena.models.manifest import TrainingManifest
+
+        raw = {
+            "algorithm": {"name": "PPO"},
+            "environment": {"name": "merge-env", "version": "v1"},
+            "network": {"latent_dim": 64, "encoder_config": {"hidden_size": [64]}},
+        }
+        out = TrainingManifest.get_validated(raw, mode="json")
+        # Network section is left raw for the server to validate.
+        assert out["network"] == {
+            "latent_dim": 64,
+            "encoder_config": {"hidden_size": [64]},
+        }
+        assert "arch" not in out["network"]["encoder_config"]
 
 
 class TestAttachManifestTree:

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-from click.testing import CliRunner
-
 from agilerl.arena.cli_manifest import (
     _manifest_spec_to_click_option,
     _parse_json_cli_value,
@@ -20,6 +18,7 @@ from agilerl.arena.cli_manifest import (
 from agilerl.arena.client import ArenaClient
 from agilerl.arena.config import CommandConfig
 from agilerl.arena.exceptions import ArenaValidationError
+from click.testing import CliRunner
 
 
 def _command_config() -> CommandConfig:

--- a/agilerl/models/manifest.py
+++ b/agilerl/models/manifest.py
@@ -250,6 +250,19 @@ class TrainingManifest(BaseModel):
             )
             raise ValueError(msg)
 
+        recurrent = bool(getattr(self.algorithm, "recurrent", False))
+        net_config = getattr(self.algorithm, "net_config", None)
+        if isinstance(net_config, dict):
+            simba = bool(net_config.get("simba", False))
+        else:
+            simba = bool(getattr(net_config, "simba", False))
+        if recurrent and simba:
+            msg = (
+                "`simba` and `recurrent` cannot both be set: a network cannot use "
+                "both a SimBa and a recurrent (LSTM) encoder. Enable only one."
+            )
+            raise ValueError(msg)
+
         return self
 
     @staticmethod

--- a/agilerl/models/manifest.py
+++ b/agilerl/models/manifest.py
@@ -19,6 +19,7 @@ from agilerl.models.hpo import MutationSpec, TournamentSelectionSpec
 from agilerl.models.networks import (
     FinetuningNetworkSpec,
     NetworkSpec,
+    network_arch_is_resolvable,
     normalize_manifest_network,
 )
 from agilerl.models.training import ReplayBufferSpec, TrainingSpec
@@ -129,6 +130,10 @@ def _resolve_network(data: Any) -> dict[str, Any]:
         return FinetuningNetworkSpec.model_validate(data).model_dump(mode="json")
 
     normalized = normalize_manifest_network(data)
+    if not network_arch_is_resolvable(normalized):
+        # Deferred: keep the raw network dict; the trainer resolves the arch
+        # from the observation space in Trainer.__init__.
+        return normalized
     spec = NetworkSpec.model_validate(normalized)
     data_dict = spec.model_dump()
     data_dict["encoder_config"]["arch"] = spec.encoder_config.arch
@@ -217,7 +222,14 @@ class TrainingManifest(BaseModel):
                     None,
                 )
                 if spec_cls is not None:
-                    self.algorithm.net_config = spec_cls.model_validate(self.network)
+                    if network_arch_is_resolvable(self.network):
+                        self.algorithm.net_config = spec_cls.model_validate(
+                            self.network
+                        )
+                    else:
+                        # Deferred: leave the raw dict for the trainer to resolve
+                        # once the observation space is known.
+                        self.algorithm.net_config = dict(self.network)
             # LLM algorithms expect a pretrained model
             elif issubclass(algo_spec_cls, LLMAlgorithmSpec):
                 llm_network = FinetuningNetworkSpec.model_validate(self.network)

--- a/agilerl/models/manifest.py
+++ b/agilerl/models/manifest.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import copy
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args
 
 import yaml
-from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
 from typing_extensions import Self
 
 from agilerl import HAS_ARENA_DEPENDENCIES, HAS_LLM_DEPENDENCIES, AgentType
@@ -23,6 +32,8 @@ from agilerl.models.networks import (
     normalize_manifest_network,
 )
 from agilerl.models.training import ReplayBufferSpec, TrainingSpec
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from agilerl.models.env import GymEnvSpec, LLMEnvSpec, OfflineEnvSpec, PzEnvSpec
@@ -179,6 +190,64 @@ EnvironmentFromManifest = Annotated[
     dict[str, Any], BeforeValidator(_coerce_environment)
 ]
 NetworkFromManifest = Annotated[dict[str, Any], BeforeValidator(_resolve_network)]
+
+
+def _known_field_names(model: BaseModel) -> set[str]:
+    """Return every accepted input key for *model*: field names plus aliases.
+
+    Includes declared-but-excluded fields (e.g. ``cudagraphs``) and every
+    :class:`~pydantic.AliasChoices` option so aliased keys are not mistaken
+    for unknown fields.
+    """
+    names: set[str] = set()
+    for field_name, field in type(model).model_fields.items():
+        names.add(field_name)
+        if isinstance(field.alias, str):
+            names.add(field.alias)
+        validation_alias = field.validation_alias
+        if isinstance(validation_alias, str):
+            names.add(validation_alias)
+        elif isinstance(validation_alias, AliasChoices):
+            names.update(c for c in validation_alias.choices if isinstance(c, str))
+    return names
+
+
+def _collect_unknown_fields(
+    raw: dict[str, Any], validated: TrainingManifest
+) -> list[str]:
+    """Collect dotted paths of manifest keys dropped during validation.
+
+    Only sections that resolve to a concrete Pydantic model are inspected;
+    ``environment`` (a raw passthrough dict) and ``network`` (normalized
+    before validation) are skipped to avoid false positives.
+    """
+    if not isinstance(raw, dict):
+        return []
+
+    dumped = validated.model_dump(mode="json", exclude_none=True)
+
+    unknown: list[str] = []
+    top_known = _known_field_names(validated) | set(dumped)
+    unknown.extend(str(key) for key in raw if key not in top_known)
+
+    sections: dict[str, Any] = {
+        "algorithm": validated.algorithm,
+        "training": validated.training,
+        "mutation": validated.mutation,
+        "replay_buffer": validated.replay_buffer,
+        "tournament_selection": validated.tournament_selection,
+    }
+    for section, model in sections.items():
+        raw_section = raw.get(section)
+        if not isinstance(raw_section, dict) or not isinstance(model, BaseModel):
+            continue
+        known = _known_field_names(model)
+        dumped_section = dumped.get(section)
+        if isinstance(dumped_section, dict):
+            known |= set(dumped_section)
+        unknown.extend(f"{section}.{key}" for key in raw_section if key not in known)
+
+    return unknown
 
 
 class TrainingManifest(BaseModel):
@@ -387,7 +456,13 @@ class TrainingManifest(BaseModel):
         :rtype: dict[str, Any] | TrainingManifest
         """
         data = TrainingManifest._load_yaml(manifest)
+        raw_snapshot = copy.deepcopy(data) if isinstance(data, dict) else {}
         validated = cls.model_validate(data)
+
+        unknown = _collect_unknown_fields(raw_snapshot, validated)
+        if unknown:
+            formatted = "[" + ", ".join(f'"{name}"' for name in unknown) + "]"
+            logger.warning("Ignoring unrecognized manifest field(s): %s", formatted)
 
         if mode == "json":
             return validated.model_dump(mode="json", exclude_none=True)

--- a/agilerl/models/networks.py
+++ b/agilerl/models/networks.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
+from gymnasium import spaces
 from pydantic import (
     BaseModel,
     Field,
@@ -18,6 +19,36 @@ T = TypeVar("T", bound=BaseModel)
 
 
 _MANIFEST_ENCODER_ARCHS = ("mlp", "cnn", "lstm", "simba", "multiinput")
+
+
+def infer_encoder_arch(
+    observation_space: spaces.Space,
+    *,
+    recurrent: bool = False,
+    simba: bool = False,
+) -> Literal["mlp", "cnn", "lstm", "simba", "multiinput"]:
+    """Infer the encoder architecture from an observation space.
+
+    Mirrors the branch order in
+    :func:`agilerl.utils.evolvable_networks.get_default_encoder_config` and
+    :meth:`agilerl.networks.base.EvolvableNetwork._build_encoder` so the schema
+    used to validate ``encoder_config`` always matches the encoder that will be
+    built. ``simba`` takes precedence over ``recurrent``.
+
+    :param observation_space: The (single-agent or per-agent) observation space.
+    :param recurrent: Whether the algorithm requests a recurrent encoder.
+    :param simba: Whether the network requests a SimBa encoder.
+    :returns: One of ``"mlp"``, ``"cnn"``, ``"lstm"``, ``"simba"``, ``"multiinput"``.
+    """
+    if isinstance(observation_space, (spaces.Dict, spaces.Tuple)):
+        return "multiinput"
+    if isinstance(observation_space, spaces.Box) and len(observation_space.shape) == 3:
+        return "cnn"
+    if simba:
+        return "simba"
+    if recurrent:
+        return "lstm"
+    return "mlp"
 
 
 def normalize_manifest_network(data: Any) -> Any:

--- a/agilerl/models/networks.py
+++ b/agilerl/models/networks.py
@@ -51,15 +51,28 @@ def infer_encoder_arch(
     return "mlp"
 
 
+def network_arch_is_resolvable(network: dict) -> bool:
+    """Return True if the manifest network section declares an ``arch``.
+
+    Checks the top level and the nested ``encoder_config``. When False, the
+    architecture must be inferred from the observation space at build time.
+    """
+    if not isinstance(network, dict):
+        return False
+    if network.get("arch"):
+        return True
+    encoder_config = network.get("encoder_config")
+    return isinstance(encoder_config, dict) and bool(encoder_config.get("arch"))
+
+
 def normalize_manifest_network(data: Any) -> Any:
-    """Move a top-level ``arch`` key into ``encoder_config.arch``.
+    """Move a top-level ``arch`` key into ``encoder_config.arch`` when present.
 
-    Raw YAML/JSON manifests place ``arch`` at the network section root,
-    but :class:`NetworkSpec` (a discriminated union) expects it nested
-    under ``encoder_config``.  This helper bridges the two representations.
-
-    :raises ValueError: If ``arch`` is missing from both the network root and
-        ``encoder_config``.
+    Raw YAML/JSON manifests place ``arch`` at the network section root, but
+    :class:`NetworkSpec` (a discriminated union) expects it nested under
+    ``encoder_config``. When ``arch`` is absent it is inferred later from the
+    observation space, so this helper leaves the data unchanged rather than
+    raising.
     """
     if not isinstance(data, dict):
         return data
@@ -73,12 +86,8 @@ def normalize_manifest_network(data: Any) -> Any:
     arch = top_level_arch or nested_arch
 
     if arch is None:
-        supported = ", ".join(_MANIFEST_ENCODER_ARCHS)
-        msg = (
-            "Missing encoder architecture in the manifest. "
-            f"Set 'arch' at the top level of 'network'. Supported values: {supported}."
-        )
-        raise ValueError(msg)
+        # Deferred: architecture inferred from the observation space later.
+        return data
 
     if encoder_config is None:
         data["encoder_config"] = {"arch": arch}

--- a/agilerl/models/networks.py
+++ b/agilerl/models/networks.py
@@ -363,11 +363,7 @@ def encoder_spec_for_arch(arch: str) -> type[BaseModel]:
     :rtype: type[BaseModel]
     """
     for member in get_args(EncoderType):
-        arch_field = member.model_fields["arch"]
-        member_arch = arch_field.default
-        if member_arch is None:
-            member_arch = get_args(arch_field.annotation)[0]
-        if member_arch == arch:
+        if member.model_fields["arch"].default == arch:
             return member
     msg = f"Unknown encoder arch: {arch!r}"
     raise ValueError(msg)

--- a/agilerl/models/networks.py
+++ b/agilerl/models/networks.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, get_args
 
 from gymnasium import spaces
 from pydantic import (
@@ -348,6 +348,29 @@ class LstmSpec(BaseModel):
 
 
 EncoderType = MlpSpec | CnnSpec | LstmSpec | MultiInputSpec | SimbaSpec
+
+
+def encoder_spec_for_arch(arch: str) -> type[BaseModel]:
+    """Return the encoder spec class (``MlpSpec``, ``CnnSpec``, ...) for an arch literal.
+
+    Single source of truth mapping an ``arch`` string (as produced by
+    :func:`infer_encoder_arch`) to the concrete pydantic spec that validates
+    that encoder's ``encoder_config``.
+
+    :param arch: The encoder architecture literal (e.g. ``"mlp"``, ``"cnn"``).
+    :type arch: str
+    :returns: The encoder spec class whose ``arch`` field matches.
+    :rtype: type[BaseModel]
+    """
+    for member in get_args(EncoderType):
+        arch_field = member.model_fields["arch"]
+        member_arch = arch_field.default
+        if member_arch is None:
+            member_arch = get_args(arch_field.annotation)[0]
+        if member_arch == arch:
+            return member
+    msg = f"Unknown encoder arch: {arch!r}"
+    raise ValueError(msg)
 
 
 class NetworkSpec(BaseModel):

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -799,8 +799,19 @@ class ArenaTrainer(Trainer):
         validated_manifest = ArenaManifest.get_validated(manifest, mode="python")
         env_spec = cls._resolve_env_spec(validated_manifest)
 
+        algorithm = validated_manifest.algorithm
+        # Deferred network (``arch`` omitted): the arena manifest leaves
+        # ``net_config`` unset and keeps the raw network section. Carry it on the
+        # spec so it is submitted for the server to resolve, not dropped.
+        if (
+            "net_config" in type(algorithm).model_fields
+            and algorithm.net_config is None
+            and validated_manifest.network
+        ):
+            algorithm.net_config = validated_manifest.network
+
         return cls(
-            algorithm=validated_manifest.algorithm,
+            algorithm=algorithm,
             environment=env_spec,
             client=client,
             api_key=api_key,

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -33,12 +33,14 @@ from agilerl.models.env import (
     OfflineEnvSpec,
     PzEnvSpec,
 )
+from agilerl.models.networks import infer_encoder_arch, network_arch_is_resolvable
 from agilerl.utils.trainer_utils import (
     EnvironmentT,
     build_mutations_from_spec,
     build_replay_buffer_from_spec,
     build_tournament_from_spec,
     create_population_from_spec,
+    get_spaces_from_env,
 )
 
 logger = logging.getLogger(__name__)
@@ -322,6 +324,7 @@ class LocalTrainer(Trainer):
 
         # Instantiate the training components from their specs.
         self.env = self._make_env()
+        self._resolve_deferred_net_config()
         self.population = create_population_from_spec(
             population_size=self.training_spec.pop_size,
             algo_spec=self.algorithm_spec,
@@ -365,6 +368,67 @@ class LocalTrainer(Trainer):
         else:
             self.env_factory = None
             self.train_fn = self.algorithm_spec.get_training_fn()
+
+    def _resolve_deferred_net_config(self) -> None:
+        """Resolve a manifest network section whose ``arch`` was omitted.
+
+        When the manifest did not declare ``arch``, ``net_config`` is left as a
+        raw dict by manifest validation. Now that the environment (hence the
+        observation space) exists, infer the arch and validate the network into
+        the algorithm's concrete ``NetworkSpec``. No-ops when ``net_config`` is
+        already a validated spec (programmatic construction) or None.
+        """
+        net_config = getattr(self.algorithm_spec, "net_config", None)
+        if not isinstance(net_config, dict):
+            return
+        if network_arch_is_resolvable(net_config):
+            return
+
+        from typing import get_args
+
+        from agilerl.models.networks import NetworkSpec
+        from agilerl.utils.evolvable_networks import get_default_encoder_config
+
+        observation_space, _ = get_spaces_from_env(self.algorithm_spec, self.env)
+        simba = bool(net_config.get("simba", False))
+        recurrent = bool(getattr(self.algorithm_spec, "recurrent", False))
+
+        if isinstance(observation_space, dict):
+            # Multi-agent: handled in Task 4.
+            self._resolve_deferred_net_config_multi_agent(
+                net_config, observation_space, simba, recurrent
+            )
+            return
+
+        arch = infer_encoder_arch(observation_space, recurrent=recurrent, simba=simba)
+        resolved = dict(net_config)
+        # `arch` alone isn't enough to validate: variant-specific fields (e.g.
+        # ``MlpSpec.hidden_size``, ``CnnSpec.channel_size``) are required with
+        # no default. Seed them from the same default-config helper the
+        # algorithms themselves use (mirrors the same branch order as
+        # ``infer_encoder_arch``), then let any user-provided overrides win.
+        default_encoder_config = get_default_encoder_config(
+            observation_space, simba=simba, recurrent=recurrent
+        )
+        encoder_config = {
+            **default_encoder_config,
+            **(resolved.get("encoder_config") or {}),
+        }
+        encoder_config["arch"] = arch
+        resolved["encoder_config"] = encoder_config
+
+        net_config_field = type(self.algorithm_spec).model_fields.get("net_config")
+        spec_cls = next(
+            (t for t in get_args(net_config_field.annotation) if t is not type(None)),
+            NetworkSpec,
+        )
+        self.algorithm_spec.net_config = spec_cls.model_validate(resolved)
+
+    def _resolve_deferred_net_config_multi_agent(
+        self, net_config, observation_spaces, simba, recurrent
+    ) -> None:
+        msg = "multi-agent deferred net_config: Task 4"
+        raise NotImplementedError(msg)
 
     def _make_tokenizer(self) -> AutoTokenizer:
         """Create the tokenizer for the LLM algorithm.

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -384,30 +384,60 @@ class LocalTrainer(Trainer):
         if network_arch_is_resolvable(net_config):
             return
 
-        from typing import get_args
-
-        from agilerl.models.networks import NetworkSpec, encoder_spec_for_arch
-        from agilerl.utils.evolvable_networks import get_default_encoder_config
-
         observation_space, _ = get_spaces_from_env(self.algorithm_spec, self.env)
         simba = bool(net_config.get("simba", False))
         recurrent = bool(getattr(self.algorithm_spec, "recurrent", False))
 
         if isinstance(observation_space, dict):
-            # Multi-agent: handled in Task 4.
             self._resolve_deferred_net_config_multi_agent(
                 net_config, observation_space, simba, recurrent
             )
             return
 
+        encoder_config = self._resolve_encoder_config(
+            observation_space,
+            net_config.get("encoder_config"),
+            simba=simba,
+            recurrent=recurrent,
+        )
+        resolved = {**net_config, "encoder_config": encoder_config}
+        self.algorithm_spec.net_config = self._algo_net_spec_cls().model_validate(
+            resolved
+        )
+
+    def _resolve_encoder_config(
+        self,
+        observation_space: Any,
+        user_encoder_config: dict[str, Any] | None,
+        *,
+        simba: bool,
+        recurrent: bool,
+    ) -> dict[str, Any]:
+        """Build a resolved ``encoder_config`` for a single observation space.
+
+        ``arch`` alone isn't enough to validate: variant-specific fields (e.g.
+        ``MlpSpec.hidden_size``, ``CnnSpec.channel_size``) are REQUIRED with no
+        default. Seed ONLY those required fields from the default-config helper
+        the algorithms use; every OPTIONAL field must fall through to its
+        ``*Spec`` pydantic default so the deferred path resolves to the same HP
+        bounds as the eager (arch-declared) path. User-provided ``encoder_config``
+        keys overlay the seed, and ``arch`` is set last.
+
+        :param observation_space: The (per-agent) observation space.
+        :type observation_space: gymnasium.spaces.Space
+        :param user_encoder_config: The manifest-provided ``encoder_config``, if any.
+        :type user_encoder_config: dict[str, Any] | None
+        :param simba: Whether the network requests a SimBa encoder.
+        :type simba: bool
+        :param recurrent: Whether the algorithm requests a recurrent encoder.
+        :type recurrent: bool
+        :returns: A resolved ``encoder_config`` dict including its ``arch``.
+        :rtype: dict[str, Any]
+        """
+        from agilerl.models.networks import encoder_spec_for_arch
+        from agilerl.utils.evolvable_networks import get_default_encoder_config
+
         arch = infer_encoder_arch(observation_space, recurrent=recurrent, simba=simba)
-        # `arch` alone isn't enough to validate: variant-specific fields (e.g.
-        # ``MlpSpec.hidden_size``, ``CnnSpec.channel_size``) are REQUIRED with no
-        # default. Seed ONLY those required fields from the default-config helper
-        # the algorithms use; every OPTIONAL field must fall through to its
-        # ``*Spec`` pydantic default so the deferred path resolves to the same HP
-        # bounds as the eager (arch-declared) path. User-provided ``encoder_config``
-        # keys overlay the seed, and ``arch`` is set last.
         encoder_spec_cls = encoder_spec_for_arch(arch)
         required = {
             name
@@ -418,22 +448,79 @@ class LocalTrainer(Trainer):
             observation_space, simba=simba, recurrent=recurrent
         )
         seed = {k: v for k, v in default_encoder_config.items() if k in required}
-        user_encoder_config = net_config.get("encoder_config") or {}
-        encoder_config = {**seed, **user_encoder_config, "arch": arch}
-        resolved = {**net_config, "encoder_config": encoder_config}
+        return {**seed, **(user_encoder_config or {}), "arch": arch}
+
+    def _algo_net_spec_cls(self) -> type:
+        """Resolve the algorithm's concrete ``NetworkSpec`` subclass.
+
+        Picks the non-``None`` member of the ``net_config`` field's type
+        annotation (e.g. ``StochasticActorSpec`` for IPPO), falling back to the
+        base :class:`~agilerl.models.networks.NetworkSpec`.
+
+        :returns: The ``NetworkSpec`` subclass used to validate the network.
+        :rtype: type
+        """
+        from typing import get_args
+
+        from agilerl.models.networks import NetworkSpec
 
         net_config_field = type(self.algorithm_spec).model_fields.get("net_config")
-        spec_cls = next(
+        return next(
             (t for t in get_args(net_config_field.annotation) if t is not type(None)),
             NetworkSpec,
         )
-        self.algorithm_spec.net_config = spec_cls.model_validate(resolved)
 
     def _resolve_deferred_net_config_multi_agent(
-        self, net_config, observation_spaces, simba, recurrent
+        self,
+        net_config: dict[str, Any],
+        observation_spaces: dict[str, Any],
+        simba: bool,
+        recurrent: bool,
     ) -> None:
-        msg = "multi-agent deferred net_config: Task 4"
-        raise NotImplementedError(msg)
+        """Resolve a deferred multi-agent network section, per agent group.
+
+        Infers the encoder arch from each agent's own observation space and
+        builds a per-group nested ``net_config`` so heterogeneous agents each
+        get the right encoder while homogeneous agents share one. The manifest's
+        shared network settings (``latent_dim``, ``head_config``, ...) are
+        applied to every group; only ``encoder_config`` is resolved per group.
+
+        Agents are keyed by their shared-policy group id (the same
+        ``rsplit("_", 1)`` prefix the algorithm uses to group homogeneous
+        agents), because ``build_net_config`` rejects individual-agent keys in a
+        grouped setting yet resolves group-id keys for both grouped and
+        ungrouped environments.
+
+        :param net_config: The raw (deferred) network section from the manifest.
+        :type net_config: dict[str, Any]
+        :param observation_spaces: Per-agent observation spaces.
+        :type observation_spaces: dict[str, gymnasium.spaces.Space]
+        :param simba: Whether the network requests a SimBa encoder.
+        :type simba: bool
+        :param recurrent: Whether the algorithm requests a recurrent encoder.
+        :type recurrent: bool
+        """
+        spec_cls = self._algo_net_spec_cls()
+        shared_fields = {k: v for k, v in net_config.items() if k != "encoder_config"}
+        user_encoder_config = net_config.get("encoder_config")
+
+        resolved: dict[str, dict[str, Any]] = {}
+        for agent_id, observation_space in observation_spaces.items():
+            group_id = (
+                agent_id.rsplit("_", 1)[0] if isinstance(agent_id, str) else agent_id
+            )
+            if group_id in resolved:
+                continue
+            encoder_config = self._resolve_encoder_config(
+                observation_space,
+                user_encoder_config,
+                simba=simba,
+                recurrent=recurrent,
+            )
+            agent_net_config = {**shared_fields, "encoder_config": encoder_config}
+            resolved[group_id] = spec_cls.model_validate(agent_net_config).model_dump()
+
+        self.algorithm_spec.net_config = resolved
 
     def _make_tokenizer(self) -> AutoTokenizer:
         """Create the tokenizer for the LLM algorithm.

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, get_args
 
 from typing_extensions import Self
 
@@ -33,7 +33,12 @@ from agilerl.models.env import (
     OfflineEnvSpec,
     PzEnvSpec,
 )
-from agilerl.models.networks import infer_encoder_arch, network_arch_is_resolvable
+from agilerl.models.networks import (
+    NetworkSpec,
+    encoder_spec_for_arch,
+    infer_encoder_arch,
+    network_arch_is_resolvable,
+)
 from agilerl.utils.trainer_utils import (
     EnvironmentT,
     build_mutations_from_spec,
@@ -434,7 +439,6 @@ class LocalTrainer(Trainer):
         :returns: A resolved ``encoder_config`` dict including its ``arch``.
         :rtype: dict[str, Any]
         """
-        from agilerl.models.networks import encoder_spec_for_arch
         from agilerl.utils.evolvable_networks import get_default_encoder_config
 
         arch = infer_encoder_arch(observation_space, recurrent=recurrent, simba=simba)
@@ -460,10 +464,6 @@ class LocalTrainer(Trainer):
         :returns: The ``NetworkSpec`` subclass used to validate the network.
         :rtype: type
         """
-        from typing import get_args
-
-        from agilerl.models.networks import NetworkSpec
-
         net_config_field = type(self.algorithm_spec).model_fields.get("net_config")
         return next(
             (t for t in get_args(net_config_field.annotation) if t is not type(None)),

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -386,7 +386,7 @@ class LocalTrainer(Trainer):
 
         from typing import get_args
 
-        from agilerl.models.networks import NetworkSpec
+        from agilerl.models.networks import NetworkSpec, encoder_spec_for_arch
         from agilerl.utils.evolvable_networks import get_default_encoder_config
 
         observation_space, _ = get_spaces_from_env(self.algorithm_spec, self.env)
@@ -401,21 +401,26 @@ class LocalTrainer(Trainer):
             return
 
         arch = infer_encoder_arch(observation_space, recurrent=recurrent, simba=simba)
-        resolved = dict(net_config)
         # `arch` alone isn't enough to validate: variant-specific fields (e.g.
-        # ``MlpSpec.hidden_size``, ``CnnSpec.channel_size``) are required with
-        # no default. Seed them from the same default-config helper the
-        # algorithms themselves use (mirrors the same branch order as
-        # ``infer_encoder_arch``), then let any user-provided overrides win.
+        # ``MlpSpec.hidden_size``, ``CnnSpec.channel_size``) are REQUIRED with no
+        # default. Seed ONLY those required fields from the default-config helper
+        # the algorithms use; every OPTIONAL field must fall through to its
+        # ``*Spec`` pydantic default so the deferred path resolves to the same HP
+        # bounds as the eager (arch-declared) path. User-provided ``encoder_config``
+        # keys overlay the seed, and ``arch`` is set last.
+        encoder_spec_cls = encoder_spec_for_arch(arch)
+        required = {
+            name
+            for name, field in encoder_spec_cls.model_fields.items()
+            if field.is_required()
+        }
         default_encoder_config = get_default_encoder_config(
             observation_space, simba=simba, recurrent=recurrent
         )
-        encoder_config = {
-            **default_encoder_config,
-            **(resolved.get("encoder_config") or {}),
-        }
-        encoder_config["arch"] = arch
-        resolved["encoder_config"] = encoder_config
+        seed = {k: v for k, v in default_encoder_config.items() if k in required}
+        user_encoder_config = net_config.get("encoder_config") or {}
+        encoder_config = {**seed, **user_encoder_config, "arch": arch}
+        resolved = {**net_config, "encoder_config": encoder_config}
 
         net_config_field = type(self.algorithm_spec).model_fields.get("net_config")
         spec_cls = next(

--- a/agilerl/utils/evolvable_networks.py
+++ b/agilerl/utils/evolvable_networks.py
@@ -120,10 +120,10 @@ def config_from_dict(config_dict: NetConfigType) -> NetConfig:
     :rtype: NetConfig
     """
     config_keys = config_dict.keys()
-    if "hidden_size" in config_keys:
-        if "num_layers" in config_keys:
-            config_cls = LstmNetConfig
-        elif "num_blocks" in config_keys:
+    if "hidden_state_size" in config_keys:
+        config_cls = LstmNetConfig
+    elif "hidden_size" in config_keys:
+        if "num_blocks" in config_keys:
             config_cls = SimBaNetConfig
         else:
             config_cls = MlpNetConfig

--- a/configs/training/bandit/neural_ts.yaml
+++ b/configs/training/bandit/neural_ts.yaml
@@ -35,7 +35,6 @@ mutation:
 
 network:
     latent_dim: 128
-    arch: mlp
     encoder_config:
         hidden_size:
             - 128

--- a/configs/training/bandit/neural_ucb.yaml
+++ b/configs/training/bandit/neural_ucb.yaml
@@ -35,7 +35,6 @@ mutation:
 
 network:
     latent_dim: 128
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/configs/training/cqn.yaml
+++ b/configs/training/cqn.yaml
@@ -35,7 +35,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: mlp
     encoder_config:
         hidden_size:
             - 64

--- a/configs/training/ddpg/ddpg.yaml
+++ b/configs/training/ddpg/ddpg.yaml
@@ -44,7 +44,6 @@ mutation:
 
 network:
     latent_dim: 128
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/configs/training/ddpg/ddpg_simba.yaml
+++ b/configs/training/ddpg/ddpg_simba.yaml
@@ -45,7 +45,7 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: simba
+    simba: true
 
     encoder_config:
         hidden_size: 128

--- a/configs/training/dqn/dqn.yaml
+++ b/configs/training/dqn/dqn.yaml
@@ -36,7 +36,6 @@ mutation:
 
 network:
     latent_dim: 128
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/configs/training/dqn/dqn_rainbow.yaml
+++ b/configs/training/dqn/dqn_rainbow.yaml
@@ -41,7 +41,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/configs/training/multi_agent/ippo.yaml
+++ b/configs/training/multi_agent/ippo.yaml
@@ -43,7 +43,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: mlp
     encoder_config:
         hidden_size:
             - 64

--- a/configs/training/multi_agent/ippo_pong.yaml
+++ b/configs/training/multi_agent/ippo_pong.yaml
@@ -43,7 +43,6 @@ mutation:
 
 network:
     latent_dim: 128
-    arch: cnn
     encoder_config:
         channel_size:
             - 64

--- a/configs/training/multi_agent/maddpg.yaml
+++ b/configs/training/multi_agent/maddpg.yaml
@@ -44,7 +44,6 @@ network:
     latent_dim: 64
     min_latent_dim: 8
     max_latent_dim: 1024
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/configs/training/multi_agent/matd3.yaml
+++ b/configs/training/multi_agent/matd3.yaml
@@ -43,7 +43,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/configs/training/multi_input.yaml
+++ b/configs/training/multi_input.yaml
@@ -41,7 +41,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: multiinput
 
     encoder_config:
         latent_dim: 64                # Per-input encoder output dimension

--- a/configs/training/ppo/ppo.yaml
+++ b/configs/training/ppo/ppo.yaml
@@ -47,7 +47,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: mlp
     encoder_config:
         hidden_size:
             - 64

--- a/configs/training/ppo/ppo_image.yaml
+++ b/configs/training/ppo/ppo_image.yaml
@@ -49,7 +49,6 @@ network:
     latent_dim: 256
     min_latent_dim: 128
     max_latent_dim: 512
-    arch: cnn
     encoder_config:
         min_channel_size: 32          # Min CNN channels for architecture mutation
         max_channel_size: 256         # Max CNN channels for architecture mutation

--- a/configs/training/ppo/ppo_recurrent.yaml
+++ b/configs/training/ppo/ppo_recurrent.yaml
@@ -45,7 +45,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: lstm
     encoder_config:
         hidden_state_size: 64         # LSTM hidden state size
         num_layers: 1                 # Number of recurrent layers

--- a/configs/training/td3.yaml
+++ b/configs/training/td3.yaml
@@ -44,7 +44,6 @@ mutation:
 
 network:
     latent_dim: 64
-    arch: mlp
 
     encoder_config:
         hidden_size:

--- a/docs/_static/examples/merge_ppo.yaml
+++ b/docs/_static/examples/merge_ppo.yaml
@@ -50,18 +50,6 @@ network:
     latent_dim: 128
     min_latent_dim: 64
     max_latent_dim: 256
-    arch: multiinput
-    encoder_config:
-        vector_space_mlp: true
-        latent_dim: 128
-        min_latent_dim: 64
-        max_latent_dim: 256
-        mlp_config:
-            hidden_size:
-                - 128
-            activation: ReLU
-            min_mlp_nodes: 64
-            max_mlp_nodes: 256
     head_config:
         hidden_size:
             - 128

--- a/docs/_static/examples/merge_ppo.yaml
+++ b/docs/_static/examples/merge_ppo.yaml
@@ -50,6 +50,17 @@ network:
     latent_dim: 128
     min_latent_dim: 64
     max_latent_dim: 256
+    encoder_config:
+        vector_space_mlp: true
+        mlp_config:
+            hidden_size:
+                - 128
+                - 128
+            activation: ReLU
+            min_hidden_layers: 1
+            max_hidden_layers: 3
+            min_mlp_nodes: 64
+            max_mlp_nodes: 256
     head_config:
         hidden_size:
             - 128
@@ -59,6 +70,6 @@ network:
         min_mlp_nodes: 64
         max_mlp_nodes: 256
 
-tournament:
+tournament_selection:
     tournament_size: 2
     elitism: true

--- a/docs/tutorials/arena_training/ppo_custom_env.rst
+++ b/docs/tutorials/arena_training/ppo_custom_env.rst
@@ -202,6 +202,10 @@ name as seen on Arena. If no version is specified, the latest one is used.
    .. literalinclude:: /_static/examples/merge_ppo.yaml
       :language: yaml
 
+Notice that the ``network`` section doesn't set an ``arch``. Arena infers the encoder
+architecture from the environment's observation space, so a ``Dict`` observation like ours
+gets a multi-input encoder automatically. Set ``simba: true`` in the network config, or
+``recurrent: true`` in the algorithm config, to opt into a SimBa or recurrent encoder instead.
 
 For this example, we will train on the ``arena-medium`` resource, which has 1x nvidia-l4 GPU, 15x CPUs, and 55GB of RAM
 (costing around 2.41 credits/node-hour on Arena), and using 2 nodes for quicker results. Since we are training a population

--- a/tests/test_models/test_infer_arch.py
+++ b/tests/test_models/test_infer_arch.py
@@ -6,7 +6,17 @@ import numpy as np
 import pytest
 from gymnasium import spaces
 
-from agilerl.models.networks import infer_encoder_arch
+from agilerl.models.networks import (
+    CnnSpec,
+    LstmSpec,
+    MlpSpec,
+    MultiInputSpec,
+    SimbaSpec,
+    encoder_spec_for_arch,
+    infer_encoder_arch,
+    network_arch_is_resolvable,
+    normalize_manifest_network,
+)
 from agilerl.modules.configs import (
     CnnNetConfig,
     LstmNetConfig,
@@ -72,3 +82,32 @@ def test_drift_guard_matches_get_default_encoder_config(space, recurrent, simba)
         infer_encoder_arch(space, recurrent=recurrent, simba=simba)
         == _CONFIG_TO_ARCH[type(cfg)]
     )
+
+
+@pytest.mark.parametrize("value", ["not-a-dict", None, 42, ["arch"]])
+def test_network_arch_is_resolvable_non_dict(value):
+    assert network_arch_is_resolvable(value) is False
+
+
+@pytest.mark.parametrize(
+    ("arch", "expected_cls"),
+    [
+        ("mlp", MlpSpec),
+        ("cnn", CnnSpec),
+        ("lstm", LstmSpec),
+        ("simba", SimbaSpec),
+        ("multiinput", MultiInputSpec),
+    ],
+)
+def test_encoder_spec_for_arch_maps_every_arch(arch, expected_cls):
+    assert encoder_spec_for_arch(arch) is expected_cls
+
+
+def test_encoder_spec_for_arch_rejects_unknown():
+    with pytest.raises(ValueError, match="Unknown encoder arch"):
+        encoder_spec_for_arch("bogus")
+
+
+@pytest.mark.parametrize("value", ["not-a-dict", None, 7])
+def test_normalize_manifest_network_non_dict_passthrough(value):
+    assert normalize_manifest_network(value) == value

--- a/tests/test_models/test_infer_arch.py
+++ b/tests/test_models/test_infer_arch.py
@@ -1,0 +1,74 @@
+"""Tests for infer_encoder_arch: obs-space -> encoder arch inference."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from agilerl.models.networks import infer_encoder_arch
+from agilerl.modules.configs import (
+    CnnNetConfig,
+    LstmNetConfig,
+    MlpNetConfig,
+    MultiInputNetConfig,
+    SimBaNetConfig,
+)
+from agilerl.utils.evolvable_networks import (
+    config_from_dict,
+    get_default_encoder_config,
+)
+
+VECTOR = spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32)
+IMAGE = spaces.Box(0, 255, shape=(3, 32, 32), dtype=np.uint8)
+DICT = spaces.Dict(
+    {"a": spaces.Box(-1.0, 1.0, shape=(2,)), "b": spaces.Box(-1.0, 1.0, shape=(3,))}
+)
+TUPLE = spaces.Tuple((spaces.Box(-1.0, 1.0, shape=(2,)), spaces.Discrete(3)))
+
+
+@pytest.mark.parametrize(
+    ("space", "recurrent", "simba", "expected"),
+    [
+        (DICT, False, False, "multiinput"),
+        (TUPLE, False, False, "multiinput"),
+        (IMAGE, False, False, "cnn"),
+        (VECTOR, False, False, "mlp"),
+        (VECTOR, True, False, "lstm"),
+        (VECTOR, False, True, "simba"),
+        (VECTOR, True, True, "simba"),  # simba wins over recurrent
+        (DICT, True, True, "multiinput"),  # space wins over flags
+        (IMAGE, True, True, "cnn"),
+    ],
+)
+def test_infer_encoder_arch(space, recurrent, simba, expected):
+    assert infer_encoder_arch(space, recurrent=recurrent, simba=simba) == expected
+
+
+_CONFIG_TO_ARCH = {
+    MlpNetConfig: "mlp",
+    CnnNetConfig: "cnn",
+    LstmNetConfig: "lstm",
+    SimBaNetConfig: "simba",
+    MultiInputNetConfig: "multiinput",
+}
+
+
+@pytest.mark.parametrize(
+    ("space", "recurrent", "simba"),
+    [
+        (DICT, False, False),
+        (IMAGE, False, False),
+        (VECTOR, False, False),
+        (VECTOR, True, False),
+        (VECTOR, False, True),
+    ],
+)
+def test_drift_guard_matches_get_default_encoder_config(space, recurrent, simba):
+    cfg = config_from_dict(
+        get_default_encoder_config(space, simba=simba, recurrent=recurrent)
+    )
+    assert (
+        infer_encoder_arch(space, recurrent=recurrent, simba=simba)
+        == _CONFIG_TO_ARCH[type(cfg)]
+    )

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -1280,3 +1280,65 @@ class TestArchOptional:
         assert network_arch_is_resolvable({"encoder_config": {"arch": "cnn"}})
         assert not network_arch_is_resolvable({"encoder_config": {"hidden_size": [64]}})
         assert not network_arch_is_resolvable({})
+
+
+class TestSimbaRecurrentConflict:
+    """``simba`` and ``recurrent`` are contradictory encoder requests.
+
+    A network cannot simultaneously be a SimBa encoder and a recurrent (LSTM)
+    encoder, so setting both must raise a clear validation error rather than
+    silently picking one (``_build_encoder`` checks recurrent before simba,
+    which would otherwise silently ignore the ``simba`` flag).
+    """
+
+    def test_deferred_raises(self):
+        """No ``arch``: ``net_config`` is a raw dict when the conflict fires."""
+        raw = _make_manifest(
+            algo={"name": "PPO", "recurrent": True},
+            env={"name": "CartPole-v1"},
+            network={"simba": True, "head_config": {"hidden_size": [64]}},
+        )
+        with pytest.raises(ValueError, match="cannot both be set"):
+            TrainingManifest.model_validate(raw)
+
+    def test_eager_raises(self):
+        """``arch: simba`` declared: ``net_config`` is a validated ``NetworkSpec``."""
+        raw = _make_manifest(
+            algo={"name": "PPO", "recurrent": True},
+            env={"name": "CartPole-v1"},
+            network={
+                "arch": "simba",
+                "encoder_config": {"hidden_size": 128, "num_blocks": 2},
+                "head_config": {"hidden_size": [64]},
+            },
+        )
+        with pytest.raises(ValueError, match="cannot both be set"):
+            TrainingManifest.model_validate(raw)
+
+    def test_only_simba_validates(self):
+        raw = _make_manifest(
+            algo={"name": "PPO"},
+            env={"name": "CartPole-v1"},
+            network={"simba": True, "head_config": {"hidden_size": [64]}},
+        )
+        manifest = TrainingManifest.model_validate(raw)
+        assert isinstance(manifest.algorithm.net_config, dict)
+        assert manifest.algorithm.net_config.get("simba") is True
+
+    def test_only_recurrent_validates(self):
+        raw = _make_manifest(
+            algo={"name": "PPO", "recurrent": True},
+            env={"name": "CartPole-v1"},
+            network={"head_config": {"hidden_size": [64]}},
+        )
+        manifest = TrainingManifest.model_validate(raw)
+        assert manifest.algorithm.recurrent is True
+
+    def test_neither_validates(self):
+        raw = _make_manifest(
+            algo={"name": "PPO"},
+            env={"name": "CartPole-v1"},
+            network={"head_config": {"hidden_size": [64]}},
+        )
+        manifest = TrainingManifest.model_validate(raw)
+        assert manifest.algorithm.recurrent is False

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -255,7 +255,7 @@ class TestTrainingManifest:
 
     # -- Network architecture injection -------------------------------------
 
-    def test_network_missing_arch_raises_helpful_error(self):
+    def test_network_missing_arch_defers_resolution(self):
         data = _make_manifest(
             algo={"name": "DQN"},
             network={
@@ -264,8 +264,12 @@ class TestTrainingManifest:
                 "head_config": {"hidden_size": [64]},
             },
         )
-        with pytest.raises(ValueError, match="Missing encoder architecture"):
-            TrainingManifest.model_validate(data)
+        manifest = TrainingManifest.model_validate(data)
+        # Deferred: no arch declared, so net_config is left as a raw dict for
+        # the trainer to resolve from the observation space (Task 3), rather
+        # than raising.
+        assert isinstance(manifest.algorithm.net_config, dict)
+        assert "arch" not in manifest.algorithm.net_config.get("encoder_config", {})
 
     @pytest.mark.parametrize(
         ("arch", "encoder_kwargs", "expected_encoder_cls"),
@@ -1240,3 +1244,39 @@ class TestFromConfigFiles:
 
         manifest = TrainingManifest.model_validate(data)
         assert isinstance(manifest.algorithm, expected_algo_cls)
+
+
+class TestArchOptional:
+    def test_arch_present_still_validates(self):
+        raw = {
+            "algorithm": {"name": "PPO"},
+            "environment": {"name": "CartPole-v1"},
+            "network": {
+                "arch": "mlp",
+                "encoder_config": {"hidden_size": [64]},
+                "head_config": {"hidden_size": [64]},
+            },
+        }
+        out = TrainingManifest.get_validated(raw, mode="json")
+        assert out["network"]["encoder_config"]["arch"] == "mlp"
+
+    def test_arch_absent_keeps_network_raw(self):
+        from agilerl.models.manifest import TrainingManifest as TM
+
+        raw = {
+            "algorithm": {"name": "PPO"},
+            "environment": {"name": "CartPole-v1"},
+            "network": {"latent_dim": 64, "encoder_config": {"hidden_size": [64]}},
+        }
+        manifest = TM.model_validate(raw)
+        # Deferred: net_config left as a raw dict, not a NetworkSpec.
+        assert isinstance(manifest.algorithm.net_config, dict)
+        assert "arch" not in manifest.algorithm.net_config.get("encoder_config", {})
+
+    def test_network_arch_is_resolvable(self):
+        from agilerl.models.networks import network_arch_is_resolvable
+
+        assert network_arch_is_resolvable({"arch": "mlp"})
+        assert network_arch_is_resolvable({"encoder_config": {"arch": "cnn"}})
+        assert not network_arch_is_resolvable({"encoder_config": {"hidden_size": [64]}})
+        assert not network_arch_is_resolvable({})

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -105,6 +105,50 @@ def test_get_validated_json_omits_unset_optional_sections() -> None:
     assert "network" not in out
 
 
+def test_get_validated_warns_on_unknown_algorithm_field() -> None:
+    with patch("agilerl.models.manifest.logger") as mock_logger:
+        TrainingManifest.get_validated(
+            _make_manifest(
+                {"name": "DQN", "lr": 3e-4, "bogus_algo_field": 1},
+                env={"name": "CartPole-v1"},
+            )
+        )
+    mock_logger.warning.assert_called_once()
+    template, formatted = mock_logger.warning.call_args.args
+    assert "unrecognized manifest field" in template
+    assert "algorithm.bogus_algo_field" in formatted
+
+
+def test_get_validated_warns_on_unknown_top_level_field() -> None:
+    with patch("agilerl.models.manifest.logger") as mock_logger:
+        TrainingManifest.get_validated(
+            _make_manifest(
+                {"name": "DQN"}, env={"name": "CartPole-v1"}, bogus_top_level=123
+            )
+        )
+    mock_logger.warning.assert_called_once()
+    assert "bogus_top_level" in mock_logger.warning.call_args.args[1]
+
+
+def test_get_validated_no_warning_for_known_aliased_or_excluded_fields() -> None:
+    # `cudagraphs` is declared-but-excluded, and population_size / metrics_interval
+    # / memory_size are validation aliases: none are unknown.
+    with patch("agilerl.models.manifest.logger") as mock_logger:
+        TrainingManifest.get_validated(
+            _make_manifest(
+                {"name": "DQN", "lr": 3e-4, "cudagraphs": True},
+                env={"name": "CartPole-v1"},
+                training={
+                    "population_size": 4,
+                    "metrics_interval": 123,
+                    "max_steps": 1000,
+                },
+                replay_buffer={"memory_size": 4096},
+            )
+        )
+    mock_logger.warning.assert_not_called()
+
+
 class TestNormalizeNetworkForPlatform:
     """Tests for network normalization via get_validated(mode='json')."""
 

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -151,6 +151,42 @@ def test_get_validated_no_warning_for_known_aliased_or_excluded_fields() -> None
     mock_logger.warning.assert_not_called()
 
 
+def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
+    from agilerl.models.manifest import _collect_unknown_fields
+
+    validated = TrainingManifest.get_validated(
+        _make_manifest({"name": "DQN"}, env={"name": "CartPole-v1"}), mode="python"
+    )
+    assert _collect_unknown_fields("not-a-dict", validated) == []
+    assert _collect_unknown_fields(None, validated) == []
+
+
+def test_known_field_names_includes_all_alias_forms() -> None:
+    from pydantic import AliasChoices, BaseModel, Field
+
+    from agilerl.models.manifest import _known_field_names
+
+    class _M(BaseModel):
+        plain: int = Field(default=0)
+        aliased: int = Field(default=0, alias="aliased_in")
+        val_str: int = Field(default=0, validation_alias="val_str_in")
+        val_choices: int = Field(
+            default=0, validation_alias=AliasChoices("choice_a", "choice_b")
+        )
+
+    names = _known_field_names(_M())
+    assert {
+        "plain",
+        "aliased",
+        "aliased_in",
+        "val_str",
+        "val_str_in",
+        "val_choices",
+        "choice_a",
+        "choice_b",
+    } <= names
+
+
 class TestNormalizeNetworkForPlatform:
     """Tests for network normalization via get_validated(mode='json')."""
 

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import yaml
+from gymnasium import spaces
 from pydantic import ValidationError
 
 from agilerl import HAS_ARENA_DEPENDENCIES, HAS_LLM_DEPENDENCIES
@@ -1150,6 +1152,18 @@ _MULTI_AGENT_CONFIGS = [
     ("multi_agent/ippo_pong.yaml", IPPOSpec),
 ]
 
+# Configs omit the network ``arch``, so it is inferred from the observation
+# space at build time. Give the stub env a space matching the expected encoder.
+_OBS_SPACE_FOR_ENCODER = {
+    MlpSpec: spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32),
+    LstmSpec: spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32),
+    SimbaSpec: spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32),
+    CnnSpec: spaces.Box(0, 255, shape=(3, 32, 32), dtype=np.uint8),
+    MultiInputSpec: spaces.Dict(
+        {"vector": spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32)}
+    ),
+}
+
 
 class TestFromConfigFiles:
     """Load every YAML config under ``configs/training/`` and verify that
@@ -1157,12 +1171,27 @@ class TestFromConfigFiles:
     """
 
     @pytest.fixture(autouse=True)
-    def _patch_heavy_init(self):
+    def _patch_heavy_init(self, request):
         """Avoid spawning real environments and populations for config
         file integration tests.
+
+        When a test parametrizes ``expected_encoder_cls``, give the stub env a
+        matching observation space so the deferred obs-space -> encoder-arch
+        inference resolves to the expected encoder.
         """
+        env = MagicMock()
+        callspec = getattr(request.node, "callspec", None)
+        expected_encoder_cls = (
+            callspec.params.get("expected_encoder_cls")
+            if callspec is not None
+            else None
+        )
+        obs_space = _OBS_SPACE_FOR_ENCODER.get(expected_encoder_cls)
+        if obs_space is not None:
+            env.single_observation_space = obs_space
+
         with (
-            patch.object(LocalTrainer, "_make_env", return_value=MagicMock()),
+            patch.object(LocalTrainer, "_make_env", return_value=env),
             patch(
                 "agilerl.training.trainer.create_population_from_spec",
                 return_value=[MagicMock()],

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -52,14 +52,16 @@ class TestNormalizeManifestNetwork:
         )
         assert normalized["encoder_config"] == {"arch": "mlp"}
 
-    def test_missing_arch_raises_helpful_error(self):
-        with pytest.raises(ValueError, match="Missing encoder architecture"):
-            normalize_manifest_network(
-                {
-                    "encoder_config": {"hidden_size": [64]},
-                    "head_config": {"hidden_size": [64]},
-                },
-            )
+    def test_missing_arch_deferred(self):
+        # Deferred: no arch declared anywhere, so the data is returned
+        # unchanged rather than raising; the trainer resolves the arch later.
+        data = {
+            "encoder_config": {"hidden_size": [64]},
+            "head_config": {"hidden_size": [64]},
+        }
+        normalized = normalize_manifest_network(data)
+        assert "arch" not in normalized["encoder_config"]
+        assert normalized == data
 
 
 class TestMinMaxValidator:
@@ -987,8 +989,9 @@ class TestManifestFromTrainerSpecsForeignModels:
     """Foreign BaseModel inputs are dumped before manifest validation."""
 
     def test_from_trainer_specs_coerces_foreign_training_model(self):
-        from agilerl.arena.models.env import EnvSpec as ArenaEnvSpec
         from pydantic import BaseModel
+
+        from agilerl.arena.models.env import EnvSpec as ArenaEnvSpec
 
         class ForeignTraining(BaseModel):
             max_steps: int = 300
@@ -1004,7 +1007,6 @@ class TestManifestFromTrainerSpecsForeignModels:
 
     def test_resolve_foreign_arena_algorithm(self):
         from agilerl.arena.models.algorithms.ppo import PPOSpec as ArenaPPOSpec
-
         from agilerl.models.manifest import _resolve_algorithm
 
         resolved = _resolve_algorithm(ArenaPPOSpec(learn_step=48))

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -989,9 +989,8 @@ class TestManifestFromTrainerSpecsForeignModels:
     """Foreign BaseModel inputs are dumped before manifest validation."""
 
     def test_from_trainer_specs_coerces_foreign_training_model(self):
-        from pydantic import BaseModel
-
         from agilerl.arena.models.env import EnvSpec as ArenaEnvSpec
+        from pydantic import BaseModel
 
         class ForeignTraining(BaseModel):
             max_steps: int = 300
@@ -1007,6 +1006,7 @@ class TestManifestFromTrainerSpecsForeignModels:
 
     def test_resolve_foreign_arena_algorithm(self):
         from agilerl.arena.models.algorithms.ppo import PPOSpec as ArenaPPOSpec
+
         from agilerl.models.manifest import _resolve_algorithm
 
         resolved = _resolve_algorithm(ArenaPPOSpec(learn_step=48))

--- a/tests/test_train/_dummy_envs.py
+++ b/tests/test_train/_dummy_envs.py
@@ -31,6 +31,24 @@ class DictObsEnv(gym.Env):
         return self.observation_space.sample(), 0.0, False, False, {}
 
 
+class ImageObsEnv(gym.Env):
+    """Single-agent env with a 3-D Box observation space (needs EvolvableCNN)."""
+
+    def __init__(self, render_mode=None):
+        self.observation_space = spaces.Box(
+            low=0, high=255, shape=(3, 32, 32), dtype=np.uint8
+        )
+        self.action_space = spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32)
+        self.render_mode = render_mode
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        return self.observation_space.sample(), {}
+
+    def step(self, action):
+        return self.observation_space.sample(), 0.0, False, False, {}
+
+
 class HeteroParallelEnv(ParallelEnv):
     """Two agents: one Dict-obs (multiinput), one vector-obs (mlp)."""
 

--- a/tests/test_train/_dummy_envs.py
+++ b/tests/test_train/_dummy_envs.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
+from pettingzoo import ParallelEnv
 
 
 class DictObsEnv(gym.Env):
@@ -26,3 +29,46 @@ class DictObsEnv(gym.Env):
 
     def step(self, action):
         return self.observation_space.sample(), 0.0, False, False, {}
+
+
+class HeteroParallelEnv(ParallelEnv):
+    """Two agents: one Dict-obs (multiinput), one vector-obs (mlp)."""
+
+    metadata: ClassVar[dict] = {"name": "hetero_v0"}
+
+    def __init__(self, render_mode=None):
+        self.possible_agents = ["dict_agent", "vec_agent"]
+        self.render_mode = render_mode
+        self._obs = {
+            "dict_agent": spaces.Dict(
+                {"a": spaces.Box(-1.0, 1.0, shape=(3,), dtype=np.float32)}
+            ),
+            "vec_agent": spaces.Box(-1.0, 1.0, shape=(4,), dtype=np.float32),
+        }
+        self._act = {
+            "dict_agent": spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32),
+            "vec_agent": spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32),
+        }
+
+    def observation_space(self, agent):
+        return self._obs[agent]
+
+    def action_space(self, agent):
+        return self._act[agent]
+
+    def reset(self, *, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        return (
+            {a: self._obs[a].sample() for a in self.agents},
+            {a: {} for a in self.agents},
+        )
+
+    def step(self, actions):
+        obs = {a: self._obs[a].sample() for a in self.agents}
+        return (
+            obs,
+            dict.fromkeys(self.agents, 0.0),
+            dict.fromkeys(self.agents, False),
+            dict.fromkeys(self.agents, False),
+            {a: {} for a in self.agents},
+        )

--- a/tests/test_train/_dummy_envs.py
+++ b/tests/test_train/_dummy_envs.py
@@ -1,0 +1,28 @@
+"""Importable dummy gym envs for manifest entrypoint resolution in tests."""
+
+from __future__ import annotations
+
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+
+
+class DictObsEnv(gym.Env):
+    """Single-agent env with a Dict observation space (needs EvolvableMultiInput)."""
+
+    def __init__(self, render_mode=None):
+        self.observation_space = spaces.Dict(
+            {
+                "a": spaces.Box(-1.0, 1.0, shape=(3,), dtype=np.float32),
+                "b": spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32),
+            }
+        )
+        self.action_space = spaces.Box(-1.0, 1.0, shape=(2,), dtype=np.float32)
+        self.render_mode = render_mode
+
+    def reset(self, *, seed=None, options=None):
+        super().reset(seed=seed)
+        return self.observation_space.sample(), {}
+
+    def step(self, action):
+        return self.observation_space.sample(), 0.0, False, False, {}

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -2584,3 +2584,47 @@ class TestLocalTrainerResolveEnvSpecBranches:
         result = LocalTrainer._resolve_env_spec(manifest)
         assert isinstance(result, LLMEnvSpec)
         assert result.env_type == LLMEnvType.REASONING
+
+
+def test_from_manifest_infers_multiinput_when_arch_absent(tmp_path):
+    """A Dict-obs env with NO arch builds an EvolvableMultiInput encoder."""
+    import yaml
+
+    from agilerl.modules.multi_input import EvolvableMultiInput
+    from agilerl.training.trainer import LocalTrainer
+
+    manifest = {
+        "algorithm": {"name": "PPO", "learn_step": 64},
+        "environment": {
+            "name": "dict-obs-env",
+            "num_envs": 2,
+            "entrypoint": "tests.test_train._dummy_envs:DictObsEnv",
+        },
+        "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
+        "network": {"latent_dim": 32, "head_config": {"hidden_size": [32]}},
+    }
+    path = tmp_path / "m.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+
+    trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
+    encoder = trainer.population[0].actor.encoder
+    assert isinstance(encoder, EvolvableMultiInput)
+
+
+def test_from_manifest_wrong_arch_is_overridden_when_omitted(tmp_path):
+    """Vector-obs env with no arch builds an EvolvableMLP."""
+    import yaml
+
+    from agilerl.modules.mlp import EvolvableMLP
+    from agilerl.training.trainer import LocalTrainer
+
+    manifest = {
+        "algorithm": {"name": "PPO", "learn_step": 64},
+        "environment": {"name": "CartPole-v1", "num_envs": 2},
+        "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
+        "network": {"latent_dim": 32, "head_config": {"hidden_size": [32]}},
+    }
+    path = tmp_path / "m.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
+    assert isinstance(trainer.population[0].actor.encoder, EvolvableMLP)

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -2630,27 +2630,96 @@ def test_from_manifest_wrong_arch_is_overridden_when_omitted(tmp_path):
     assert isinstance(trainer.population[0].actor.encoder, EvolvableMLP)
 
 
-def test_deferred_encoder_uses_spec_defaults_not_dataclass(tmp_path):
+@pytest.mark.parametrize(
+    ("arch", "environment", "algorithm_extra", "network_extra", "assertions"),
+    [
+        pytest.param(
+            "mlp",
+            {"name": "CartPole-v1", "num_envs": 2},
+            {},
+            {},
+            # MlpSpec defaults (dataclass MlpNetConfig would be 500 / 3)
+            {"max_mlp_nodes": 256, "max_hidden_layers": 6},
+            id="mlp",
+        ),
+        pytest.param(
+            "multiinput",
+            {
+                "name": "dict-obs-env",
+                "num_envs": 2,
+                "entrypoint": "tests.test_train._dummy_envs:DictObsEnv",
+            },
+            {},
+            {},
+            # MultiInputSpec default (dataclass MultiInputNetConfig would be 16)
+            {"latent_dim": 32},
+            id="multiinput",
+        ),
+        pytest.param(
+            "cnn",
+            {
+                "name": "image-obs-env",
+                "num_envs": 2,
+                "entrypoint": "tests.test_train._dummy_envs:ImageObsEnv",
+            },
+            {},
+            {},
+            # CnnSpec default (dataclass CnnNetConfig would be 16)
+            {"min_channel_size": 8},
+            id="cnn",
+        ),
+        pytest.param(
+            "lstm",
+            {"name": "CartPole-v1", "num_envs": 2},
+            {"recurrent": True},
+            {},
+            # LstmSpec defaults (dataclass LstmNetConfig would be 500 / 4)
+            {"max_hidden_state_size": 256, "max_layers": 6},
+            id="lstm",
+        ),
+        pytest.param(
+            "simba",
+            {"name": "CartPole-v1", "num_envs": 2},
+            {},
+            {"simba": True},
+            # SimbaSpec default (dataclass SimBaNetConfig would be 500)
+            {"max_mlp_nodes": 256},
+            id="simba",
+        ),
+    ],
+)
+def test_deferred_encoder_uses_spec_defaults_not_dataclass(
+    tmp_path, arch, environment, algorithm_extra, network_extra, assertions
+):
     """A no-arch manifest must resolve encoder HP bounds from the pydantic
     ``*Spec`` defaults, not the ``modules/configs`` dataclass defaults.
+
+    Parametrized across every inferable arch (mlp, multiinput, cnn, lstm,
+    simba) so the invariant is guarded regardless of which encoder the
+    deferred path infers from the observation space / algorithm flags.
     """
     import yaml
 
     from agilerl.training.trainer import LocalTrainer
 
     manifest = {
-        "algorithm": {"name": "PPO", "learn_step": 64},
-        "environment": {"name": "CartPole-v1", "num_envs": 2},
+        "algorithm": {"name": "PPO", "learn_step": 64, **algorithm_extra},
+        "environment": environment,
         "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
-        "network": {"latent_dim": 32, "head_config": {"hidden_size": [32]}},
+        "network": {
+            "latent_dim": 32,
+            "head_config": {"hidden_size": [32]},
+            **network_extra,
+        },
     }
     path = tmp_path / "m.yaml"
     path.write_text(yaml.safe_dump(manifest))
     trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
 
     enc = trainer.algorithm_spec.net_config.encoder_config
-    assert enc.max_mlp_nodes == 256  # MlpSpec default (dataclass would be 500)
-    assert enc.max_hidden_layers == 6  # MlpSpec default (dataclass would be 3)
+    assert enc.arch == arch
+    for field, expected in assertions.items():
+        assert getattr(enc, field) == expected
 
 
 def test_from_manifest_multi_agent_heterogeneous_per_agent_encoders(tmp_path):

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -2651,3 +2651,57 @@ def test_deferred_encoder_uses_spec_defaults_not_dataclass(tmp_path):
     enc = trainer.algorithm_spec.net_config.encoder_config
     assert enc.max_mlp_nodes == 256  # MlpSpec default (dataclass would be 500)
     assert enc.max_hidden_layers == 6  # MlpSpec default (dataclass would be 3)
+
+
+def test_from_manifest_multi_agent_heterogeneous_per_agent_encoders(tmp_path):
+    """Heterogeneous multi-agent env with no arch: per-agent encoders inferred."""
+    import yaml
+
+    from agilerl.modules.mlp import EvolvableMLP
+    from agilerl.modules.multi_input import EvolvableMultiInput
+    from agilerl.training.trainer import LocalTrainer
+
+    manifest = {
+        "algorithm": {"name": "IPPO", "learn_step": 64},
+        "environment": {
+            "name": "hetero-env",
+            "num_envs": 2,
+            "entrypoint": "tests.test_train._dummy_envs:HeteroParallelEnv",
+        },
+        "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
+        "network": {"latent_dim": 32, "head_config": {"hidden_size": [32]}},
+    }
+    path = tmp_path / "m.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+
+    trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
+    agent = trainer.population[0]
+    encoders = {aid: net.encoder for aid, net in agent.actors.items()}
+    assert isinstance(encoders["dict_agent"], EvolvableMultiInput)
+    assert isinstance(encoders["vec_agent"], EvolvableMLP)
+
+
+def test_from_manifest_multi_agent_homogeneous(tmp_path):
+    """Homogeneous multi-agent env with no arch: shared MLP encoder per group."""
+    import yaml
+
+    from agilerl.modules.mlp import EvolvableMLP
+    from agilerl.training.trainer import LocalTrainer
+
+    manifest = {
+        "algorithm": {"name": "IPPO", "learn_step": 64},
+        "environment": {
+            "name": "pettingzoo.mpe.simple_spread_v3",
+            "num_envs": 2,
+        },
+        "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
+        "network": {"latent_dim": 32, "head_config": {"hidden_size": [32]}},
+    }
+    path = tmp_path / "m.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
+    agent = trainer.population[0]
+    # simple_spread agents (agent_0/1/2) share a prefix -> one grouped policy.
+    assert len(agent.actors) >= 1
+    for net in agent.actors.values():
+        assert isinstance(net.encoder, EvolvableMLP)

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -2722,6 +2722,35 @@ def test_deferred_encoder_uses_spec_defaults_not_dataclass(
         assert getattr(enc, field) == expected
 
 
+def test_resolve_deferred_net_config_noop_when_arch_present(tmp_path):
+    """A raw net_config that already declares an ``arch`` is left untouched
+    (nothing to infer), so ``_resolve_deferred_net_config`` returns early.
+    """
+    import yaml
+
+    from agilerl.training.trainer import LocalTrainer
+
+    manifest = {
+        "algorithm": {"name": "PPO", "learn_step": 64},
+        "environment": {"name": "CartPole-v1", "num_envs": 2},
+        "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
+        "network": {
+            "latent_dim": 32,
+            "arch": "mlp",
+            "encoder_config": {"hidden_size": [32]},
+            "head_config": {"hidden_size": [32]},
+        },
+    }
+    path = tmp_path / "m.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
+
+    raw = {"arch": "mlp", "encoder_config": {"arch": "mlp", "hidden_size": [64]}}
+    trainer.algorithm_spec.net_config = raw
+    trainer._resolve_deferred_net_config()
+    assert trainer.algorithm_spec.net_config is raw
+
+
 def test_from_manifest_multi_agent_heterogeneous_per_agent_encoders(tmp_path):
     """Heterogeneous multi-agent env with no arch: per-agent encoders inferred."""
     import yaml

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -2628,3 +2628,26 @@ def test_from_manifest_wrong_arch_is_overridden_when_omitted(tmp_path):
     path.write_text(yaml.safe_dump(manifest))
     trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
     assert isinstance(trainer.population[0].actor.encoder, EvolvableMLP)
+
+
+def test_deferred_encoder_uses_spec_defaults_not_dataclass(tmp_path):
+    """A no-arch manifest must resolve encoder HP bounds from the pydantic
+    ``*Spec`` defaults, not the ``modules/configs`` dataclass defaults.
+    """
+    import yaml
+
+    from agilerl.training.trainer import LocalTrainer
+
+    manifest = {
+        "algorithm": {"name": "PPO", "learn_step": 64},
+        "environment": {"name": "CartPole-v1", "num_envs": 2},
+        "training": {"max_steps": 200, "evo_steps": 100, "pop_size": 1},
+        "network": {"latent_dim": 32, "head_config": {"hidden_size": [32]}},
+    }
+    path = tmp_path / "m.yaml"
+    path.write_text(yaml.safe_dump(manifest))
+    trainer = LocalTrainer.from_manifest(manifest=path, device="cpu")
+
+    enc = trainer.algorithm_spec.net_config.encoder_config
+    assert enc.max_mlp_nodes == 256  # MlpSpec default (dataclass would be 500)
+    assert enc.max_hidden_layers == 6  # MlpSpec default (dataclass would be 3)

--- a/tests/test_utils/test_utils_evolvable.py
+++ b/tests/test_utils/test_utils_evolvable.py
@@ -95,13 +95,13 @@ def test_config_from_dict():
         config_from_dict({"unknown_key": 1})
 
 
-def test_config_from_dict_hidden_size_num_layers_selects_lstm():
+def test_config_from_dict_hidden_state_size_selects_lstm():
     from agilerl.modules.configs import LstmNetConfig
 
-    lstm_cfg = LstmNetConfig(hidden_state_size=64, num_layers=2)
-    with patch.object(LstmNetConfig, "from_dict", return_value=lstm_cfg):
-        cfg = config_from_dict({"hidden_size": 128, "num_layers": 2})
-    assert cfg is lstm_cfg
+    cfg = config_from_dict({"hidden_state_size": 128, "num_layers": 2})
+    assert isinstance(cfg, LstmNetConfig)
+    assert cfg.hidden_state_size == 128
+    assert cfg.num_layers == 2
 
 
 def test_tuple_to_dict_space():


### PR DESCRIPTION
Manifests no longer need to hard-code the network arch. When it's omitted, the architecture is inferred from the environment's observation space at build time, and the encoder schema is validated to match the encoder that actually gets built.

##  Core changes
  - ` infer_encoder_arch(obs_space, *, recurrent, simba)` (models/networks.py) — maps an observation space to an arch literal (multiinput/cnn/lstm/simba/mlp), mirroring the encoder-build branch order; simba > recurrent, obs-space shape wins over both.
  - `LocalTrainer `deferred resolution — once the env exists, `_resolve_deferred_net_config` infers the arch and validates the network into the algorithm's concrete `NetworkSpec`. Handles multi-agent per shared-policy group (heterogeneous agents each get the right encoder). Seeds only
  required encoder fields so the deferred path resolves to the same HP bounds as the explicit path.
  - Arena client — when arch is omitted, the raw network section is passed through to the server for its own obs-space-aware resolution.

##  Misc
  - Tutorial manifest: tournament → tournament_selection (the server-recognized key); custom-env tutorial drops the explicit arch.
  - Removed unsupported cudagraphs field from Arena DQNSpec.