### PR TITLE
Docs & CLI Fixes Arena Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ AGENTS.md
 
 # Symlink for type-checking (repo root only)
 /agilerl/arena/
+
+# Local Arena client backend switcher (dev tooling)
+/set-local-client.sh

--- a/agilerl-arena/agilerl/arena/cli.py
+++ b/agilerl-arena/agilerl/arena/cli.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import click
-
 import agilerl.arena  # noqa: F401 — configure package logging before submodules
+import click
 from agilerl.arena import console
 from agilerl.arena.cli_manifest import handle_help_option
 from agilerl.arena.config import CommandConfig, arena_client

--- a/agilerl-arena/agilerl/arena/cli.py
+++ b/agilerl-arena/agilerl/arena/cli.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import agilerl.arena  # noqa: F401 — configure package logging before submodules
 import click
+
+import agilerl.arena  # noqa: F401 — configure package logging before submodules
+from agilerl.arena import console
 from agilerl.arena.cli_manifest import handle_help_option
 from agilerl.arena.config import CommandConfig, arena_client
 from agilerl.arena.exceptions import ArenaError
@@ -662,7 +664,7 @@ def experiment_checkpoints(
 @click.option(
     "--preview-rows",
     type=click.IntRange(0),
-    default=10,
+    default=5,
     show_default=True,
     help="When CSV is returned, preview this many rows in a rich table.",
 )
@@ -896,14 +898,9 @@ def agent_generate(
             project_name=project_name,
         ) as agent,
     ):
-        completion = "".join(agent.generate_stream(prompt))
-        emit_result(
-            {
-                "deployment": target,
-                "prompt": prompt,
-                "completion": completion,
-            }
-        )
+        for chunk in agent.generate_stream(prompt):
+            console.print(chunk, end="", markup=False, highlight=False, soft_wrap=True)
+        console.print()
 
 
 @main.group("projects")

--- a/agilerl-arena/agilerl/arena/client.py
+++ b/agilerl-arena/agilerl/arena/client.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any, ClassVar, TypedDict
 
 import httpx
