### PR TITLE
ci: run test matrix on uv.lock changes

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -10,6 +10,7 @@ on:
             - tests/**
             - .github/workflows/**
             - pyproject.toml
+            - uv.lock
     pull_request:
         paths:
             - agilerl/**
@@ -17,6 +18,7 @@ on:
             - tests/**
             - .github/workflows/**
             - pyproject.toml
+            - uv.lock
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -10,6 +10,7 @@ on:
             - tests/**
             - .github/workflows/**
             - pyproject.toml
+            - uv.lock
     pull_request:
         branches: [main, nightly]
         paths:
@@ -18,6 +19,7 @@ on:
             - tests/**
             - .github/workflows/**
             - pyproject.toml
+            - uv.lock
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -10,6 +10,7 @@ on:
             - tests/**
             - .github/workflows/**
             - pyproject.toml
+            - uv.lock
     pull_request:
         branches: [main, nightly]
         paths:
@@ -18,6 +19,7 @@ on:
             - tests/**
             - .github/workflows/**
             - pyproject.toml
+            - uv.lock
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
## What

Add `uv.lock` to the `paths:` filter (both `push` and `pull_request` triggers) of the Linux, macOS, and Windows test workflows. Branch filters are left untouched.

## Why

The test workflows currently filter on `paths:` that include `pyproject.toml` but **not** `uv.lock`:

```yaml
paths:
    - agilerl/**
    - agilerl-arena/**
    - tests/**
    - .github/workflows/**
    - pyproject.toml
```

A dependency bump that stays within an existing version constraint changes **only `uv.lock`** — `pyproject.toml` is untouched. This is exactly the shape of Dependabot's weekly `uv` updates (e.g. #567, #566, #550, #538, which each touch only `uv.lock`). Because `uv.lock` isn't in the filter, the full test matrix **never runs** against the newly resolved versions — not on the PR, and not on the post-merge `push` to `nightly` either (the `push` trigger has the same filter). The green ticks on those PRs are only CodeQL / pre-commit / docs; the suite that would catch a runtime break doesn't execute.

This closes the gap so lockfile-only changes are exercised by the suite. Verified locally that all three workflows still parse and that `uv.lock` is present in both the `push` and `pull_request` path lists.

