### PR TITLE
fix: resolve code-quality findings from PR #578

### DIFF
--- a/agilerl-arena/tests/test_cli.py
+++ b/agilerl-arena/tests/test_cli.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from click.testing import CliRunner
+
 from agilerl.arena.cli import (
     _redact_agent_rows_for_display,
     arena_client,
@@ -14,7 +16,6 @@ from agilerl.arena.cli import (
 )
 from agilerl.arena.config import CommandConfig, build_client
 from agilerl.arena.exceptions import ArenaAPIError
-from click.testing import CliRunner
 
 
 @pytest.fixture
@@ -188,11 +189,13 @@ class TestArenaClientContextManager:
             request_timeout=30,
             upload_timeout=300,
         )
+        mock_client.get_current_user.side_effect = ArenaAPIError(
+            "boom", status_code=500
+        )
         with patch("agilerl.arena.config.build_client", return_value=mock_client):
             with patch("agilerl.arena.config.handle_error") as mock_handle:
-                with arena_client(cfg):
-                    msg = "boom"
-                    raise ArenaAPIError(msg, status_code=500)
+                with arena_client(cfg) as client:
+                    client.get_current_user()
                 mock_handle.assert_called_once()
         mock_client.close.assert_called_once()
 

--- a/agilerl-arena/tests/test_cli.py
+++ b/agilerl-arena/tests/test_cli.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-from click.testing import CliRunner
-
 from agilerl.arena.cli import (
     _redact_agent_rows_for_display,
     arena_client,
@@ -16,6 +14,7 @@ from agilerl.arena.cli import (
 )
 from agilerl.arena.config import CommandConfig, build_client
 from agilerl.arena.exceptions import ArenaAPIError
+from click.testing import CliRunner
 
 
 @pytest.fixture

--- a/agilerl/metrics.py
+++ b/agilerl/metrics.py
@@ -289,6 +289,18 @@ class MultiAgentMetrics(BaseMetrics):
         self.agent_ids: list[str] = list(agent_ids)
         self.scores: list[float] | list[list[float]] = []
 
+    def __eq__(self, other: object) -> bool:
+        """Compare metrics by tracked state, including sub-agent identifiers.
+
+        :param other: Other metrics to compare.
+        :type other: object
+        :returns: True if the metrics are equal, False otherwise.
+        :rtype: bool
+        """
+        if not isinstance(other, MultiAgentMetrics):
+            return NotImplemented
+        return self.agent_ids == other.agent_ids and super().__eq__(other)
+
     def _init_metric(self, name: str) -> None:
         """Initialize storage for a newly registered metric.
 

--- a/agilerl/models/algo.py
+++ b/agilerl/models/algo.py
@@ -370,9 +370,9 @@ class RLAlgorithmSpec(AlgorithmSpec):
 
     def build_algorithm(
         self,
-        observation_space: SupportedObservationSpace,
-        action_space: SupportedActionSpace,
-        index: int,
+        observation_space: SupportedObservationSpace | None = None,
+        action_space: SupportedActionSpace | None = None,
+        index: int | None = None,
         resume_from_checkpoint: str | None = None,
         device: str | torch.device = "cpu",
         accelerator: Accelerator | None = None,
@@ -380,11 +380,11 @@ class RLAlgorithmSpec(AlgorithmSpec):
         """Build a single-agent algorithm instance from spec fields.
 
         :param observation_space: Observation space.
-        :type observation_space: SupportedObservationSpace
+        :type observation_space: SupportedObservationSpace | None
         :param action_space: Action space.
-        :type action_space: SupportedActionSpace
+        :type action_space: SupportedActionSpace | None
         :param index: Index of the algorithm in the population.
-        :type index: int
+        :type index: int | None
         :param resume_from_checkpoint: Path to resume from checkpoint.
         :type resume_from_checkpoint: str | None
         :param device: Torch device. Defaults to "cpu".
@@ -393,7 +393,14 @@ class RLAlgorithmSpec(AlgorithmSpec):
         :type accelerator: Accelerator | None
         :returns: Single-agent algorithm instance.
         :rtype: RLAlgorithm
+        :raises ValueError: If observation_space, action_space, or index is None.
         """
+        if observation_space is None or action_space is None or index is None:
+            msg = (
+                "RLAlgorithmSpec.build_algorithm requires observation_space, "
+                "action_space, and index."
+            )
+            raise ValueError(msg)
         algo_cls = self.algo_class()
         algo = algo_cls(
             observation_space=observation_space,
@@ -425,9 +432,9 @@ class MultiAgentRLAlgorithmSpec(AlgorithmSpec):
 
     def build_algorithm(
         self,
-        observation_spaces: dict[str, SupportedObservationSpace],
-        action_spaces: dict[str, SupportedActionSpace],
-        index: int,
+        observation_spaces: dict[str, SupportedObservationSpace] | None = None,
+        action_spaces: dict[str, SupportedActionSpace] | None = None,
+        index: int | None = None,
         resume_from_checkpoint: str | None = None,
         device: str | torch.device = "cpu",
         accelerator: Accelerator | None = None,
@@ -435,11 +442,11 @@ class MultiAgentRLAlgorithmSpec(AlgorithmSpec):
         """Build a multi-agent algorithm from spec fields.
 
         :param observation_spaces: Per-agent observation spaces.
-        :type observation_spaces: dict[str, SupportedObservationSpace]
+        :type observation_spaces: dict[str, SupportedObservationSpace] | None
         :param action_spaces: Per-agent action spaces.
-        :type action_spaces: dict[str, SupportedActionSpace]
+        :type action_spaces: dict[str, SupportedActionSpace] | None
         :param index: Index of the algorithm in the population.
-        :type index: int
+        :type index: int | None
         :param resume_from_checkpoint: Path to resume from checkpoint.
         :type resume_from_checkpoint: str | None
         :param device: Torch device. Defaults to "cpu".
@@ -448,7 +455,14 @@ class MultiAgentRLAlgorithmSpec(AlgorithmSpec):
         :type accelerator: Accelerator | None
         :returns: Multi-agent algorithm instance.
         :rtype: MultiAgentRLAlgorithm
+        :raises ValueError: If observation_spaces, action_spaces, or index is None.
         """
+        if observation_spaces is None or action_spaces is None or index is None:
+            msg = (
+                "MultiAgentRLAlgorithmSpec.build_algorithm requires "
+                "observation_spaces, action_spaces, and index."
+            )
+            raise ValueError(msg)
         algo_cls = self.algo_class()
         algo = algo_cls(
             observation_spaces=observation_spaces,
@@ -507,7 +521,7 @@ class LLMAlgorithmSpec(AlgorithmSpec):
 
     def build_algorithm(
         self,
-        tokenizer: Any,
+        tokenizer: Any | None = None,
         index: int = 0,
         resume_from_checkpoint: str | None = None,
         accelerator: Accelerator | None = None,
@@ -517,7 +531,7 @@ class LLMAlgorithmSpec(AlgorithmSpec):
         """Build an LLM algorithm instance from spec fields.
 
         :param tokenizer: A HuggingFace ``AutoTokenizer`` instance.
-        :type tokenizer: Any
+        :type tokenizer: Any | None
         :param index: Index of the algorithm in the population.
         :type index: int
         :param resume_from_checkpoint: Path to resume from checkpoint.
@@ -532,7 +546,12 @@ class LLMAlgorithmSpec(AlgorithmSpec):
         :type actor_network: Any | None
         :returns: LLM algorithm instance.
         :rtype: LLMAlgorithm
+        :raises ValueError: If tokenizer is None.
         """
+        if tokenizer is None:
+            msg = "LLMAlgorithmSpec.build_algorithm requires a tokenizer."
+            raise ValueError(msg)
+
         micro_batch_size_per_gpu = None
         if accelerator is not None:
             micro_batch_size_per_gpu = max(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -262,6 +262,23 @@ class TestBaseMetricsEquality:
         assert a == b
 
 
+class TestMultiAgentMetricsEquality:
+    def test_equal_same_agent_ids(self):
+        a = MultiAgentMetrics(["a", "b"])
+        b = MultiAgentMetrics(["a", "b"])
+        assert a == b
+
+    def test_not_equal_different_agent_ids(self):
+        a = MultiAgentMetrics(["a", "b"])
+        b = MultiAgentMetrics(["a", "c"])
+        assert a != b
+
+    def test_not_equal_different_type(self):
+        a = MultiAgentMetrics(["a", "b"])
+        assert a.__eq__("not_metrics") is NotImplemented
+        assert a.__eq__(AgentMetrics()) is NotImplemented
+
+
 class TestBaseMetricsRegisterGuard:
     def test_duplicate_scalar_raises(self):
         m = AgentMetrics()

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -1014,9 +1014,8 @@ class TestManifestFromTrainerSpecsForeignModels:
     """Foreign BaseModel inputs are dumped before manifest validation."""
 
     def test_from_trainer_specs_coerces_foreign_training_model(self):
-        from pydantic import BaseModel
-
         from agilerl.arena.models.env import EnvSpec as ArenaEnvSpec
+        from pydantic import BaseModel
 
         class ForeignTraining(BaseModel):
             max_steps: int = 300
@@ -1032,6 +1031,7 @@ class TestManifestFromTrainerSpecsForeignModels:
 
     def test_resolve_foreign_arena_algorithm(self):
         from agilerl.arena.models.algorithms.ppo import PPOSpec as ArenaPPOSpec
+
         from agilerl.models.manifest import _resolve_algorithm
 
         resolved = _resolve_algorithm(ArenaPPOSpec(learn_step=48))

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -721,6 +721,31 @@ class TestAlgoSpecClassVars:
         mock_algo.load_checkpoint.assert_called_once_with("/some/path")
 
 
+class TestBuildAlgorithmMissingArgsRaise:
+    """build_algorithm overrides reject missing required inputs."""
+
+    def test_rl_spec_requires_spaces_and_index(self):
+        from agilerl.models.algo import RLAlgorithmSpec
+
+        spec = RLAlgorithmSpec(learn_step=1)
+        with pytest.raises(ValueError, match="observation_space"):
+            spec.build_algorithm()
+
+    def test_multi_agent_spec_requires_spaces_and_index(self):
+        from agilerl.models.algo import MultiAgentRLAlgorithmSpec
+
+        spec = MultiAgentRLAlgorithmSpec()
+        with pytest.raises(ValueError, match="observation_spaces"):
+            spec.build_algorithm()
+
+    def test_llm_spec_requires_tokenizer(self):
+        from agilerl.models.algo import LLMAlgorithmSpec
+
+        spec = LLMAlgorithmSpec.__new__(LLMAlgorithmSpec)
+        with pytest.raises(ValueError, match="requires a tokenizer"):
+            spec.build_algorithm()
+
+
 class TestBuildAlgorithmForwardsOnlySetFields:
     """Unset spec fields must fall through to the algorithm's own defaults."""
 
@@ -989,8 +1014,9 @@ class TestManifestFromTrainerSpecsForeignModels:
     """Foreign BaseModel inputs are dumped before manifest validation."""
 
     def test_from_trainer_specs_coerces_foreign_training_model(self):
-        from agilerl.arena.models.env import EnvSpec as ArenaEnvSpec
         from pydantic import BaseModel
+
+        from agilerl.arena.models.env import EnvSpec as ArenaEnvSpec
 
         class ForeignTraining(BaseModel):
             max_steps: int = 300
@@ -1006,7 +1032,6 @@ class TestManifestFromTrainerSpecsForeignModels:
 
     def test_resolve_foreign_arena_algorithm(self):
         from agilerl.arena.models.algorithms.ppo import PPOSpec as ArenaPPOSpec
-
         from agilerl.models.manifest import _resolve_algorithm
 
         resolved = _resolve_algorithm(ArenaPPOSpec(learn_step=48))


### PR DESCRIPTION
- test_cli: remove unreachable code in test_handles_arena_error by triggering the ArenaAPIError via a mocked client call instead of a bare raise (handle_error is mocked, so the error is swallowed and pytest.raises would not fire)
- metrics: override __eq__ in MultiAgentMetrics so agent_ids is included in equality comparisons
- models/algo: give build_algorithm overrides (RL, MultiAgent, LLM) defaulted params with explicit ValueError guards to fix override signature mismatch with AlgorithmSpec.build_algorithm