+from typing_extensions import Self
+
 from agilerl.arena.auth import (
     ArenaOAuth2,
     is_oauth_access_token_valid,
@@ -40,7 +42,6 @@ from agilerl.arena.utils import (
     prepare_env_upload,
     prepare_file_upload,
 )
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -127,8 +128,6 @@ class ArenaClient:
     CONFIG_FILE: ClassVar[Path] = CONFIG_DIR / "config.json"
 
     _CAPABILITIES_PATH: ClassVar[str] = "/api/cli/v1/capabilities"
-    # Capability checks gate `--help` rendering, so keep them snappy even when the
-    # API is slow/unreachable instead of blocking on the full request timeout.
     _CAPABILITIES_TIMEOUT_SECS: ClassVar[float] = 5.0
     _MANIFEST_ALLOWED_PATH_PREFIX: ClassVar[str] = "/api/cli/v1/on-prem"
     _MANIFEST_ALLOWED_METHODS: ClassVar[frozenset[str]] = frozenset(
@@ -1205,7 +1204,8 @@ class ArenaClient:
             f" (checkpoint {checkpoint})" if checkpoint else " (best checkpoint)"
         )
         logger.info(
-            "Agent deployed successfully from experiment %s%s.",
+            "Agent submitted for deployment from experiment %s%s. "
+            "Check its status in Arena.",
             experiment_name,
             checkpoint_suffix,
         )

--- a/agilerl-arena/agilerl/arena/client.py
+++ b/agilerl-arena/agilerl/arena/client.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Any, ClassVar, TypedDict
 
 import httpx
-from typing_extensions import Self
-
 from agilerl.arena.auth import (
     ArenaOAuth2,
     is_oauth_access_token_valid,
@@ -42,6 +40,7 @@ from agilerl.arena.utils import (
     prepare_env_upload,
     prepare_file_upload,
 )
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/agilerl/arena/models/algorithms/grpo.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/grpo.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from pydantic import Field, model_validator
-
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
+from pydantic import Field, model_validator
 
 
 @register()

--- a/agilerl-arena/agilerl/arena/models/algorithms/grpo.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/grpo.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from pydantic import Field, model_validator
+
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
-from pydantic import Field, model_validator
 
 
 @register()
@@ -18,7 +19,7 @@ class GRPOSpec(LLMAlgorithmSpec):
     lr: float = Field(default=0.0001, ge=0.0)
     clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
-    max_output_tokens: int | None = Field(default=1024)
+    max_output_tokens: int | None = Field(default=1024, exclude=True)
     min_output_tokens: int | None = Field(default=None)
     cosine_lr_schedule_config: CosineLRScheduleConfig | None = Field(default=None)
     vllm_config: VLLMConfig | None = Field(default=None)

--- a/agilerl-arena/agilerl/arena/models/algorithms/llmppo.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/llmppo.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal
 
+from pydantic import Field, model_validator
+
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
-from pydantic import Field, model_validator
 
 
 @register()
@@ -21,7 +22,7 @@ class LLMPPOSpec(LLMAlgorithmSpec):
     gamma: float = Field(default=0.99, ge=0.0, le=1.0)
     gae_lambda: float = Field(default=0.95, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
-    max_output_tokens: int | None = Field(default=1024)
+    max_output_tokens: int | None = Field(default=1024, exclude=True)
     min_output_tokens: int | None = Field(default=None)
     action_granularity: Literal["turn", "token", "auto"] = Field(default="auto")
     cosine_lr_schedule_config: CosineLRScheduleConfig | None = Field(default=None)

--- a/agilerl-arena/agilerl/arena/models/algorithms/llmppo.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/llmppo.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal
 
-from pydantic import Field, model_validator
-
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
+from pydantic import Field, model_validator
 
 
 @register()

--- a/agilerl-arena/agilerl/arena/models/algorithms/llmreinforce.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/llmreinforce.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal
 
+from pydantic import Field, model_validator
+
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
-from pydantic import Field, model_validator
 
 
 @register()
@@ -18,7 +19,7 @@ class LLMREINFORCESpec(LLMAlgorithmSpec):
     clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
     gamma: float = Field(default=0.99, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
-    max_output_tokens: int | None = Field(default=1024)
+    max_output_tokens: int | None = Field(default=1024, exclude=True)
     min_output_tokens: int | None = Field(default=None)
     action_granularity: Literal["turn", "token", "auto"] = Field(default="auto")
     cosine_lr_schedule_config: CosineLRScheduleConfig | None = Field(default=None)

--- a/agilerl-arena/agilerl/arena/models/algorithms/llmreinforce.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/llmreinforce.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal
 
-from pydantic import Field, model_validator
-
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
+from pydantic import Field, model_validator
 
 
 @register()

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -7,8 +7,18 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args
 
-import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 import yaml
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
+from typing_extensions import Self
+
+import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 from agilerl.arena.models.algo import (
     ARENA_REGISTRY,
     AlgoSpecT,
@@ -20,15 +30,6 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    model_validator,
-)
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -328,7 +329,6 @@ class TrainingManifest(BaseModel):
                     llm_network.pretrained_model_name_or_path
                 )
                 self.algorithm.max_model_len = llm_network.max_context_length
-                self.algorithm.lora_config = llm_network.lora_config
 
         if (
             issubclass(algo_spec_cls, LLMAlgorithmSpec)

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -7,18 +7,8 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal, get_args
 
-import yaml
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    model_validator,
-)
-from typing_extensions import Self
-
 import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
+import yaml
 from agilerl.arena.models.algo import (
     ARENA_REGISTRY,
     AlgoSpecT,
@@ -30,6 +20,15 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/agilerl/arena/output.py
+++ b/agilerl-arena/agilerl/arena/output.py
@@ -9,6 +9,11 @@ from functools import singledispatch
 from typing import Any
 
 import click
+from rich.live import Live
+from rich.markup import escape
+from rich.table import Table
+from typing_extensions import Self
+
 from agilerl.arena import console, error_console
 from agilerl.arena.exceptions import ArenaAPIError, ArenaError, resolve_api_error_class
 from agilerl.arena.stream import (
@@ -18,10 +23,6 @@ from agilerl.arena.stream import (
     StatusEvent,
     StreamEvent,
 )
-from rich.live import Live
-from rich.markup import escape
-from rich.table import Table
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -353,10 +354,31 @@ def emit_csv_preview(payload: bytes, *, max_rows: int) -> None:
 
     header = rows[0]
     data_rows = rows[1 : max_rows + 1]
+    if len(header) > len(data_rows) + 1:
+        table = _build_pivoted_preview(header, data_rows)
+    else:
+        table = _build_flat_preview(header, data_rows)
+    console.print(table)
+
+
+def _build_flat_preview(header: list[str], data_rows: list[list[str]]) -> Table:
+    """One column per metric, one row per record (natural CSV layout)."""
     table = Table(title=f"Metrics Preview (first {len(data_rows)} rows)")
     for column in header:
         table.add_column(column)
     for row in data_rows:
         padded = row + [""] * max(0, len(header) - len(row))
         table.add_row(*padded[: len(header)])
-    console.print(table)
+    return table
+
+
+def _build_pivoted_preview(header: list[str], data_rows: list[list[str]]) -> Table:
+    """One row per metric with a column per record."""
+    table = Table(title=f"Metrics Preview (first {len(data_rows)} rows)")
+    table.add_column("Metric", style="bold", no_wrap=True)
+    for index in range(len(data_rows)):
+        table.add_column(f"Row {index + 1}", justify="right")
+    for col_index, name in enumerate(header):
+        values = [row[col_index] if col_index < len(row) else "" for row in data_rows]
+        table.add_row(name, *values)
+    return table

--- a/agilerl-arena/agilerl/arena/output.py
+++ b/agilerl-arena/agilerl/arena/output.py
@@ -9,11 +9,6 @@ from functools import singledispatch
 from typing import Any
 
 import click
-from rich.live import Live
-from rich.markup import escape
-from rich.table import Table
-from typing_extensions import Self
-
 from agilerl.arena import console, error_console
 from agilerl.arena.exceptions import ArenaAPIError, ArenaError, resolve_api_error_class
 from agilerl.arena.stream import (
@@ -23,6 +18,10 @@ from agilerl.arena.stream import (
     StatusEvent,
     StreamEvent,
 )
+from rich.live import Live
+from rich.markup import escape
+from rich.table import Table
+from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/pyproject.toml
+++ b/agilerl-arena/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl-arena"
-version = "0.1.0.dev1"
+version = "0.1.0"
 description = "Arena Platform Client Library and CLI."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,6 +6,13 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
+
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -25,12 +32,6 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -116,8 +117,9 @@ def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
 
 
 def test_known_field_names_includes_all_alias_forms() -> None:
-    from agilerl.arena.models.manifest import _known_field_names
     from pydantic import AliasChoices, BaseModel, Field
+
+    from agilerl.arena.models.manifest import _known_field_names
 
     class _M(BaseModel):
         plain: int = Field(default=0)
@@ -216,6 +218,29 @@ def test_llm_pretrained_model_can_come_from_network_section() -> None:
         "Qwen/Qwen2.5-0.5B-Instruct"
     )
     assert payload["algorithm"]["max_model_len"] == 2048
+
+
+def test_llm_lora_and_max_output_tokens_excluded_from_algorithm() -> None:
+    payload = TrainingManifest.get_validated(
+        _manifest(
+            algorithm={"name": "GRPO", "group_size": 8},
+            environment={"name": "my-llm-env"},
+            network={
+                "pretrained_model_name_or_path": "Qwen/Qwen2.5-0.5B-Instruct",
+                "max_context_length": 512,
+                "lora_config": {"lora_r": 16},
+            },
+        )
+    )
+    algorithm = payload["algorithm"]
+    # Model fields the platform expects under algorithm are still there.
+    assert algorithm["pretrained_model_name_or_path"] == "Qwen/Qwen2.5-0.5B-Instruct"
+    assert algorithm["max_model_len"] == 512
+    # lora_config and max_output_tokens must not be emitted under algorithm.
+    assert "lora_config" not in algorithm
+    assert "max_output_tokens" not in algorithm
+    # lora_config still travels under the network section.
+    assert payload["network"]["lora_config"]["lora_r"] == 16
 
 
 def test_get_validated_loads_yaml_file(tmp_path) -> None:

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,13 +6,6 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
-
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -32,6 +25,12 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -117,9 +116,8 @@ def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
 
 
 def test_known_field_names_includes_all_alias_forms() -> None:
-    from pydantic import AliasChoices, BaseModel, Field
-
     from agilerl.arena.models.manifest import _known_field_names
+    from pydantic import AliasChoices, BaseModel, Field
 
     class _M(BaseModel):
         plain: int = Field(default=0)

--- a/agilerl-arena/tests/test_cli.py
+++ b/agilerl-arena/tests/test_cli.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from click.testing import CliRunner
+
 from agilerl.arena.cli import (
     _redact_agent_rows_for_display,
     arena_client,
@@ -14,7 +16,6 @@ from agilerl.arena.cli import (
 )
 from agilerl.arena.config import CommandConfig, build_client
 from agilerl.arena.exceptions import ArenaAPIError
-from click.testing import CliRunner
 
 
 @pytest.fixture
@@ -972,6 +973,7 @@ class TestAgentGenerateCommand:
             )
         assert result.exit_code == 0
         mock_agent.generate_stream.assert_called_once_with("hi")
+        assert result.output.strip() == "foobar"
 
     def test_generate_uses_active_agent(self, runner, mock_client):
         mock_agent = MagicMock()

--- a/agilerl-arena/tests/test_cli.py
+++ b/agilerl-arena/tests/test_cli.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-from click.testing import CliRunner
-
 from agilerl.arena.cli import (
     _redact_agent_rows_for_display,
     arena_client,
@@ -16,6 +14,7 @@ from agilerl.arena.cli import (
 )
 from agilerl.arena.config import CommandConfig, build_client
 from agilerl.arena.exceptions import ArenaAPIError
+from click.testing import CliRunner
 
 
 @pytest.fixture

--- a/agilerl-arena/tests/test_client.py
+++ b/agilerl-arena/tests/test_client.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-
 from agilerl.arena.auth import ArenaOAuth2
 from agilerl.arena.client import ArenaClient, _TokenStore
 from agilerl.arena.exceptions import (

--- a/agilerl-arena/tests/test_client.py
+++ b/agilerl-arena/tests/test_client.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+
 from agilerl.arena.auth import ArenaOAuth2
 from agilerl.arena.client import ArenaClient, _TokenStore
 from agilerl.arena.exceptions import (
@@ -1603,7 +1604,8 @@ class TestInferenceDeployments:
             json={"experiment_name": "exp1", "checkpoint": "step_100"},
         )
         assert result == {"deployed": True}
-        assert "deployed successfully" in caplog.text
+        assert "submitted for deployment" in caplog.text
+        assert "Check its status in Arena" in caplog.text
         assert "step_100" in caplog.text
 
     def test_deploy_agent_no_checkpoint(self, api_key_client):

--- a/agilerl-arena/tests/test_output.py
+++ b/agilerl-arena/tests/test_output.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+
 from agilerl.arena.exceptions import (
     ArenaAPIError,
     ArenaTrainingError,
@@ -476,3 +477,22 @@ class TestEmitCsvPreview:
     def test_empty_csv_no_output(self, mock_console):
         emit_csv_preview(b"", max_rows=5)
         mock_console.print.assert_not_called()
+
+    @patch("agilerl.arena.output.console")
+    def test_wide_csv_is_pivoted(self, mock_console):
+        header = ",".join(f"metric_{i}" for i in range(30))
+        row = ",".join(str(i) for i in range(30))
+        csv_data = f"{header}\n{row}\n{row}\n".encode()
+        emit_csv_preview(csv_data, max_rows=2)
+        table = mock_console.print.call_args.args[0]
+        # Pivoted: one leading "Metric" column plus one column per preview row.
+        assert [col.header for col in table.columns] == ["Metric", "Row 1", "Row 2"]
+        assert table.row_count == 30
+
+    @patch("agilerl.arena.output.console")
+    def test_narrow_csv_stays_flat(self, mock_console):
+        csv_data = b"col1,col2\n1,2\n3,4\n5,6\n"
+        emit_csv_preview(csv_data, max_rows=3)
+        table = mock_console.print.call_args.args[0]
+        assert [col.header for col in table.columns] == ["col1", "col2"]
+        assert table.row_count == 3

--- a/agilerl-arena/tests/test_output.py
+++ b/agilerl-arena/tests/test_output.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-
 from agilerl.arena.exceptions import (
     ArenaAPIError,
     ArenaTrainingError,

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -859,13 +859,42 @@ class ArenaTrainer(Trainer):
         )
         return TrainingManifest.to_arena_manifest(manifest)
 
-    def train(self) -> dict[str, Any]:
+    def train(
+        self,
+        *,
+        resource_id: str | int | None = None,
+        num_nodes: int | None = None,
+        project: str | None = None,
+        experiment_name: str | None = None,
+        reward_file: str | Path | bytes | None = None,
+        completion: str | None = None,
+    ) -> dict[str, Any]:
         """Build the manifest and submit the training job to Arena.
 
-        :returns: Arena API response including ``job_id`` and ``status``.
+        :param resource_id: Arena cluster type or resource id for the job.
+        :type resource_id: str | int | None
+        :param num_nodes: The number of nodes to use for training.
+        :type num_nodes: int | None
+        :param project: The project to submit the experiment to.
+        :type project: str | None
+        :param experiment_name: The name of the experiment to submit.
+        :type experiment_name: str | None
+        :param reward_file: Python reward module for reasoning dataset jobs.
+        :type reward_file: str | Path | bytes | None
+        :param completion: Optional model completion for reward validation.
+        :type completion: str | None
+        :returns: Arena API response.
         :rtype: dict[str, Any]
         """
-        return self._client.submit_experiment(self.to_manifest())
+        return self._client.submit_experiment(
+            self.to_manifest(),
+            resource_id=resource_id,
+            num_nodes=num_nodes,
+            project=project,
+            experiment_name=experiment_name,
+            reward_file=reward_file,
+            completion=completion,
+        )
 
     def resume_from_checkpoint(self, job_id: str, max_steps: int) -> None:
         """Resume a training job from a checkpoint.

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -42,3 +42,9 @@
 .admonition.tutorial dl dd > p {
   margin: 0;
 }
+
+/* .. container:: scrollable-output — cap tall terminal transcripts and scroll */
+.scrollable-output pre {
+  max-height: 28rem;
+  overflow: auto;
+}

--- a/docs/_static/examples/gsm8k-grpo/reward.py
+++ b/docs/_static/examples/gsm8k-grpo/reward.py
@@ -1,0 +1,37 @@
+import re
+
+
+def reward(question: str, answer: str, completion: str) -> float:
+    """Combined GSM8K reward: answer correctness plus output format."""
+    return correctness_reward(answer, completion) + format_reward(completion)
+
+
+def extract_gold_answer(answer: str) -> str | None:
+    """Return the final numeric answer from a GSM8K answer (the value after ``####``)."""
+    match = re.search(r"####\s*(-?[\d,]+)", answer)
+    return match.group(1).replace(",", "").strip() if match else None
+
+
+def extract_model_answer(completion: str) -> str | None:
+    """Return the final number inside the model's ``<answer>...</answer>`` block."""
+    block = re.search(r"<answer>([\s\S]*?)</answer>", completion)
+    if block is None:
+        return None
+    number = re.search(r"-?[\d,]+", block.group(1))
+    return number.group(0).replace(",", "").strip() if number else None
+
+
+def correctness_reward(answer: str, completion: str) -> float:
+    """Reward 1.0 when the model's final answer matches the gold answer, else 0.0."""
+    gold = extract_gold_answer(answer)
+    predicted = extract_model_answer(completion)
+    if gold is None or predicted is None:
+        return 0.0
+    return 1.0 if predicted == gold else 0.0
+
+
+def format_reward(completion: str) -> float:
+    """Reward 1.0 when the completion follows ``<think>...</think>\\n<answer>...</answer>``."""
+    text = "<think>" + completion
+    regex = r"^<think>[\s\S]*?</think>\n<answer>[\s\S]*?</answer>$"
+    return 1.0 if re.match(regex, text.strip()) else 0.0

--- a/docs/_static/examples/gsm8k_grpo.yaml
+++ b/docs/_static/examples/gsm8k_grpo.yaml
@@ -1,0 +1,60 @@
+---
+algorithm:
+    name: GRPO
+    batch_size: 6
+    beta: 0.001
+    lr: 0.000005
+    clip_coef: 0.2
+    max_grad_norm: 0.1
+    update_epochs: 1
+    group_size: 8
+    temperature: 0.9
+    use_vllm: false
+    calc_position_embeddings: true
+    reduce_memory_peak: false
+
+environment:
+    name: gsm8k
+
+training:
+    max_steps: 100_000
+    evo_steps: 5
+    pop_size: 2
+    eval_loop: 1
+    evaluation_interval: 5
+
+mutation:
+    mutation_sd: 0.1
+    rand_seed: 42
+    probabilities:
+        no_mut: 0.1
+        arch_mut: 0.0
+        new_layer: 0.0
+        params_mut: 0.0
+        act_mut: 0.0
+        rl_hp_mut: 0.6
+    rl_hp_selection:
+        lr:
+            min: 0.0000001
+            max: 0.00001
+        beta:
+            min: 0.0001
+            max: 0.01
+
+tournament_selection:
+    tournament_size: 2
+    elitism: true
+
+network:
+    pretrained_model_name_or_path: Qwen/Qwen2.5-0.5B-Instruct
+    max_context_length: 512
+    lora_config:
+        lora_r: 16
+        lora_alpha: 64
+        target_modules:
+            - q_proj
+            - k_proj
+            - v_proj
+            - o_proj
+        lora_dropout: 0.05
+        task_type: CAUSAL_LM

--- a/docs/_static/examples/merge-env/merge_env.py
+++ b/docs/_static/examples/merge-env/merge_env.py
@@ -61,7 +61,7 @@ class MergeEnv(gym.Env):
                 "sin(drift)": spaces.Box(-1, 1, shape=(1,), dtype=np.float64),
                 "airspeed": spaces.Box(-np.inf, np.inf, shape=(1,), dtype=np.float64),
                 "waypoint_dist": spaces.Box(-np.inf, np.inf, shape=(1,), dtype=np.float64),
-                "faf_reached": spaces.Box(0, 1, shape=(1,), dtype=np.int64),
+                "faf_reached": spaces.Box(0, 1, shape=(1,), dtype=np.float64),
                 "x_r": spaces.Box(-np.inf, np.inf, shape=(NUM_AC_STATE,), dtype=np.float64),
                 "y_r": spaces.Box(-np.inf, np.inf, shape=(NUM_AC_STATE,), dtype=np.float64),
                 "vx_r": spaces.Box(-np.inf, np.inf, shape=(NUM_AC_STATE,), dtype=np.float64),

--- a/docs/_static/examples/merge_ppo.yaml
+++ b/docs/_static/examples/merge_ppo.yaml
@@ -17,8 +17,9 @@ environment:
     version: v1
 
 training:
-    max_steps: 1_000_000
-    evo_steps: 10_000
+    max_steps: 10_000_000
+    evo_steps: 160_000
+    eval_steps: 500
     pop_size: 4
 
 mutation:

--- a/docs/arena/index.rst
+++ b/docs/arena/index.rst
@@ -502,9 +502,19 @@ will be deployed by default.
 Interacting with a Deployed Agent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each deployment runs one agent type. Metadata is loaded when you construct
-:class:`~agilerl.arena.inference.Agent` (see :attr:`~agilerl.arena.inference.Agent.metadata`).
-Call the matching client method; the server returns HTTP 400 if the route does
+Each deployment runs one agent type. The simplest way to interact with one is to open it by
+name with :meth:`~agilerl.arena.client.ArenaClient.open_inference_agent`, which returns an
+:class:`~agilerl.arena.inference.Agent` you can make requests to:
+
+.. code-block:: python
+
+   from agilerl.arena import ArenaClient
+
+   with ArenaClient() as client:
+       with client.open_inference_agent("<deployment-name>") as agent:
+           print(agent.metadata.agent.algo, agent.metadata.agent.llm)
+
+Call the matching agent method; the server returns HTTP 400 if the route does
 not match the deployment:
 
 - **RL** (single- or multi-agent, recurrent): :meth:`~agilerl.arena.inference.Agent.get_action`
@@ -512,47 +522,13 @@ not match the deployment:
 - **LLM**: :meth:`~agilerl.arena.inference.Agent.generate` or
   :meth:`~agilerl.arena.inference.Agent.generate_stream`
 
-.. code-block:: python
+.. tip::
 
-   from agilerl.arena.inference import Agent
+   For LLM deployments, set an active agent with ``arena agent run <deployment-name>`` and you
+   can drop the deployment name from later CLI commands. ``arena agent generate --prompt "..."``
+   then makes inference requests to the active agent.
 
-   agent = Agent(
-       "https://<deployment-id>.inference.agilerl.com",
-       api_key="your-arena-api-key",
-   )
-   print(agent.metadata.agent.algo, agent.metadata.agent.llm)
-
-Routing by deployment type
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-   if agent.metadata.agent.llm:
-       result = agent.generate(
-           ["Explain reinforcement learning."],
-           params={"max_new_tokens": 128},
-       )
-       for item in result.results:
-           print(item.completion)
-
-       for chunk in agent.generate_stream("Summarize PPO in one sentence."):
-           print(chunk, end="", flush=True)
-
-   elif agent.metadata.agent.supervised:
-       import numpy as np
-
-       outputs, meta = agent.predict(np.array([1.0, 2.0, 3.0]))
-       print(meta.inference_time_ms, outputs)
-
-   else:
-       import gymnasium as gym
-
-       env = gym.make("LunarLander-v3")
-       obs, _ = env.reset()
-       action, _ = agent.get_action(obs)
-       print(action)
-
-RL inference
+RL Inference
 ^^^^^^^^^^^^
 
 :meth:`~agilerl.arena.inference.Agent.get_action` serializes NumPy observations
@@ -564,25 +540,20 @@ observation spaces, and recurrent hidden states.
    import numpy as np
    import gymnasium as gym
 
-   from agilerl.arena.inference import Agent
+   from agilerl.arena import ArenaClient
 
    env = gym.make("LunarLander-v3")
-   agent = Agent("https://<deployment-id>.inference.agilerl.com", api_key="...")
 
-   obs, _ = env.reset()
-   action, hidden_state = agent.get_action(obs)
+   with ArenaClient() as client:
+       with client.open_inference_agent("lunar-lander-dqn") as agent:
+         # Single request
+         obs, _ = env.reset()
+         action, hidden_state = agent.get_action(obs)
 
-   # Batched inference
-   batch_size = 8
-   obs_batch = np.stack([env.observation_space.sample() for _ in range(batch_size)])
-   actions, _ = agent.get_action(obs_batch, batched=True)
-
-   # Dict observation space (single-agent)
-   obs_dict = {
-       "image": np.random.randn(64, 64, 3),
-       "velocity": np.array([1.0, 0.5]),
-   }
-   action, hidden_state = agent.get_action(obs_dict)
+         # Batched inference
+         batch_size = 8
+         obs_batch = np.stack([env.observation_space.sample() for _ in range(batch_size)])
+         actions, _ = agent.get_action(obs_batch, batched=True)
 
 Multi-agent RL passes per-agent observations and returns a dict of actions:
 
@@ -596,3 +567,6 @@ Multi-agent RL passes per-agent observations and returns a dict of actions:
 
    :ref:`tutorial_arena_end_to_end`
       Complete walkthrough of validating, training, and deploying a custom environment on Arena.
+
+   :ref:`tutorial_arena_grpo_gsm8k`
+      Complete walkthrough of fine-tuning an LLM with GRPO on the GSM8K dataset in Arena.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ We are constantly adding more algorithms and features. AgileRL already includes 
 
 .. raw:: html
 
-   <h3 id="llm-finetuning-benchmarks">LLM Fine-tuning benchmarks</h3>
+   <h3 id="llm-finetuning-benchmarks">LLM Fine-tuning</h3>
 
 AgileRL's multi-turn LLM training enables state-of-the-art performance on long-horizon tasks with small models. In the following example, AgileRL's CISPO was benchmarked against ART and TRL on the `GEM <https://github.com/axon-rl/gem>`_ Sudoku Hard task. This is a difficult multi-turn problem, which requires a context length of 32k tokens and up to 50 turns per rollout. The sync AgileRL run is a single agent using the AgileRL framework. The async and HPO runs were performed on `Arena <https://arena.agilerl.com>`_, AgileRL's RLOps platform. All runs used the same starting hyperparameters. AgileRL runs were run on A100 40GB nodes, whereas ART and TRL required A100 80GB nodes due to a lack of optimizations. AgileRL runs significantly outperformed those using the ART and TRL frameworks.
 
@@ -63,7 +63,7 @@ AgileRL's multi-turn LLM training enables state-of-the-art performance on long-h
 
 .. raw:: html
 
-   <h3 id="classic-rl-benchmarks">Classic RL benchmarks</h3>
+   <h3 id="classic-rl-benchmarks">Classic RL</h3>
 
 Reinforcement learning algorithms and libraries are usually benchmarked once the optimal hyperparameters for training are known, but it often takes hundreds or thousands of experiments to discover these. This is unrealistic and does not reflect the true, total time taken for training. What if we could remove the need to conduct all these prior experiments?
 

--- a/docs/tutorials/arena_training/grpo_gsm8k.rst
+++ b/docs/tutorials/arena_training/grpo_gsm8k.rst
@@ -1,0 +1,355 @@
+.. _tutorial_arena_grpo_gsm8k:
+
+Training GRPO on GSM8K in Arena
+================================
+
+This tutorial walks through the full Arena workflow for LLM reasoning: registering a dataset,
+writing a reward function, submitting a training job, monitoring progress, and deploying the
+fine-tuned model. We fine-tune ``Qwen/Qwen2.5-0.5B-Instruct`` with **GRPO** on **GSM8K**, a
+dataset of grade-school math word problems, as our running example.
+
+It is the language-model counterpart to :ref:`tutorial_arena_end_to_end`. Where that tutorial
+validates a custom Gymnasium environment, here we register a Hugging Face dataset and supply a
+reward function instead.
+
+Prerequisites
+-------------
+
+Installation
+~~~~~~~~~~~~
+
+Arena is provided by the separate ``agilerl-arena`` distribution (``agilerl.arena.*``
+in the shared namespace). It pulls in lightweight client dependencies (``httpx``,
+``rich``, etc.) rather than core training stacks. Install it directly, or through
+the AgileRL extra:
+
+.. code-block:: bash
+
+   pip install agilerl-arena
+   # or
+   pip install "agilerl[arena]"
+
+Authentication
+~~~~~~~~~~~~~~
+
+All Arena operations require authentication. You can authenticate in one of two ways:
+
+1. **API Key**: set the ``ARENA_API_KEY`` environment variable:
+
+   .. code-block:: bash
+
+      export ARENA_API_KEY="arena_pat..."
+
+   .. note::
+
+      Personal access tokens can be found in the Arena dashboard under
+      *Profile Management* → *CLI API Key*.
+
+2. **Device login** (interactive): run the login command, which opens a browser for OAuth authentication:
+
+   .. tab-set::
+      :sync-group: interface
+
+      .. tab-item:: Python
+         :sync: python
+
+         .. code-block:: python
+
+            from agilerl.arena import ArenaClient
+
+            client = ArenaClient()
+            client.login()
+
+      .. tab-item:: CLI
+         :sync: cli
+
+         .. code-block:: bash
+
+            arena login
+
+   Credentials are persisted locally so you only need to authenticate once per machine.
+
+The Task
+~~~~~~~~
+
+GRPO (Group Relative Policy Optimization) rewards a model for solving problems that have a
+verifiable answer. Instead of training a separate critic to estimate value, GRPO samples a group
+of completions for each prompt and scores each one relative to the group mean. This removes the
+critic network and gives a stable training signal, which makes it a good fit for reasoning tasks.
+
+Our task is GSM8K. Each row is a ``question`` (a math word problem) and an ``answer`` whose final
+line holds the solution after a ``####`` marker:
+
+.. code-block:: text
+
+   question: Natalia sold clips to 48 of her friends in April, and then she sold half as many
+             clips in May. How many clips did she sell altogether in April and May?
+   answer:   Natalia sold 48/2 = 24 clips in May.
+             Altogether she sold 48+24 = 72 clips.
+             #### 72
+
+We reward the model for producing the correct final number, and for wrapping its reasoning and
+answer in the format we ask for.
+
+Register the Dataset
+~~~~~~~~~~~~~~~~~~~~~
+
+Before training, we register the dataset on Arena. We import GSM8K straight from Hugging Face and
+map its columns onto the keys Arena's reasoning datasets expect (``question`` and ``answer``).
+GSM8K already uses those names, so the mapping is one-to-one.
+
+.. tab-set::
+   :sync-group: interface
+
+   .. tab-item:: Python
+      :sync: python
+
+      .. code-block:: python
+
+         client.create_dataset(
+             name="gsm8k",
+             category="reasoning",
+             hf_dataset_name="openai/gsm8k",
+             hf_config="main",
+             hf_split="train",
+             column_mapping={"question": "question", "answer": "answer"},
+         )
+
+   .. tab-item:: CLI
+      :sync: cli
+
+      .. code-block:: bash
+
+         arena datasets create gsm8k \
+             --category reasoning \
+             --hf-dataset openai/gsm8k \
+             --hf-config main \
+             --hf-split train \
+             --column-mapping '{"question": "question", "answer": "answer"}'
+
+Datasets fall into one of three categories: ``reasoning`` (a prompt with a verifiable answer, as
+here), ``preference`` (chosen vs. rejected responses), and ``sft`` (supervised fine-tuning pairs).
+GRPO trains on ``reasoning`` datasets.
+
+You can browse datasets already registered for your organization, or search Hugging Face, with
+``arena datasets list`` (add ``--search`` to query Hugging Face).
+
+The Reward Function
+~~~~~~~~~~~~~~~~~~~
+
+A reasoning job needs a reward function: a Python file that scores each completion the model
+produces. Arena calls a function named ``reward`` with three arguments, ``question``, ``answer``,
+and ``completion``, and expects a single ``float`` back. The higher the reward, the better the
+completion.
+
+Our reward has two parts. A **correctness** reward parses the gold answer after ``####``, extracts
+the final number from the model's ``<answer>`` block, and returns ``1.0`` when they match. A
+**format** reward returns ``1.0`` when the completion wraps its reasoning and answer in
+``<think>...</think>`` and ``<answer>...</answer>`` tags. The most a completion can score is
+``2.0``. We never tell the model which answer or format to produce; it discovers both from the
+reward.
+
+.. collapse:: reward.py
+
+   .. literalinclude:: /_static/examples/gsm8k-grpo/reward.py
+      :language: python
+
+The reward function runs on Arena's infrastructure during training. Arena also runs it once when
+you submit the job, as a quick check that it imports and returns a number.
+
+Creating a Project
+~~~~~~~~~~~~~~~~~~
+
+Before submitting a training job, we need a project to submit it to. Language-model runs live in
+an LLM-based project, so we pass that flag when creating it.
+
+.. tab-set::
+   :sync-group: interface
+
+   .. tab-item:: Python
+      :sync: python
+
+      .. code-block:: python
+
+         client.create_project(name="GSM8K Tutorial", description=None, llm_based=True)
+
+   .. tab-item:: CLI
+      :sync: cli
+
+      .. code-block:: bash
+
+         arena projects create "GSM8K Tutorial" --llm-based
+
+.. tip::
+
+   You can set a default project to work on by using the ``arena projects set-default <project-name>`` CLI command.
+
+Submit a Training Job
+~~~~~~~~~~~~~~~~~~~~~
+
+We define the training configuration in a YAML manifest (``gsm8k_grpo.yaml``). The ``environment``
+section references the dataset by the name we registered it under. The ``network`` section names
+the base model and its LoRA adapter, so training only updates the adapter weights.
+
+.. collapse:: gsm8k_grpo.yaml
+
+   .. literalinclude:: /_static/examples/gsm8k_grpo.yaml
+      :language: yaml
+
+Unlike the :ref:`PPO tutorial <tutorial_arena_end_to_end>`, there is no observation space for Arena
+to infer an encoder from. The model architecture comes entirely from
+``pretrained_model_name_or_path`` and the ``lora_config``.
+
+We submit the manifest together with the reward function. Passing ``--reward-file`` tells Arena
+this is a reasoning job, and it validates the reward function against a sample completion before
+the run starts.
+
+.. tab-set::
+   :sync-group: interface
+
+   .. tab-item:: Python
+      :sync: python
+
+      .. code-block:: python
+
+         result = client.submit_experiment(
+             manifest="gsm8k_grpo.yaml",
+             reward_file="reward.py",
+             resource_id="arena-medium",
+             num_nodes=2,
+             project="GSM8K Tutorial",
+             experiment_name="gsm8k-grpo-v1",
+         )
+
+   .. tab-item:: CLI
+      :sync: cli
+
+      .. code-block:: bash
+
+         arena experiments submit gsm8k_grpo.yaml \
+             --reward-file reward.py \
+             --resource-id arena-medium \
+             --num-nodes 2 \
+             --project 'GSM8K Tutorial' \
+             --experiment-name gsm8k-grpo-v1
+
+.. tip::
+
+   You can view all of the available resources to train on by running the CLI command ``arena resources list``.
+
+Monitor Training
+~~~~~~~~~~~~~~~~
+
+You can monitor training progress directly from the Arena dashboard, or download
+metrics programmatically:
+
+.. tab-set::
+   :sync-group: interface
+
+   .. tab-item:: Python
+      :sync: python
+
+      .. code-block:: python
+
+         # Download training metrics
+         client.download_experiment_metrics(
+             experiment_name="gsm8k-grpo-v1",
+             output_path="metrics.csv",
+         )
+
+         # List available checkpoints
+         checkpoints = client.list_checkpoints(
+             experiment_name="gsm8k-grpo-v1"
+         )
+         print(checkpoints)
+
+   .. tab-item:: CLI
+      :sync: cli
+
+      .. code-block:: bash
+
+         # Download metrics
+         arena experiments metrics gsm8k-grpo-v1 --output-file metrics.csv
+
+         # List checkpoints
+         arena experiments checkpoints gsm8k-grpo-v1
+
+Deploy the Trained Model
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once training is complete, deploy the best checkpoint to an inference endpoint:
+
+.. tab-set::
+   :sync-group: interface
+
+   .. tab-item:: Python
+      :sync: python
+
+      .. code-block:: python
+
+         # Deploy the best checkpoint
+         client.deploy_agent(experiment_name="gsm8k-grpo-v1")
+
+         # Or deploy a specific checkpoint
+         client.deploy_agent(
+             experiment_name="gsm8k-grpo-v1",
+             checkpoint="step_500",
+         )
+
+   .. tab-item:: CLI
+      :sync: cli
+
+      .. code-block:: bash
+
+         # Deploy the best checkpoint
+         arena agent deploy gsm8k-grpo-v1
+
+         # Deploy a specific checkpoint
+         arena agent deploy gsm8k-grpo-v1 --checkpoint step_500
+
+Interact with the Deployed Model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After deployment, open the model by name and send it a prompt to receive a completion. The
+deployment name matches the experiment you deployed; you can also list your deployments with
+``arena agent list``.
+
+.. tab-set::
+   :sync-group: interface
+
+   .. tab-item:: Python
+      :sync: python
+
+      .. code-block:: python
+
+         from agilerl.arena import ArenaClient
+
+         prompt = "Weng earns $12 an hour for babysitting. Yesterday, she just did 50 minutes of babysitting. How much did she earn?"
+
+         with ArenaClient() as client:
+             with client.open_inference_agent("gsm8k-grpo-v1") as agent:
+                 # Generate a full completion
+                 result = agent.generate(prompt)
+                 print(result.results[0].completion)
+
+                 # Or stream tokens as they are produced
+                 for chunk in agent.generate_stream(prompt):
+                     print(chunk, end="")
+
+   .. tab-item:: CLI
+      :sync: cli
+
+      .. code-block:: bash
+
+         # Always streams tokens as they are generated
+         arena agent generate gsm8k-grpo-v1 \
+             --prompt "Weng earns \$12 an hour for babysitting. Yesterday, she just did 50 minutes of babysitting. How much did she earn?"
+
+.. tip::
+
+   Set a default agent with ``arena agent run gsm8k-grpo-v1`` and you can drop the deployment
+   name from later commands. ``arena agent generate --prompt "..."`` then uses the active agent.
+
+.. seealso::
+
+   :ref:`arena_client` for the full reference on all Arena client methods.

--- a/docs/tutorials/arena_training/grpo_gsm8k.rst
+++ b/docs/tutorials/arena_training/grpo_gsm8k.rst
@@ -127,8 +127,15 @@ GSM8K already uses those names, so the mapping is one-to-one.
              --hf-split train \
              --column-mapping '{"question": "question", "answer": "answer"}'
 
-Datasets fall into one of three categories: ``reasoning`` (a prompt with a verifiable answer, as
-here), ``preference`` (chosen vs. rejected responses), and ``sft`` (supervised fine-tuning pairs).
+Datasets fall into one of three categories, and each expects its own column mapping keys:
+
+* ``reasoning``: question and answer pairs for algorithms like GRPO, as here.
+  Expects ``{"question": "<column>", "answer": "<column>"}``.
+* ``preference``: a prompt with a chosen and a rejected completion, for algorithms like DPO.
+  Expects ``{"prompt": "<column>", "chosen": "<column>", "rejected": "<column>"}``.
+* ``sft``: supervised fine-tuning pairs mapping a prompt to a target completion.
+  Expects ``{"prompt": "<column>", "target": "<column>"}``.
+
 GRPO trains on ``reasoning`` datasets.
 
 You can browse datasets already registered for your organization, or search Hugging Face, with

--- a/docs/tutorials/arena_training/index.rst
+++ b/docs/tutorials/arena_training/index.rst
@@ -23,9 +23,12 @@ Tutorials
 
 - :doc:`PPO on a Custom Gym Environment <ppo_custom_env>`: Upload and validate a **Merge** air
   traffic environment on Arena, train PPO with evolutionary HPO, and deploy the trained agent for inference.
+- :doc:`GRPO on GSM8K <grpo_gsm8k>`: Register the **GSM8K** math dataset from Hugging Face, write a
+  reward function, fine-tune ``Qwen2.5-0.5B-Instruct`` with GRPO, and deploy the model for inference.
 
 .. toctree::
    :maxdepth: 1
    :hidden:
 
    PPO on a Custom Gym Environment <ppo_custom_env>
+   GRPO on GSM8K <grpo_gsm8k>

--- a/docs/tutorials/arena_training/ppo_custom_env.rst
+++ b/docs/tutorials/arena_training/ppo_custom_env.rst
@@ -419,14 +419,15 @@ with ``arena agent list``.
    from agilerl.arena import ArenaClient
    from merge_env import MergeEnv
 
-   client = ArenaClient()
-   agent = client.open_inference_agent("merge-ppo-v1")
-
-   # Get an action from the deployed model
+   # Initialize the environment
    env = MergeEnv()
-   observation, _ = env.reset()
-   action, _ = agent.get_action(observation)
-   print(f"Agent chose action: {action}")
+
+   # Initialize the client and the deployed agent
+   with ArenaClient() as client:
+      with client.open_inference_agent("merge-ppo-v1") as agent:
+         observation, _ = env.reset()
+         action, _ = agent.get_action(observation)
+         print(f"Action: {action}")
 
 .. seealso::
 

--- a/docs/tutorials/arena_training/ppo_custom_env.rst
+++ b/docs/tutorials/arena_training/ppo_custom_env.rst
@@ -101,7 +101,7 @@ with the keyword arguments passed to the environment's constructor:
    ├── requirements.txt
    └── env_config.yaml
 
-When submitting an environment for validation, ``agielrl-arena`` automatically packages the whole folder.
+When submitting an environment for validation, ``agilerl-arena`` automatically packages the whole folder.
 ``requirements.txt`` is installed on the validation environment before the checks are ran, and
 ``env_config.yaml`` is applied when the environment is created:
 

--- a/docs/tutorials/arena_training/ppo_custom_env.rst
+++ b/docs/tutorials/arena_training/ppo_custom_env.rst
@@ -75,9 +75,8 @@ traffic simulator and follows the standard Gymnasium interface.
 
 The observation is a dictionary describing the ownship (its drift from the target heading,
 airspeed, distance to the next waypoint) and the relative position, velocity and track of
-the nearest aircraft. The action is continuous, with shape ``(2,)``: a heading change and a
-speed change. PPO handles continuous actions with a Gaussian policy, which makes it a good
-fit for this task.
+the nearest aircraft. The action is continuous, with shape ``(2,)``: - a heading change and a speed change.
+PPO handles continuous actions with a Gaussian policy, which makes it a good fit for this task.
 
 The environment source is taken from
 `bluesky-gym <https://github.com/TUDelft-CNS-ATM/bluesky-gym>`_.
@@ -102,8 +101,8 @@ with the keyword arguments passed to the environment's constructor:
    ├── requirements.txt
    └── env_config.yaml
 
-When you point Arena at a directory, it packages the whole folder and picks these files up
-automatically. ``requirements.txt`` is installed on Arena before your environment runs, and
+When submitting an environment for validation, ``agielrl-arena`` automatically packages the whole folder.
+``requirements.txt`` is installed on the validation environment before the checks are ran, and
 ``env_config.yaml`` is applied when the environment is created:
 
 .. literalinclude:: /_static/examples/merge-env/requirements.txt
@@ -120,7 +119,7 @@ Validate the Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Before training, we need to register and validate our environment on Arena. Validation
-ensures the environment is importable, has the correct interface, and can be stepped
+ensures the environment is importable, has the correct interface, and can be stepped reliably
 without errors.
 
 An entrypoint corresponds to the specific class we want to validate for training. In order to be
@@ -135,7 +134,7 @@ All available entrypoints in the specified environment source are automatically 
 If there are multiple available entrypoints in the same file, we need to provide the
 one we want to validate against to avoid ambiguity through the ``entrypoint`` parameter.
 The ``merge_env.py`` file defines a single Gymnasium environment class, ``MergeEnv``,
-so the ``entrypoint`` parameter is unnecessary.
+so passing ``entrypoint`` is unnecessary.
 
 If no version is specified when creating an environment from scratch, ``v1`` is used by default.
 
@@ -158,6 +157,98 @@ If no version is specified when creating an environment from scratch, ``v1`` is 
       .. code-block:: bash
 
          arena env validate merge-env --source merge-env/
+
+Validation uploads the environment, installs its requirements, and runs a series of interface
+checks. For the environment as shipped, some of these checks fail:
+
+.. container:: scrollable-output
+
+   .. code-block:: text
+
+      INFO     No version specified, defaulting to v1.
+      INFO     Uploading environment 'merge-env:v1' (13.4 KB)
+      INFO     Installing requirements…
+      INFO       Resolving dependencies…
+      INFO       Installing 23 package(s)
+      INFO       Downloading kiwisolver
+      INFO       Downloading pillow
+      INFO       Downloading pandas
+      INFO       Downloading fonttools
+      INFO       Downloading matplotlib
+      INFO       Downloading scipy
+      INFO       Downloading pygame
+      INFO       Downloading openap
+      INFO       Downloading bluesky-navdata
+      INFO       Installed bluesky-gym 0.2.0
+      INFO       Installed bluesky-navdata 1.0.0
+      INFO       Installed bluesky-simulator 1.1.1
+      INFO       Installed cloudpickle 3.1.2
+      INFO       Installed contourpy 1.3.3
+      INFO       Installed cycler 0.12.1
+      INFO       Installed fonttools 4.63.0
+      INFO       Installed kiwisolver 1.5.0
+      INFO       Installed matplotlib 3.11.0
+      INFO       Installed msgpack 1.2.1
+      INFO       Installed openap 2.6.0
+      INFO       Installed packaging 26.2
+      INFO       Installed pandas 3.0.3
+      INFO       Installed pillow 12.3.0
+      INFO       Installed pygame 2.6.1
+      INFO       Installed pyparsing 3.3.2
+      INFO       Installed python-dateutil 2.9.0.post0
+      INFO       Installed pyyaml 6.0.3
+      INFO       Installed pyzmq 27.1.0
+      INFO       Installed scipy 1.18.0
+      INFO       Installed six 1.17.0
+      INFO       Installed stable-baselines3 2.9.0
+      INFO       Installed zmq 0.0.0
+      INFO     Installed 23 package(s)
+      INFO     Identifying available entrypoints
+      INFO     Environment uploaded successfully
+      INFO     Running validation checks for 'merge_env:MergeEnv'
+      ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      ┃ Check                         ┃ Result ┃ Details                                                                     ┃
+      ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+      │ Environment class path        │ PASS   │                                                                             │
+      │ Class exists in path          │ PASS   │                                                                             │
+      │ Preliminary environment       │ PASS   │                                                                             │
+      │ Action space                  │ PASS   │                                                                             │
+      │ Action space limits           │ PASS   │                                                                             │
+      │ Observation space             │ PASS   │                                                                             │
+      │ Observation space limits      │ PASS   │                                                                             │
+      │ Seed deprecation              │ PASS   │                                                                             │
+      │ Reset return info deprecation │ PASS   │                                                                             │
+      │ Reset return type             │ FAIL   │ dtype error in key faf_reached of observation: The observation dtype does   │
+      │                               │        │ not match the dtype defined in the observation space. Returned observation  │
+      │                               │        │ has dtype int64, expected float64.                                          │
+      │ Reset seed                    │ FAIL   │ dtype error in key faf_reached of observation: The observation dtype does   │
+      │                               │        │ not match the dtype defined in the observation space. Returned observation  │
+      │                               │        │ has dtype int64, expected float64.                                          │
+      │ Reset options                 │ PASS   │                                                                             │
+      │ Reset                         │ PASS   │                                                                             │
+      │ Step                          │ FAIL   │ The obs returned by the `step()` method was expecting observation numpy     │
+      │                               │        │ array dtype to be float64, actual type: int64                               │
+      │ Episode lifecycle             │ PASS   │                                                                             │
+      └───────────────────────────────┴────────┴─────────────────────────────────────────────────────────────────────────────┘
+      INFO     Validation checks did not pass. Please review the errors above and re-validate the environment.
+
+The failing checks all point to the same issue: the ``faf_reached`` key of the observation. The
+observation space declares it as ``float64``:
+
+.. code-block:: python
+
+   "faf_reached": spaces.Box(0, 1, shape=(1,), dtype=np.float64),
+
+but the environment builds that key with ``np.array([self.wpt_reach])``, and since
+``self.wpt_reach`` is an integer this returns an ``int64`` array. The fix is to declare the space
+with the same integer dtype the environment actually returns:
+
+.. code-block:: python
+
+   "faf_reached": spaces.Box(0, 1, shape=(1,), dtype=np.int64),
+
+Re-run the validation command with the corrected environment and all checks now pass (you will need to
+give it a new version v2).
 
 After validation succeeds, the environment is automatically profiled to determine its
 resource usage. You will be able to view it in the **Environments** section of the Arena
@@ -192,8 +283,7 @@ Before submitting a training job, we need to create a project to submit it to (i
 Submit a Training Job
 ~~~~~~~~~~~~~~~~~~~~~
 
-With the environment validated, we can now submit a training job for it. For this example, we will
-train a ``PPO`` agent on this task. We define the training configuration in a YAML manifest
+For this example, we will train a ``PPO`` agent on this task. We define the training configuration in a YAML manifest
 (``merge_ppo.yaml``). Note how in the ``environment`` section we reference the validated environment by its
 name as seen on Arena. If no version is specified, the latest one is used.
 
@@ -321,8 +411,8 @@ Interact with the Deployed Agent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After deployment, open the agent by name and send it observations to receive actions. The
-deployment name matches the experiment you deployed; you can also list your deployments with
-``arena agent list``.
+deployment name matches the experiment you deployed by default. You can list available deployments
+with ``arena agent list``.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.0.dev2"
+version = "2.8.0"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ llm = [
     "vllm>=0.23; sys_platform == 'linux'",
 ]
 arena = [
-    "agilerl-arena==0.1.0.dev0",
+    "agilerl-arena==0.1.0",
 ]
 all = [
     "swig>=4.4.1; sys_platform != 'win32'",
@@ -70,7 +70,7 @@ all = [
     "peft==0.19.1",
     "transformers==5.11.0",
     "vllm>=0.23; sys_platform == 'linux'",
-    "agilerl-arena==0.1.0.dev0",
+    "agilerl-arena==0.1.0",
 ]
 
 [dependency-groups]

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -738,8 +738,41 @@ class TestArenaTrainerTrain:
         result = trainer.train()
 
         mock_get_validated.assert_called_once()
-        mock_client.submit_experiment.assert_called_once_with(validated)
+        mock_client.submit_experiment.assert_called_once_with(
+            validated,
+            resource_id=None,
+            num_nodes=None,
+            project=None,
+            experiment_name=None,
+            reward_file=None,
+            completion=None,
+        )
         assert result["job_id"] == "test-123"
+
+    def test_train_forwards_submit_kwargs(self, mock_client, ppo_spec, training_spec):
+        env_spec = ArenaEnvSpec(name="CartPole-v1")
+        trainer = ArenaTrainer(
+            algorithm=ppo_spec,
+            environment=env_spec,
+            training=training_spec,
+            client=mock_client,
+        )
+        trainer.train(
+            resource_id="arena-medium",
+            num_nodes=2,
+            project="GSM8K Tutorial",
+            experiment_name="gsm8k-grpo",
+            reward_file="reward.py",
+            completion="#### 42",
+        )
+
+        kwargs = mock_client.submit_experiment.call_args.kwargs
+        assert kwargs["resource_id"] == "arena-medium"
+        assert kwargs["num_nodes"] == 2
+        assert kwargs["project"] == "GSM8K Tutorial"
+        assert kwargs["experiment_name"] == "gsm8k-grpo"
+        assert kwargs["reward_file"] == "reward.py"
+        assert kwargs["completion"] == "#### 42"
 
     def test_train_submits_manifest(self, mock_client, ppo_spec, training_spec):
         env_spec = ArenaEnvSpec(name="CartPole-v1")

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.0.dev2"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ docs = [
 
 [[package]]
 name = "agilerl-arena"
-version = "0.1.0.dev1"
+version = "0.1.0"
 source = { editable = "agilerl-arena" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
  Docs and bug fixes for the Arena client, plus a new LLM fine-tuning tutorial.

  ## New GRPO on GSM8K tutorial (docs/tutorials/arena_training/grpo_gsm8k.rst)
  - End-to-end LLM counterpart to the PPO custom-env tutorial: register the GSM8K dataset from Hugging Face, write a reward function, fine-tune Qwen2.5-0.5B-Instruct with GRPO + LoRA, monitor, deploy, and
  run inference, with Python/CLI tabs throughout.
  - Ships two example assets: docs/_static/examples/gsm8k_grpo.yaml (GRPO manifest) and docs/_static/examples/gsm8k-grpo/reward.py (correctness + format reward).

 ## Manifest payload fix (agilerl-arena)
  - Reasoning job submissions emitted algorithm.lora_config and algorithm.max_output_tokens, which the platform rejects with Ignoring unrecognized manifest field(s). The client no longer copies
  network.lora_config onto the algorithm spec (its home is the network section, which the platform reads), and max_output_tokens is excluded from serialization on the GRPO/LLMPPO/LLMREINFORCE specs.
  pretrained_model_name_or_path and max_model_len still surface under algorithm as the platform expects.

 ## CLI UX fixes
  - arena agent generate now streams tokens to the terminal as they are generated instead of buffering the full completion into a table.
  - arena experiments metrics preview pivots wide CSVs (one row per metric, one column per record) so many-metric runs stay readable; default --preview-rows lowered from 10 to 5.
  - deploy_agent log message corrected from "deployed successfully" to "submitted for deployment" with a pointer to check status in Arena, matching the actual async semantics.

##  PPO tutorial improvements
  - Added the full validation transcript showing the shipped environment failing dtype checks, and the fail-then-fix narrative for the faf_reached observation (merge_env.py example now ships the pre-fix
  float64 declaration to match). Long transcripts are capped and scrollable via new scrollable-output CSS.
  - merge_ppo.yaml training values updated (max_steps 10M, evo_steps 160k, eval_steps 500).