### PR TITLE
refactor(llm): compute fused LoRA routing with sliced views, drop PEFT-hook path (fixes #584)

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -133,9 +133,9 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
     from safetensors.torch import load_file
 
     from agilerl.algorithms.core.llm_ops.fused_lora import (
-        clear_fused_adapter_routing,
         patch_lora_for_fused_forward,
         set_fused_adapter_routing,
+        unset_fused_adapter_routing,
     )
     from agilerl.algorithms.core.llm_ops.vllm_colocate import (
         patch_vllm_lora_keep_resident,
@@ -4253,7 +4253,7 @@ class LLMAlgorithm(EvolvableAlgorithm, ABC):
            The routing is **not** cleared here — it must remain active until
            after ``backward()`` completes (for gradient checkpoint
            recomputation).  Callers must call
-           ``clear_fused_adapter_routing`` after the backward pass.
+           ``unset_fused_adapter_routing`` after the backward pass.
 
            Callers are responsible for ensuring the model is in training
            mode and adapter trainability is restored before entering the
@@ -4431,7 +4431,7 @@ class LLMAlgorithm(EvolvableAlgorithm, ABC):
                 routing,
                 batch_size=batch_size,
             )
-            clear_fused_adapter_routing(self._get_unwrapped_actor())
+            unset_fused_adapter_routing(self._get_unwrapped_actor())
             ref_logprobs = log_probs[:B]
             actor_logprobs = log_probs[B : 2 * B]
             critic_values = values[2 * B :] if self.use_value_head else None

--- a/agilerl/algorithms/core/llm_ops/__init__.py
+++ b/agilerl/algorithms/core/llm_ops/__init__.py
@@ -10,10 +10,10 @@ fires.
 
 from agilerl import HAS_LIGER_KERNEL
 from agilerl.algorithms.core.llm_ops.fused_lora import (
-    clear_fused_adapter_routing,
     patch_lora_for_fused_forward,
     set_fused_adapter_routing,
     unpatch_lora_for_fused_forward,
+    unset_fused_adapter_routing,
 )
 from agilerl.algorithms.core.llm_ops.vllm_colocate import (
     get_vllm_internal_model,
@@ -38,7 +38,6 @@ __all__ = [
     "LigerDPOWithAlpha",
     "LigerFusedLinearPolicyLossFunction",
     "apply_fused_policy_loss",
-    "clear_fused_adapter_routing",
     "get_vllm_internal_model",
     "llm_policy_loss_fn",
     "patch_lora_for_fused_forward",
@@ -46,4 +45,5 @@ __all__ = [
     "patch_vllm_strip_multimodal_towers",
     "set_fused_adapter_routing",
     "unpatch_lora_for_fused_forward",
+    "unset_fused_adapter_routing",
 ]

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -38,25 +38,49 @@ except ImportError:  # pragma: no cover
     LoraLayer = None  # type: ignore[assignment, misc]
 
 
+def _align_routing_to_leading_dim(routing: Sequence[str], args: tuple) -> Sequence[str]:
+    """Repeat each per-row adapter name to match the input's leading dim.
+
+    Models that flatten ``(batch, seq, hidden)`` to ``(batch * seq, hidden)``
+    before a LoRA linear (OPT, Switch/NLLB-MoE) need one name per flattened row;
+    a no-op when the leading dim already equals the routing length.
+
+    :param routing: Adapter names, one per logical batch row.
+    :type routing: Sequence[str]
+    :param args: Positional forward args; ``args[0]`` is the input tensor.
+    :type args: tuple
+    :return: Routing expanded to the input's leading dim, or unchanged.
+    :rtype: Sequence[str]
+    """
+    if not args or not isinstance(args[0], torch.Tensor):
+        return routing
+    leading = args[0].shape[0]
+    n = len(routing)
+    if n == 0 or leading == n or leading % n != 0:
+        return routing
+    factor = leading // n
+    return [name for name in routing for _ in range(factor)]
+
+
 def _fused_routing_pre_hook(
     module: nn.Module,
     args: tuple,
     kwargs: dict,
 ) -> tuple[tuple, dict]:
-    """Forward pre-hook that injects ``adapter_names`` when fused routing is active.
+    """Inject leading-dim-aligned ``adapter_names`` when fused routing is active.
 
     :param module: The LoRA layer about to run ``forward``.
     :type module: nn.Module
-    :param args: Positional arguments passed to ``forward``.
+    :param args: Positional forward args; ``args[0]`` is the input tensor.
     :type args: tuple
-    :param kwargs: Keyword arguments passed to ``forward``.
+    :param kwargs: Keyword args passed to ``forward``.
     :type kwargs: dict
-    :return: ``args`` unchanged and ``kwargs`` possibly updated with ``adapter_names``.
+    :return: ``args`` unchanged and ``kwargs`` with ``adapter_names`` set when routing is active.
     :rtype: tuple[tuple, dict]
     """
     routing = getattr(module, "_fused_adapter_routing", None)
     if routing is not None:
-        kwargs["adapter_names"] = routing
+        kwargs["adapter_names"] = _align_routing_to_leading_dim(routing, args)
     return args, kwargs
 
 

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -206,7 +206,7 @@ def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
     """Route each row of the next forward's batch through its own adapter.
 
     Routing stays active — including for gradient-checkpoint recomputation
-    during ``backward()`` — until ``clear_fused_adapter_routing`` is called.
+    during ``backward()`` — until ``unset_fused_adapter_routing`` is called.
 
     :param model: The patched model whose LoRA layers should route rows.
     :param routing: Adapter name per batch row, e.g. ``["actor"] * B +
@@ -240,7 +240,7 @@ def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
         module._fused_adapter_routing = routing  # type: ignore[attr-defined]
 
 
-def clear_fused_adapter_routing(model: nn.Module) -> None:
+def unset_fused_adapter_routing(model: nn.Module) -> None:
     """Deactivate fused routing, restoring standard single-adapter forward.
 
     :param model: The model whose LoRA layers should clear fused routing.

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -27,39 +27,6 @@ try:
 except ImportError:  # pragma: no cover
     LoraLayer = None  # type: ignore[assignment, misc]
 
-# The batch is a stack of rows, and ``routing`` labels each row with an adapter
-# name. ``_contiguous_groups`` collapses consecutive same-name rows into one
-# ``(name, start, stop)`` run, where ``[start, stop)`` are the row indices that
-# adapter owns. Worked example — routing for a
-# 4-row batch::
-#
-#     routing   = ["actor", "actor", "critic", "critic"]
-#     row index =    0         1         2          3
-#
-# becomes two groups::
-#
-#     ("actor",  0, 2)   ->  rows 0, 1  (start=0, stop=2)
-#     ("critic", 2, 4)   ->  rows 2, 3  (start=2, stop=4)
-AdapterGroups = list[tuple[str, int, int]]
-
-
-def _contiguous_groups(routing: Sequence[str]) -> AdapterGroups:
-    """Compress a per-row adapter list into ``(name, start, stop)`` runs.
-
-    :param routing: Adapter name for each batch row.
-    :raises ValueError: If *routing* is empty.
-    """
-    groups: AdapterGroups = []
-    start = 0
-    for name, run in itertools.groupby(routing):
-        stop = start + sum(1 for _ in run)
-        groups.append((name, start, stop))
-        start = stop
-    if not groups:
-        msg = "Fused adapter routing must name at least one row."
-        raise ValueError(msg)
-    return groups
-
 
 def _lora_delta(layer: nn.Module, adapter: str, rows: torch.Tensor) -> torch.Tensor:
     """One adapter's low-rank delta for a slice of input rows."""
@@ -68,7 +35,7 @@ def _lora_delta(layer: nn.Module, adapter: str, rows: torch.Tensor) -> torch.Ten
     return layer.lora_B[adapter](lora_a(rows)) * layer.scaling[adapter]
 
 
-def _needs_peft_mixed_forward(layer: nn.Module, groups: AdapterGroups) -> bool:
+def _needs_peft_mixed_forward(layer: nn.Module, routing: Sequence[str]) -> bool:
     """Whether any routed adapter needs PEFT's own mixed-batch forward.
 
     The sliced path computes the standard linear delta; embedding adapters
@@ -77,32 +44,7 @@ def _needs_peft_mixed_forward(layer: nn.Module, groups: AdapterGroups) -> bool:
     """
     embedding = getattr(layer, "lora_embedding_A", None) or {}
     variants = getattr(layer, "lora_variant", None) or {}
-    return any(name in embedding or name in variants for name, _, _ in groups)
-
-
-def _groups_for_leading_dim(groups: AdapterGroups, n_rows: int) -> AdapterGroups:
-    """Rescale routing groups to a layer input with *n_rows* leading rows.
-
-    Some layers flatten ``(batch, seq, hidden)`` to ``(batch * seq, hidden)``
-    before their linears (OPT's MLP, MoE experts). The flatten is row-major,
-    so sample ``i`` becomes the contiguous run ``[i * seq, (i + 1) * seq)``
-    and the groups scale by ``seq``. No-op when the leading dim already
-    matches the routed batch.
-
-    :raises ValueError: If *n_rows* is not a whole multiple of the routed
-        batch — the routing cannot be lined up with this input.
-    """
-    n_samples = groups[-1][2]
-    if n_rows == n_samples:
-        return groups
-    if n_rows % n_samples != 0:
-        msg = (
-            f"Fused adapter routing covers {n_samples} rows but the input's "
-            f"leading dimension is {n_rows}."
-        )
-        raise ValueError(msg)
-    factor = n_rows // n_samples
-    return [(name, start * factor, stop * factor) for name, start, stop in groups]
+    return any(name in embedding or name in variants for name in set(routing))
 
 
 def _routed_forward(
@@ -113,40 +55,48 @@ def _routed_forward(
 ) -> torch.Tensor:
     """Replacement ``forward`` installed on patched LoRA layers.
 
-    Runs the layer's ordinary single-adapter forward until routing is set.
-    Adapters that do not wrap this layer leave their rows on the base output,
-    matching PEFT's mixed-batch behaviour.
+    ``routing`` names the adapter for each batch row (e.g. ``["actor"] * B +
+    ["critic"] * B``). Same-adapter rows are contiguous, so we run the base
+    layer once and add each adapter's delta to its slice — walking the
+    contiguous runs with :func:`itertools.groupby`. ``"__base__"`` and
+    adapters that don't wrap this layer leave their rows on the base output,
+    matching PEFT's mixed-batch behaviour. Falls back to the layer's ordinary
+    forward while routing is unset.
     """
-    groups = layer._fused_adapter_groups
-    if groups is None:
+    routing = layer._fused_adapter_routing
+    if routing is None:
         return type(layer).forward(layer, x, *forward_args, **forward_kwargs)
 
-    groups = _groups_for_leading_dim(groups, x.shape[0])
+    # Layers that flatten (batch, seq, hidden) -> (batch * seq, hidden) before
+    # their linears (OPT's MLP, MoE experts) show seq rows per routed sample.
+    # The flatten is row-major, so each run just covers ``factor`` times as
+    # many contiguous rows.
+    factor, remainder = divmod(x.shape[0], len(routing))
+    if remainder:
+        msg = (
+            f"Fused adapter routing covers {len(routing)} rows but the layer "
+            f"input's leading dimension is {x.shape[0]}."
+        )
+        raise ValueError(msg)
 
-    if _needs_peft_mixed_forward(layer, groups):
-        adapter_names = [
-            name for name, start, stop in groups for _ in range(stop - start)
-        ]
+    if _needs_peft_mixed_forward(layer, routing):
+        names = [name for name in routing for _ in range(factor)]
         return layer._mixed_batch_forward(
-            x, *forward_args, adapter_names=adapter_names, **forward_kwargs
+            x, *forward_args, adapter_names=names, **forward_kwargs
         )
 
     base_out = layer.base_layer(x, *forward_args, **forward_kwargs)
 
-    if len(groups) == 1:
-        name = groups[0][0]
-        if name == "__base__" or name not in layer.lora_A:
-            return base_out
-        return base_out + _lora_delta(layer, name, x).to(base_out.dtype)
-
     pieces = []
-    for name, start, stop in groups:
-        rows = base_out.narrow(0, start, stop - start)
+    start = 0
+    for name, run in itertools.groupby(routing):
+        n = sum(1 for _ in run) * factor
+        rows = base_out.narrow(0, start, n)
         if name != "__base__" and name in layer.lora_A:
-            delta = _lora_delta(layer, name, x.narrow(0, start, stop - start))
-            rows = rows + delta.to(rows.dtype)
+            rows = rows + _lora_delta(layer, name, x.narrow(0, start, n)).to(rows.dtype)
         pieces.append(rows)
-    return torch.cat(pieces)
+        start += n
+    return pieces[0] if len(pieces) == 1 else torch.cat(pieces)
 
 
 def _store_layer_cache(model: nn.Module, layers: list[nn.Module]) -> None:
@@ -157,7 +107,11 @@ def _store_layer_cache(model: nn.Module, layers: list[nn.Module]) -> None:
 
 
 def _get_cached_lora_layers(model: nn.Module) -> list[nn.Module]:
-    """All ``LoraLayer`` modules under *model*, cached after the first traversal."""
+    """All ``LoraLayer`` modules under *model*, cached after the first traversal.
+
+    :param model: A ``PeftModel`` or any module containing ``LoraLayer`` s.
+    :return: The LoRA layers under *model*.
+    """
     cached = getattr(model, "_fused_lora_layers", None)
     if cached is not None:
         return cached
@@ -170,90 +124,16 @@ def _get_cached_lora_layers(model: nn.Module) -> list[nn.Module]:
     return layers
 
 
-def patch_lora_for_fused_forward(model: nn.Module) -> None:
-    """Swap every LoRA layer's ``forward`` for the fused-routing forward.
-
-    Routing starts inactive, so the patched layers behave exactly as before
-    until ``set_fused_adapter_routing`` is called. Idempotent — call again
-    after adding adapters that wrap new modules; only the new layers are
-    patched and the cached layer list is refreshed either way.
-
-    :param model: A ``PeftModel`` or any module containing ``LoraLayer`` s.
-    """
-    if LoraLayer is None:
-        return
-    layers: list[nn.Module] = []
-    for module in nn.Module.modules(model):
-        if not isinstance(module, LoraLayer):
-            continue
-        layers.append(module)
-        if not hasattr(module, "_fused_adapter_groups"):
-            module._fused_adapter_groups = None  # type: ignore[attr-defined]
-            module.forward = partial(_routed_forward, module)  # type: ignore[method-assign]
-    _store_layer_cache(model, layers)
-
-
-def unpatch_lora_for_fused_forward(model: nn.Module) -> None:
-    """Restore every LoRA layer's original ``forward`` and drop routing state.
-
-    After this, ``set_fused_adapter_routing`` raises until the model is
-    patched again.
-
-    :param model: The model to release from fused-routing control.
-    """
-    for module in _get_cached_lora_layers(model):
-        if hasattr(module, "_fused_adapter_groups"):
-            del module._fused_adapter_groups
-            del module.forward
-    if hasattr(model, "_fused_lora_layers"):
-        del model._fused_lora_layers
-
-
-def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
-    """Route each row of the next forward's batch through its own adapter.
-
-    Routing stays active — including for gradient-checkpoint recomputation
-    during ``backward()`` — until ``clear_fused_adapter_routing`` is called.
-
-    :param model: The patched model whose LoRA layers should route rows.
-    :param routing: Adapter name per batch row, e.g. ``["actor"] * B +
-        ["critic"] * B``. ``"__base__"`` runs a row through the frozen base
-        weights with no delta.
-    :raises RuntimeError: If LoRA layers are unpatched (the routing would be
-        silently ignored) or have adapters merged into the base weights.
-    :raises ValueError: If *routing* is empty, names an unknown adapter, or
-        names a DoRA adapter (unsupported, as in PEFT's mixed-batch forward).
-    """
-    layers = _get_cached_lora_layers(model)
-    if not layers:
-        # Plain base model (no adapters) or PEFT not installed: nothing to
-        # route, and the unfused forward is already correct.
-        return
-    if any(not hasattr(m, "_fused_adapter_groups") for m in layers):
-        msg = (
-            "set_fused_adapter_routing called on a model with LoRA layers that "
-            "have no fused-routing forward; the routing would be silently "
-            "ignored. Call patch_lora_for_fused_forward(model) first (again, "
-            "if adapters were added after the last call)."
-        )
-        raise RuntimeError(msg)
-
-    groups = _contiguous_groups(routing)
-    _validate_routing(layers, groups)
-    for module in layers:
-        module._fused_adapter_groups = groups  # type: ignore[attr-defined]
-
-
-def _validate_routing(layers: list[nn.Module], groups: AdapterGroups) -> None:
+def _validate_routing(layers: list[nn.Module], routing: Sequence[str]) -> None:
     """Reject routings PEFT would compute silently wrongly (unknown names)
     or that the fused forward cannot compute (merged weights, DoRA).
 
     :param layers: All LoRA layers under the model.
-    :param groups: Contiguous runs of adapter names in the routing.
+    :param routing: Adapter name per batch row.
     :raises RuntimeError: If any layer has merged adapters.
     :raises ValueError: If any adapter name is unknown or a DoRA adapter.
     """
-    requested = {name for name, _, _ in groups if name != "__base__"}
+    requested = set(routing) - {"__base__"}
     available: set[str] = set()
     for module in layers:
         if getattr(module, "merged", False):
@@ -283,11 +163,88 @@ def _validate_routing(layers: list[nn.Module], groups: AdapterGroups) -> None:
         raise ValueError(msg)
 
 
+def patch_lora_for_fused_forward(model: nn.Module) -> None:
+    """Swap every LoRA layer's ``forward`` for the fused-routing forward.
+
+    Routing starts inactive, so the patched layers behave exactly as before
+    until ``set_fused_adapter_routing`` is called. Idempotent — call again
+    after adding adapters that wrap new modules; only the new layers are
+    patched and the cached layer list is refreshed either way.
+
+    :param model: A ``PeftModel`` or any module containing ``LoraLayer`` s.
+    """
+    if LoraLayer is None:
+        return
+    layers: list[nn.Module] = []
+    for module in nn.Module.modules(model):
+        if not isinstance(module, LoraLayer):
+            continue
+        layers.append(module)
+        if not hasattr(module, "_fused_adapter_routing"):
+            module._fused_adapter_routing = None  # type: ignore[attr-defined]
+            module.forward = partial(_routed_forward, module)  # type: ignore[method-assign]
+    _store_layer_cache(model, layers)
+
+
+def unpatch_lora_for_fused_forward(model: nn.Module) -> None:
+    """Restore every LoRA layer's original ``forward`` and drop routing state.
+
+    After this, ``set_fused_adapter_routing`` raises until the model is
+    patched again.
+
+    :param model: The model to release from fused-routing control.
+    """
+    for module in _get_cached_lora_layers(model):
+        if hasattr(module, "_fused_adapter_routing"):
+            del module._fused_adapter_routing
+            del module.forward
+    if hasattr(model, "_fused_lora_layers"):
+        del model._fused_lora_layers
+
+
+def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
+    """Route each row of the next forward's batch through its own adapter.
+
+    Routing stays active — including for gradient-checkpoint recomputation
+    during ``backward()`` — until ``clear_fused_adapter_routing`` is called.
+
+    :param model: The patched model whose LoRA layers should route rows.
+    :param routing: Adapter name per batch row, e.g. ``["actor"] * B +
+        ["critic"] * B``. ``"__base__"`` runs a row through the frozen base
+        weights with no delta.
+    :raises RuntimeError: If LoRA layers are unpatched (the routing would be
+        silently ignored) or have adapters merged into the base weights.
+    :raises ValueError: If *routing* is empty, names an unknown adapter, or
+        names a DoRA adapter (unsupported, as in PEFT's mixed-batch forward).
+    """
+    layers = _get_cached_lora_layers(model)
+    if not layers:
+        # Plain base model (no adapters) or PEFT not installed: nothing to
+        # route, and the unfused forward is already correct.
+        return
+    if any(not hasattr(m, "_fused_adapter_routing") for m in layers):
+        msg = (
+            "set_fused_adapter_routing called on a model with LoRA layers that "
+            "have no fused-routing forward; the routing would be silently "
+            "ignored. Call patch_lora_for_fused_forward(model) first (again, "
+            "if adapters were added after the last call)."
+        )
+        raise RuntimeError(msg)
+
+    routing = list(routing)
+    if not routing:
+        msg = "Fused adapter routing must name at least one row."
+        raise ValueError(msg)
+    _validate_routing(layers, routing)
+    for module in layers:
+        module._fused_adapter_routing = routing  # type: ignore[attr-defined]
+
+
 def clear_fused_adapter_routing(model: nn.Module) -> None:
     """Deactivate fused routing, restoring standard single-adapter forward.
 
     :param model: The model whose LoRA layers should clear fused routing.
     """
     for module in _get_cached_lora_layers(model):
-        if hasattr(module, "_fused_adapter_groups"):
-            module._fused_adapter_groups = None  # type: ignore[attr-defined]
+        if hasattr(module, "_fused_adapter_routing"):
+            module._fused_adapter_routing = None  # type: ignore[attr-defined]

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -1,33 +1,23 @@
 """Fused multi-adapter LoRA forward pass.
 
-Enables running multiple LoRA adapters (e.g. actor + critic) in a single
-forward pass by partitioning the batch dimension.  Each adapter's LoRA
-weights are applied only to its assigned batch rows, while the frozen base
-weights are computed once for the entire batch.
+Runs several LoRA adapters (e.g. actor + critic) in one forward pass by
+routing each batch row to an adapter: the frozen base layer runs once over
+the full batch and each adapter's low-rank delta is added to its rows only.
+This removes adapter switching from ``learn()``, which would otherwise
+desynchronise gradient-checkpoint recomputation.
 
-This eliminates adapter switching during training and resolves the
-gradient-checkpointing / DeepSpeed incompatibility that arises when
-different adapters must be active for different parts of the computation
-graph.
-
-The mechanism piggy-backs on PEFT's existing ``_mixed_batch_forward``
-(which handles the per-row LoRA routing) but bypasses the inference-only
-gate and uses persistent per-layer attributes instead of ephemeral hooks
-so that routing survives gradient-checkpoint recomputation.
-
-.. note::
-    LoRA layer references are cached on the model during
-    ``patch_lora_for_fused_forward`` and reused by ``set_`` / ``clear_``
-    to avoid repeated ``nn.Module.modules()`` traversals (which are
-    expensive when called dozens of times per ``learn()``).
-    We use ``nn.Module.modules()`` rather than ``model.modules()``
-    because ``EvolvableModule`` overrides ``modules()`` to return only
-    evolvable children, which excludes the LoRA layers.
+Rows routed to the same adapter form contiguous runs, so each adapter's
+rows are sliced with ``narrow`` and its delta added out of place. Adding out
+of place (rather than accumulating into the base output) is what lets this
+work unchanged on a quantized (bitsandbytes) base, whose forward returns a
+view of a custom autograd Function that autograd forbids editing in place.
 """
 
 from __future__ import annotations
 
+import itertools
 from collections.abc import Sequence
+from functools import partial
 
 import torch
 import torch.nn as nn
@@ -37,119 +27,158 @@ try:
 except ImportError:  # pragma: no cover
     LoraLayer = None  # type: ignore[assignment, misc]
 
+# The batch is a stack of rows, and ``routing`` labels each row with an adapter
+# name. ``_contiguous_groups`` collapses consecutive same-name rows into one
+# ``(name, start, stop)`` run, where ``[start, stop)`` are the row indices that
+# adapter owns. Worked example — routing for a
+# 4-row batch::
+#
+#     routing   = ["actor", "actor", "critic", "critic"]
+#     row index =    0         1         2          3
+#
+# becomes two groups::
+#
+#     ("actor",  0, 2)   ->  rows 0, 1  (start=0, stop=2)
+#     ("critic", 2, 4)   ->  rows 2, 3  (start=2, stop=4)
+AdapterGroups = list[tuple[str, int, int]]
 
-def _align_routing_to_leading_dim(routing: Sequence[str], args: tuple) -> Sequence[str]:
-    """Repeat each per-row adapter name to match the input's leading dim.
 
-    Models that flatten ``(batch, seq, hidden)`` to ``(batch * seq, hidden)``
-    before a LoRA linear (OPT, Switch/NLLB-MoE) need one name per flattened row;
-    a no-op when the leading dim already equals the routing length.
+def _contiguous_groups(routing: Sequence[str]) -> AdapterGroups:
+    """Compress a per-row adapter list into ``(name, start, stop)`` runs.
 
-    :param routing: Adapter names, one per logical batch row.
-    :type routing: Sequence[str]
-    :param args: Positional forward args; ``args[0]`` is the input tensor.
-    :type args: tuple
-    :return: Routing expanded to the input's leading dim, or unchanged.
-    :rtype: Sequence[str]
+    :param routing: Adapter name for each batch row.
+    :raises ValueError: If *routing* is empty.
     """
-    if not args or not isinstance(args[0], torch.Tensor):
-        return routing
-    leading = args[0].shape[0]
-    n = len(routing)
-    if n == 0 or leading == n or leading % n != 0:
-        return routing
-    factor = leading // n
-    return [name for name in routing for _ in range(factor)]
+    groups: AdapterGroups = []
+    start = 0
+    for name, run in itertools.groupby(routing):
+        stop = start + sum(1 for _ in run)
+        groups.append((name, start, stop))
+        start = stop
+    if not groups:
+        msg = "Fused adapter routing must name at least one row."
+        raise ValueError(msg)
+    return groups
 
 
-def _fused_routing_pre_hook(
-    module: nn.Module,
-    args: tuple,
-    kwargs: dict,
-) -> tuple[tuple, dict]:
-    """Inject leading-dim-aligned ``adapter_names`` when fused routing is active.
+def _lora_delta(layer: nn.Module, adapter: str, rows: torch.Tensor) -> torch.Tensor:
+    """One adapter's low-rank delta for a slice of input rows."""
+    lora_a = layer.lora_A[adapter]
+    rows = layer.lora_dropout[adapter](rows.to(lora_a.weight.dtype))
+    return layer.lora_B[adapter](lora_a(rows)) * layer.scaling[adapter]
 
-    :param module: The LoRA layer about to run ``forward``.
-    :type module: nn.Module
-    :param args: Positional forward args; ``args[0]`` is the input tensor.
-    :type args: tuple
-    :param kwargs: Keyword args passed to ``forward``.
-    :type kwargs: dict
-    :return: ``args`` unchanged and ``kwargs`` with ``adapter_names`` set when routing is active.
-    :rtype: tuple[tuple, dict]
+
+def _needs_peft_mixed_forward(layer: nn.Module, groups: AdapterGroups) -> bool:
+    """Whether any routed adapter needs PEFT's own mixed-batch forward.
+
+    The sliced path computes the standard linear delta; embedding adapters
+    and LoRA variants (e.g. aLoRA) use different maths, so those layers
+    delegate to ``LoraLayer._mixed_batch_forward``.
     """
-    routing = getattr(module, "_fused_adapter_routing", None)
-    if routing is not None:
-        kwargs["adapter_names"] = _align_routing_to_leading_dim(routing, args)
-    return args, kwargs
+    embedding = getattr(layer, "lora_embedding_A", None) or {}
+    variants = getattr(layer, "lora_variant", None) or {}
+    return any(name in embedding or name in variants for name, _, _ in groups)
+
+
+def _groups_for_leading_dim(groups: AdapterGroups, n_rows: int) -> AdapterGroups:
+    """Rescale routing groups to a layer input with *n_rows* leading rows.
+
+    Some layers flatten ``(batch, seq, hidden)`` to ``(batch * seq, hidden)``
+    before their linears (OPT's MLP, MoE experts). The flatten is row-major,
+    so sample ``i`` becomes the contiguous run ``[i * seq, (i + 1) * seq)``
+    and the groups scale by ``seq``. No-op when the leading dim already
+    matches the routed batch.
+
+    :raises ValueError: If *n_rows* is not a whole multiple of the routed
+        batch — the routing cannot be lined up with this input.
+    """
+    n_samples = groups[-1][2]
+    if n_rows == n_samples:
+        return groups
+    if n_rows % n_samples != 0:
+        msg = (
+            f"Fused adapter routing covers {n_samples} rows but the input's "
+            f"leading dimension is {n_rows}."
+        )
+        raise ValueError(msg)
+    factor = n_rows // n_samples
+    return [(name, start * factor, stop * factor) for name, start, stop in groups]
+
+
+def _routed_forward(
+    layer: nn.Module,
+    x: torch.Tensor,
+    *forward_args,
+    **forward_kwargs,
+) -> torch.Tensor:
+    """Replacement ``forward`` installed on patched LoRA layers.
+
+    Runs the layer's ordinary single-adapter forward until routing is set.
+    Adapters that do not wrap this layer leave their rows on the base output,
+    matching PEFT's mixed-batch behaviour.
+    """
+    groups = layer._fused_adapter_groups
+    if groups is None:
+        return type(layer).forward(layer, x, *forward_args, **forward_kwargs)
+
+    groups = _groups_for_leading_dim(groups, x.shape[0])
+
+    if _needs_peft_mixed_forward(layer, groups):
+        adapter_names = [
+            name for name, start, stop in groups for _ in range(stop - start)
+        ]
+        return layer._mixed_batch_forward(
+            x, *forward_args, adapter_names=adapter_names, **forward_kwargs
+        )
+
+    base_out = layer.base_layer(x, *forward_args, **forward_kwargs)
+
+    if len(groups) == 1:
+        name = groups[0][0]
+        if name == "__base__" or name not in layer.lora_A:
+            return base_out
+        return base_out + _lora_delta(layer, name, x).to(base_out.dtype)
+
+    pieces = []
+    for name, start, stop in groups:
+        rows = base_out.narrow(0, start, stop - start)
+        if name != "__base__" and name in layer.lora_A:
+            delta = _lora_delta(layer, name, x.narrow(0, start, stop - start))
+            rows = rows + delta.to(rows.dtype)
+        pieces.append(rows)
+    return torch.cat(pieces)
+
+
+def _store_layer_cache(model: nn.Module, layers: list[nn.Module]) -> None:
+    try:
+        model._fused_lora_layers = layers  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass  # Best-effort cache; routing falls back to a module traversal.
 
 
 def _get_cached_lora_layers(model: nn.Module) -> list[nn.Module]:
-    """Return the cached list of LoRA layers, falling back to a full traversal.
-
-    :param model: Root module that may store ``_fused_lora_layers`` after
-        ``patch_lora_for_fused_forward`` runs.
-    :type model: nn.Module
-    :return: All ``LoraLayer`` instances under ``model``, or an empty list if PEFT
-        is not installed.
-    :rtype: list[nn.Module]
-    """
+    """All ``LoraLayer`` modules under *model*, cached after the first traversal."""
     cached = getattr(model, "_fused_lora_layers", None)
     if cached is not None:
         return cached
     if LoraLayer is None:
         return []
+    # nn.Module.modules rather than model.modules: EvolvableModule overrides
+    # modules() to return only evolvable children, which excludes LoRA layers.
     layers = [m for m in nn.Module.modules(model) if isinstance(m, LoraLayer)]
-    try:
-        model._fused_lora_layers = layers  # type: ignore[attr-defined]
-    except (AttributeError, TypeError):
-        # Best-effort cache: some wrapped/slotted modules may reject dynamic attrs.
-        # This only impacts caching/performance, not correctness.
-        pass
+    _store_layer_cache(model, layers)
     return layers
 
 
-def _make_base_output_clone_hook(lora_layer: nn.Module):
-    """Clone the base-layer output while fused routing is active.
-
-    Fused adapter routing otherwise breaks on a quantized base: PEFT
-    accumulates the LoRA delta in place into the base output, which is a view
-    of bitsandbytes' quantized matmul output, and autograd forbids that
-    in-place edit. Cloning the output fixes it; no-op when routing is inactive.
-    """
-
-    def _hook(module: nn.Module, args: tuple, output):
-        if getattr(lora_layer, "_fused_adapter_routing", None) is None:
-            return None
-        if isinstance(output, torch.Tensor):
-            return output.clone()
-        return None
-
-    return _hook
-
-
 def patch_lora_for_fused_forward(model: nn.Module) -> None:
-    """Register forward pre-hooks on all LoRA layers.
+    """Swap every LoRA layer's ``forward`` for the fused-routing forward.
 
-    The hooks inject per-sample adapter routing into each layer's forward
-    call when ``_fused_adapter_routing`` is set, triggering PEFT's
-    ``_mixed_batch_forward`` code path.  When the attribute is ``None``
-    (the default), the hooks are no-ops and standard single-adapter
-    forward runs unchanged.
+    Routing starts inactive, so the patched layers behave exactly as before
+    until ``set_fused_adapter_routing`` is called. Idempotent — call again
+    after adding adapters that wrap new modules; only the new layers are
+    patched and the cached layer list is refreshed either way.
 
-    Also caches the list of LoRA layers on the model for fast access
-    by ``set_fused_adapter_routing`` / ``clear_fused_adapter_routing``.
-
-    Idempotent: layers that already carry a fused-routing hook are skipped,
-    so it is safe (and required) to call again whenever adapters wrapping
-    **new** modules are added after the first call — only the new layers are
-    hooked, and the cached layer list is refreshed either way.
-
-    :param model: A ``PeftModel`` (or any ``nn.Module`` containing
-        ``LoraLayer`` sub-modules).
-    :type model: nn.Module
-    :return: ``None``
-    :rtype: None
+    :param model: A ``PeftModel`` or any module containing ``LoraLayer`` s.
     """
     if LoraLayer is None:
         return
@@ -158,113 +187,92 @@ def patch_lora_for_fused_forward(model: nn.Module) -> None:
         if not isinstance(module, LoraLayer):
             continue
         layers.append(module)
-        if hasattr(module, "_fused_adapter_routing"):
-            # Already patched (re-patch after adding adapters): keep the
-            # existing hook; double-registering would run it twice per forward.
-            continue
-        module._fused_adapter_routing = None  # type: ignore[attr-defined]
-        module._fused_routing_hook_handle = (  # type: ignore[attr-defined]
-            module.register_forward_pre_hook(
-                _fused_routing_pre_hook,
-                with_kwargs=True,
-            )
-        )
-        # Clone the frozen base output during fused routing so PEFT's in-place
-        # LoRA accumulation (``result[idx] += ...``) never mutates a bnb 4-bit/
-        # 8-bit custom-Function output view (forbidden by autograd; crashes the
-        # multi-adapter PPO gradient forward). No-op when routing is inactive.
-        base_layer = getattr(module, "base_layer", None)
-        if base_layer is not None:
-            module._fused_base_clone_handle = (  # type: ignore[attr-defined]
-                base_layer.register_forward_hook(_make_base_output_clone_hook(module))
-            )
-    try:
-        model._fused_lora_layers = layers  # type: ignore[attr-defined]
-    except (AttributeError, TypeError):
-        # Best-effort cache only: some wrapped/frozen modules may reject
-        # dynamic attribute assignment. Fused routing still works by
-        # discovering LoRA layers when needed.
-        pass
+        if not hasattr(module, "_fused_adapter_groups"):
+            module._fused_adapter_groups = None  # type: ignore[attr-defined]
+            module.forward = partial(_routed_forward, module)  # type: ignore[method-assign]
+    _store_layer_cache(model, layers)
 
 
 def unpatch_lora_for_fused_forward(model: nn.Module) -> None:
-    """Remove the hooks and per-layer state installed by ``patch_lora_for_fused_forward``.
+    """Restore every LoRA layer's original ``forward`` and drop routing state.
 
-    Restores every LoRA layer to its pre-patch state (no routing attribute,
-    no pre-hook) and drops the cached layer list. After this,
-    ``set_fused_adapter_routing`` raises until the model is patched again.
+    After this, ``set_fused_adapter_routing`` raises until the model is
+    patched again.
 
     :param model: The model to release from fused-routing control.
-    :type model: nn.Module
-    :return: ``None``
-    :rtype: None
     """
     for module in _get_cached_lora_layers(model):
-        handle = getattr(module, "_fused_routing_hook_handle", None)
-        if handle is not None:
-            handle.remove()
-            del module._fused_routing_hook_handle
-        clone_handle = getattr(module, "_fused_base_clone_handle", None)
-        if clone_handle is not None:
-            clone_handle.remove()
-            del module._fused_base_clone_handle
-        if hasattr(module, "_fused_adapter_routing"):
-            del module._fused_adapter_routing
-    try:
+        if hasattr(module, "_fused_adapter_groups"):
+            del module._fused_adapter_groups
+            del module.forward
+    if hasattr(model, "_fused_lora_layers"):
         del model._fused_lora_layers
-    except (AttributeError, TypeError):
-        pass
 
 
 def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
-    """Activate fused adapter routing on all LoRA layers.
+    """Route each row of the next forward's batch through its own adapter.
 
-    :param model: The model whose LoRA layers should use fused routing.
-    :type model: nn.Module
-    :param routing: Adapter names, one per row of the fused batch (e.g.
-        ``["actor"] * B + ["critic"] * B`` when the batch concatenates actor and
-        critic inputs).  ``"__base__"`` routes a row through the frozen base
-        weights with no LoRA delta.
-    :type routing: Sequence[str]
-    :raises RuntimeError: If LoRA layers exist that
-        ``patch_lora_for_fused_forward`` has not hooked — without the hooks
-        the routing would be silently ignored and every row would run under
-        the currently active adapter.
-    :raises ValueError: If *routing* names an adapter that no LoRA layer
-        registers — PEFT's ``_mixed_batch_forward`` silently treats unknown
-        names as base-only rows, so a typo would corrupt training without
-        an error.
-    :return: ``None``
-    :rtype: None
+    Routing stays active — including for gradient-checkpoint recomputation
+    during ``backward()`` — until ``clear_fused_adapter_routing`` is called.
+
+    :param model: The patched model whose LoRA layers should route rows.
+    :param routing: Adapter name per batch row, e.g. ``["actor"] * B +
+        ["critic"] * B``. ``"__base__"`` runs a row through the frozen base
+        weights with no delta.
+    :raises RuntimeError: If LoRA layers are unpatched (the routing would be
+        silently ignored) or have adapters merged into the base weights.
+    :raises ValueError: If *routing* is empty, names an unknown adapter, or
+        names a DoRA adapter (unsupported, as in PEFT's mixed-batch forward).
     """
     layers = _get_cached_lora_layers(model)
     if not layers:
         # Plain base model (no adapters) or PEFT not installed: nothing to
         # route, and the unfused forward is already correct.
         return
-
-    if any(not hasattr(m, "_fused_adapter_routing") for m in layers):
+    if any(not hasattr(m, "_fused_adapter_groups") for m in layers):
         msg = (
             "set_fused_adapter_routing called on a model with LoRA layers that "
-            "have no fused-routing hook; the routing would be silently ignored. "
-            "Call patch_lora_for_fused_forward(model) first (again, if adapters "
-            "were added after the last call)."
+            "have no fused-routing forward; the routing would be silently "
+            "ignored. Call patch_lora_for_fused_forward(model) first (again, "
+            "if adapters were added after the last call)."
         )
         raise RuntimeError(msg)
 
-    routing = list(routing)
-    requested = set(routing) - {"__base__"}
+    groups = _contiguous_groups(routing)
+    _validate_routing(layers, groups)
+    for module in layers:
+        module._fused_adapter_groups = groups  # type: ignore[attr-defined]
+
+
+def _validate_routing(layers: list[nn.Module], groups: AdapterGroups) -> None:
+    """Reject routings PEFT would compute silently wrongly (unknown names)
+    or that the fused forward cannot compute (merged weights, DoRA).
+
+    :param layers: All LoRA layers under the model.
+    :param groups: Contiguous runs of adapter names in the routing.
+    :raises RuntimeError: If any layer has merged adapters.
+    :raises ValueError: If any adapter name is unknown or a DoRA adapter.
+    """
+    requested = {name for name, _, _ in groups if name != "__base__"}
     available: set[str] = set()
     for module in layers:
+        if getattr(module, "merged", False):
+            msg = (
+                "Cannot use fused adapter routing while adapters are merged "
+                "into the base weights; unmerge them first."
+            )
+            raise RuntimeError(msg)
+        use_dora = getattr(module, "use_dora", None) or {}
+        dora = sorted(name for name in requested if use_dora.get(name))
+        if dora:
+            msg = f"Fused adapter routing does not support DoRA adapters: {dora}."
+            raise ValueError(msg)
         for attr in getattr(module, "adapter_layer_names", ()):
             container = getattr(module, attr, None)
             if container is not None:
                 available.update(container.keys())
-        if requested <= available:
-            break
-    # Validation is best-effort: real PEFT layers always expose their adapter
-    # containers via ``adapter_layer_names``; when none are discoverable (e.g.
-    # test doubles), routing is applied without validation.
+    # Best-effort: when no adapter containers are discoverable (e.g. test
+    # doubles), routing is applied without name validation.
     if available and not requested <= available:
         unknown = sorted(requested - available)
         msg = (
@@ -274,22 +282,12 @@ def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
         )
         raise ValueError(msg)
 
-    for module in layers:
-        module._fused_adapter_routing = routing  # type: ignore[attr-defined]
-
 
 def clear_fused_adapter_routing(model: nn.Module) -> None:
     """Deactivate fused routing, restoring standard single-adapter forward.
 
-    Lenient by design so it is safe to call from error-cleanup paths: layers
-    never patched are left untouched (rather than gaining a routing attribute
-    that would defeat ``set_fused_adapter_routing``'s patched-layer check).
-
     :param model: The model whose LoRA layers should clear fused routing.
-    :type model: nn.Module
-    :return: ``None``
-    :rtype: None
     """
     for module in _get_cached_lora_layers(model):
-        if hasattr(module, "_fused_adapter_routing"):
-            module._fused_adapter_routing = None  # type: ignore[attr-defined]
+        if hasattr(module, "_fused_adapter_groups"):
+            module._fused_adapter_groups = None  # type: ignore[attr-defined]

--- a/agilerl/algorithms/ppo_llm.py
+++ b/agilerl/algorithms/ppo_llm.py
@@ -8,7 +8,7 @@ from accelerate import Accelerator
 
 from agilerl import HAS_LIGER_KERNEL, HAS_LLM_DEPENDENCIES
 from agilerl.algorithms.core import ActionResult, LLMAlgorithm
-from agilerl.algorithms.core.llm_ops.fused_lora import clear_fused_adapter_routing
+from agilerl.algorithms.core.llm_ops.fused_lora import unset_fused_adapter_routing
 from agilerl.algorithms.core.registry import HyperparameterConfig, NetworkGroup
 from agilerl.llm_envs import ReasoningGym
 
@@ -663,7 +663,7 @@ class PPO(LLMAlgorithm):
                             batch_sampling_log_probs,
                         )
                         self._backward_pass(total_loss)
-                        clear_fused_adapter_routing(self._get_unwrapped_actor())
+                        unset_fused_adapter_routing(self._get_unwrapped_actor())
                         learn_metrics["kl"] += metrics["kl"]
                         learn_metrics["entropy"] += metrics["entropy"]
                         learn_metrics["clipfrac"] += metrics["clipfrac"]
@@ -761,7 +761,7 @@ class PPO(LLMAlgorithm):
                     total_loss = pg_loss + vf_loss + self.beta * kl_loss
 
                     self._backward_pass(total_loss)
-                    clear_fused_adapter_routing(self._get_unwrapped_actor())
+                    unset_fused_adapter_routing(self._get_unwrapped_actor())
 
                     learn_metrics["kl"] += kl_loss.item()
                     learn_metrics["entropy"] += masked_entropy.mean().item()

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -1,14 +1,14 @@
-from unittest.mock import patch
+import copy
 
 import pytest
 import torch
+from peft import LoraConfig, inject_adapter_in_model
 from torch import nn
 
 from agilerl.algorithms.core.llm_ops.fused_lora import (
-    _align_routing_to_leading_dim,
-    _fused_routing_pre_hook,
+    _contiguous_groups,
     _get_cached_lora_layers,
-    _make_base_output_clone_hook,
+    _groups_for_leading_dim,
     clear_fused_adapter_routing,
     patch_lora_for_fused_forward,
     set_fused_adapter_routing,
@@ -16,441 +16,415 @@ from agilerl.algorithms.core.llm_ops.fused_lora import (
 )
 
 
-class _DummyLoraLayer(nn.Module):
+class _Tiny(nn.Module):
     def __init__(self) -> None:
         super().__init__()
-        self.last_adapter_names = None
+        self.proj = nn.Linear(8, 6, bias=False)
 
-    def forward(self, x, adapter_names=None):
-        self.last_adapter_names = adapter_names
-        return x
+    def forward(self, x):
+        return self.proj(x)
 
 
-class _DummyFusedModel(nn.Module):
+class _TinyEmbedding(nn.Module):
     def __init__(self) -> None:
         super().__init__()
-        self.lora_a = _DummyLoraLayer()
-        self.linear = nn.Linear(2, 2)
-        self.lora_b = _DummyLoraLayer()
+        self.embed = nn.Embedding(10, 4)
+
+    def forward(self, ids):
+        return self.embed(ids)
 
 
-class _CacheRejectingFusedModel(_DummyFusedModel):
+class _TinyFlatten(nn.Module):
+    """Flattens (batch, seq, hidden) to (batch * seq, hidden) before its
+    linear, like OPT's MLP and MoE experts.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(8, 6, bias=False)
+
+    def forward(self, x):
+        batch, seq, hidden = x.shape
+        return self.proj(x.reshape(batch * seq, hidden)).reshape(batch, seq, -1)
+
+
+def _lora_config(**overrides):
+    config = {
+        "r": 2,
+        "lora_alpha": 4,
+        "target_modules": ["proj"],
+        # Random lora_B (not zeros) so every adapter produces a distinct delta.
+        "init_lora_weights": False,
+    }
+    config.update(overrides)
+    return LoraConfig(**config)
+
+
+def _build_model(adapters=("actor", "critic"), module_cls=_Tiny, **config_overrides):
+    torch.manual_seed(0)
+    model = module_cls()
+    for name in adapters:
+        model = inject_adapter_in_model(
+            _lora_config(**config_overrides), model, adapter_name=name
+        )
+    return model
+
+
+def _enable_lora_grads(model):
+    # set_adapter freezes inactive adapters; training keeps all routed
+    # adapters trainable, so the gradient tests do too.
+    for name, param in model.named_parameters():
+        if "lora_" in name:
+            param.requires_grad_(True)
+
+
+class _ViewMatmul(torch.autograd.Function):
+    """Matmul returning a view of its output, like bitsandbytes' quantized
+    matmul: autograd forbids in-place modification of the result.
+    """
+
+    @staticmethod
+    def forward(ctx, x, weight):
+        ctx.save_for_backward(weight)
+        out = x @ weight.t()
+        return out.view(out.shape)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        (weight,) = ctx.saved_tensors
+        return grad_out @ weight, None
+
+
+class _ViewLinear(nn.Module):
+    def __init__(self, linear: nn.Linear) -> None:
+        super().__init__()
+        self.weight = linear.weight
+
+    def forward(self, x):
+        return _ViewMatmul.apply(x, self.weight)
+
+
+class TestContiguousGroups:
+    def test_runs_are_compressed_in_order(self):
+        assert _contiguous_groups(["a", "a", "b", "a"]) == [
+            ("a", 0, 2),
+            ("b", 2, 3),
+            ("a", 3, 4),
+        ]
+
+    def test_empty_routing_raises(self):
+        with pytest.raises(ValueError, match="at least one row"):
+            _contiguous_groups([])
+
+
+class TestGroupsForLeadingDim:
+    def test_matching_leading_dim_returns_groups_unchanged(self):
+        groups = [("actor", 0, 2), ("critic", 2, 4)]
+        assert _groups_for_leading_dim(groups, 4) is groups
+
+    def test_whole_multiple_scales_each_run(self):
+        # Row-major flatten of (batch=4, seq=3): sample i covers rows
+        # [3i, 3i + 3), so every run scales by 3.
+        groups = [("actor", 0, 2), ("critic", 2, 4)]
+        assert _groups_for_leading_dim(groups, 12) == [
+            ("actor", 0, 6),
+            ("critic", 6, 12),
+        ]
+
+    def test_non_divisible_leading_dim_raises(self):
+        with pytest.raises(ValueError, match="covers 4 rows"):
+            _groups_for_leading_dim([("actor", 0, 4)], 7)
+
+
+class TestRoutedForward:
+    def test_rows_match_per_adapter_reference(self):
+        model = _build_model()
+        x = torch.randn(4, 8)
+        model.proj.set_adapter("actor")
+        ref_actor = model(x)
+        model.proj.set_adapter("critic")
+        ref_critic = model(x)
+        assert not torch.allclose(ref_actor, ref_critic)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor"] * 2 + ["critic"] * 2)
+        out = model(x)
+
+        assert torch.allclose(out[:2], ref_actor[:2], atol=1e-6)
+        assert torch.allclose(out[2:], ref_critic[2:], atol=1e-6)
+
+    def test_base_rows_and_non_contiguous_runs(self):
+        model = _build_model()
+        x = torch.randn(4, 8)
+        model.proj.set_adapter("actor")
+        ref_actor = model(x)
+        ref_base = model.proj.base_layer(x)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor", "__base__", "__base__", "actor"])
+        out = model(x)
+
+        assert torch.allclose(out[0], ref_actor[0], atol=1e-6)
+        assert torch.allclose(out[1:3], ref_base[1:3], atol=1e-6)
+        assert torch.allclose(out[3], ref_actor[3], atol=1e-6)
+
+    def test_single_group_covers_whole_batch(self):
+        model = _build_model()
+        x = torch.randn(4, 8)
+        model.proj.set_adapter("critic")
+        ref_critic = model(x)
+        ref_base = model.proj.base_layer(x)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["critic"] * 4)
+        assert torch.allclose(model(x), ref_critic, atol=1e-6)
+        set_fused_adapter_routing(model, ["__base__"] * 4)
+        assert torch.allclose(model(x), ref_base, atol=1e-6)
+
+    def test_adapter_missing_on_a_layer_leaves_rows_on_base_output(self):
+        # "critic" only wraps a different layer, so on ``proj`` its rows get
+        # the frozen base output — same as PEFT's mixed-batch behaviour.
+        model = _build_model(adapters=("actor",))
+        model.other = inject_adapter_in_model(
+            _lora_config(), _Tiny(), adapter_name="critic"
+        )
+        x = torch.randn(2, 8)
+        ref_base = model.proj.base_layer(x)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor", "critic"])
+        out = model(x)
+        assert torch.allclose(out[1], ref_base[1], atol=1e-6)
+
+    def test_routing_and_batch_size_mismatch_raises(self):
+        model = _build_model()
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor"] * 3)
+        with pytest.raises(ValueError, match="covers 3 rows"):
+            model(torch.randn(4, 8))
+
+    def test_layer_that_flattens_batch_and_seq_scales_the_routing(self):
+        model = _build_model(module_cls=_TinyFlatten)
+        x = torch.randn(2, 3, 8)
+        model.proj.set_adapter("actor")
+        ref_actor = model(x)
+        model.proj.set_adapter("critic")
+        ref_critic = model(x)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor", "critic"])
+        out = model(x)
+
+        assert torch.allclose(out[0], ref_actor[0], atol=1e-6)
+        assert torch.allclose(out[1], ref_critic[1], atol=1e-6)
+
+    def test_inactive_routing_runs_standard_forward(self):
+        model = _build_model()
+        x = torch.randn(4, 8)
+        model.proj.set_adapter("actor")
+        ref = model(x)
+
+        patch_lora_for_fused_forward(model)
+        assert torch.allclose(model(x), ref, atol=1e-6)
+
+        set_fused_adapter_routing(model, ["critic"] * 4)
+        clear_fused_adapter_routing(model)
+        assert torch.allclose(model(x), ref, atol=1e-6)
+
+
+class TestGradients:
+    def test_fused_gradients_match_separate_per_adapter_passes(self):
+        model = _build_model()
+        x = torch.randn(4, 8)
+        _enable_lora_grads(model)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor"] * 2 + ["critic"] * 2)
+        model(x).sum().backward()
+        layer = model.proj
+        fused_grads = {
+            name: layer.lora_A[name].weight.grad.clone() for name in ("actor", "critic")
+        }
+        model.zero_grad()
+        clear_fused_adapter_routing(model)
+
+        for name, rows in (("actor", x[:2]), ("critic", x[2:])):
+            layer.set_adapter(name)
+            _enable_lora_grads(model)
+            model(rows).sum().backward()
+            assert torch.allclose(
+                layer.lora_A[name].weight.grad, fused_grads[name], atol=1e-6
+            )
+            model.zero_grad()
+
+    def test_routing_survives_gradient_checkpoint_recompute(self):
+        model = _build_model()
+        x = torch.randn(4, 8, requires_grad=True)
+        model.proj.set_adapter("actor")
+        _enable_lora_grads(model)
+        ref_actor = model(x)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor"] * 2 + ["critic"] * 2)
+        out = torch.utils.checkpoint.checkpoint(model, x, use_reentrant=False)
+        assert torch.allclose(out[:2], ref_actor[:2], atol=1e-6)
+        out.sum().backward()
+        assert model.proj.lora_A["critic"].weight.grad is not None
+
+    def test_no_in_place_mutation_of_base_output(self):
+        # bitsandbytes' quantized matmul returns a view that autograd forbids
+        # editing in place; the fused forward must compose out of place.
+        model = _build_model()
+        model.proj.base_layer = _ViewLinear(model.proj.base_layer)
+        x = torch.randn(4, 8, requires_grad=True)
+        _enable_lora_grads(model)
+
+        probe = model.proj.base_layer(x)
+        with pytest.raises(RuntimeError, match="view"):
+            probe += 1.0
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor"] * 2 + ["critic"] * 2)
+        model(x).sum().backward()
+
+
+class TestEmbeddingDelegation:
+    def test_embedding_adapters_route_via_peft_mixed_forward(self):
+        model = _build_model(module_cls=_TinyEmbedding, target_modules=["embed"])
+        ids = torch.randint(0, 10, (2, 3))
+        model.embed.set_adapter("actor")
+        ref_actor = model(ids)
+        model.embed.set_adapter("critic")
+        ref_critic = model(ids)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor", "critic"])
+        out = model(ids)
+
+        assert torch.allclose(out[0], ref_actor[0], atol=1e-6)
+        assert torch.allclose(out[1], ref_critic[1], atol=1e-6)
+
+
+class TestSetFusedAdapterRoutingGuards:
+    def test_set_raises_when_model_not_patched(self):
+        model = _build_model()
+        with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
+            set_fused_adapter_routing(model, ["actor", "critic"])
+
+    def test_set_noops_when_model_has_no_lora_layers(self):
+        set_fused_adapter_routing(nn.Linear(2, 2), ["actor"])
+
+    def test_unknown_adapter_name_raises(self):
+        model = _build_model()
+        patch_lora_for_fused_forward(model)
+        with pytest.raises(ValueError, match="critc"):
+            set_fused_adapter_routing(model, ["actor", "critc"])
+
+    def test_merged_adapters_raise(self):
+        model = _build_model(adapters=("actor",))
+        patch_lora_for_fused_forward(model)
+        model.proj.merge()
+        with pytest.raises(RuntimeError, match="merged"):
+            set_fused_adapter_routing(model, ["actor"])
+
+    def test_dora_adapters_raise(self):
+        model = _build_model(adapters=("actor",), use_dora=True, init_lora_weights=True)
+        patch_lora_for_fused_forward(model)
+        with pytest.raises(ValueError, match="DoRA"):
+            set_fused_adapter_routing(model, ["actor"])
+
+    def test_clear_on_unpatched_model_does_not_mask_the_patch_check(self):
+        model = _build_model()
+        clear_fused_adapter_routing(model)
+        assert not hasattr(model.proj, "_fused_adapter_groups")
+        with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
+            set_fused_adapter_routing(model, ["actor"])
+
+
+class TestPatchLifecycle:
+    def test_repatch_is_idempotent(self):
+        model = _build_model()
+        patch_lora_for_fused_forward(model)
+        routed = model.proj.__dict__["forward"]
+        patch_lora_for_fused_forward(model)
+        assert model.proj.__dict__["forward"] is routed
+
+    def test_repatch_covers_layers_added_after_first_patch(self):
+        model = _build_model(adapters=("actor",))
+        patch_lora_for_fused_forward(model)
+        model.late = inject_adapter_in_model(
+            _lora_config(), _Tiny(), adapter_name="actor"
+        )
+        patch_lora_for_fused_forward(model)
+
+        assert len(model._fused_lora_layers) == 2
+        set_fused_adapter_routing(model, ["actor"])
+        assert model.late.proj._fused_adapter_groups == [("actor", 0, 1)]
+
+    def test_unpatch_restores_original_forward_and_state(self):
+        model = _build_model()
+        x = torch.randn(2, 8)
+        model.proj.set_adapter("actor")
+        ref = model(x)
+
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["critic", "critic"])
+        unpatch_lora_for_fused_forward(model)
+
+        assert "forward" not in model.proj.__dict__
+        assert not hasattr(model.proj, "_fused_adapter_groups")
+        assert not hasattr(model, "_fused_lora_layers")
+        assert torch.allclose(model(x), ref, atol=1e-6)
+        with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
+            set_fused_adapter_routing(model, ["actor"])
+
+    def test_unpatch_on_never_patched_model_is_noop(self):
+        model = _build_model()
+        unpatch_lora_for_fused_forward(model)
+        assert not hasattr(model.proj, "_fused_adapter_groups")
+
+    def test_deepcopy_rebinds_routed_forward_to_the_copy(self):
+        model = _build_model()
+        patch_lora_for_fused_forward(model)
+        clone = copy.deepcopy(model)
+
+        assert clone.proj.__dict__["forward"].args[0] is clone.proj
+        x = torch.randn(2, 8)
+        set_fused_adapter_routing(clone, ["actor", "critic"])
+        _ = clone(x)
+        # The original stays unrouted.
+        assert model.proj._fused_adapter_groups is None
+
+
+class _CacheRejectingModel(nn.Module):
+    """Rejects the ``_fused_lora_layers`` cache, forcing the traversal path."""
+
     def __setattr__(self, name, value):
         if name == "_fused_lora_layers":
             msg = "cache assignment not allowed"
             raise AttributeError(msg)
         super().__setattr__(name, value)
 
-
-class _BaseLayerLoraLayer(_DummyLoraLayer):
-    """LoRA layer exposing a ``base_layer`` submodule, like real PEFT layers.
-
-    ``base_layer`` returns its input unchanged, so the clone hook is the only
-    thing that can produce a distinct output tensor.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.base_layer = nn.Identity()
+    def forward(self, x):
+        return self.proj(x)
 
 
-class TestPatchLoraForFusedForward:
-    def test_patch_lora_for_fused_forward_registers_hooks_and_cache(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
+class TestLayerCache:
+    def test_routing_works_without_a_layer_cache(self):
+        model = _CacheRejectingModel()
+        model.proj = nn.Linear(8, 6, bias=False)
+        model = inject_adapter_in_model(_lora_config(), model, adapter_name="actor")
 
-        assert hasattr(model, "_fused_lora_layers")
-        assert len(model._fused_lora_layers) == 2
-        for layer in model._fused_lora_layers:
-            assert layer._fused_adapter_routing is None
-            assert len(layer._forward_pre_hooks) >= 1
-
-    def test_patch_lora_for_fused_forward_noops_when_loralayer_none(self):
-        model = _DummyFusedModel()
-        with patch("agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", None):
-            patch_lora_for_fused_forward(model)
-
-        assert not hasattr(model, "_fused_lora_layers")
-        assert not hasattr(model.lora_a, "_fused_adapter_routing")
-        assert not hasattr(model.lora_b, "_fused_adapter_routing")
-
-    def test_patch_lora_for_fused_forward_ignores_cache_assignment_errors(self):
-        model = _CacheRejectingFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-
-        assert not hasattr(model, "_fused_lora_layers")
-        for layer in (model.lora_a, model.lora_b):
-            assert layer._fused_adapter_routing is None
-            assert len(layer._forward_pre_hooks) >= 1
-
-
-def test_set_and_clear_fused_adapter_routing_update_all_lora_layers():
-    model = _DummyFusedModel()
-    routing = ["actor", "critic"]
-    with patch("agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer):
         patch_lora_for_fused_forward(model)
-        set_fused_adapter_routing(model, routing)
-        for layer in model._fused_lora_layers:
-            assert layer._fused_adapter_routing == routing
-
-        clear_fused_adapter_routing(model)
-        for layer in model._fused_lora_layers:
-            assert layer._fused_adapter_routing is None
-
-
-class TestFusedRoutingPreHook:
-    def test_fused_lora_hook_injects_adapter_names_into_forward_kwargs(self):
-        model = _DummyFusedModel()
-        routing = ["actor", "critic"]
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, routing)
-            _ = model.lora_a(torch.ones(1, 2))
-
-        assert model.lora_a.last_adapter_names == routing
-
-    def test_fused_routing_pre_hook_leaves_kwargs_unchanged_without_routing(self):
-        module = _DummyLoraLayer()
-        args = (torch.ones(1, 2),)
-        kwargs = {"existing_kwarg": "present"}
-
-        returned_args, returned_kwargs = _fused_routing_pre_hook(module, args, kwargs)
-
-        assert returned_args == args
-        assert returned_kwargs["existing_kwarg"] == "present"
-        assert "adapter_names" not in returned_kwargs
-
-    def test_fused_lora_hook_expands_routing_for_flattened_input(self):
-        # A model that flattens (batch, seq, hidden) -> (batch * seq, hidden)
-        # before a LoRA linear (e.g. OPT's MLP) makes x.shape[0] a multiple of
-        # the per-row routing length; the hook must expand names to match.
-        model = _DummyFusedModel()
-        routing = ["actor", "critic"]  # batch of 2
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, routing)
-            # (batch * seq, hidden) with batch=2, seq=3 -> leading dim 6.
-            _ = model.lora_a(torch.ones(6, 2))
-
-        assert model.lora_a.last_adapter_names == [
-            "actor",
-            "actor",
-            "actor",
-            "critic",
-            "critic",
-            "critic",
-        ]
-
-
-class TestAlignRoutingToLeadingDim:
-    def test_returns_routing_unchanged_when_leading_dim_matches(self):
-        # Common 3D path: (batch, seq, hidden) -> leading dim == batch.
-        routing = ["actor", "critic"]
-        aligned = _align_routing_to_leading_dim(routing, (torch.ones(2, 5, 4),))
-        assert aligned is routing
-
-    def test_expands_routing_when_leading_dim_is_multiple(self):
-        routing = ["actor", "critic", "__base__"]
-        # Flattened (batch=3, seq=2, hidden) -> leading dim 6, factor 2.
-        aligned = _align_routing_to_leading_dim(routing, (torch.ones(6, 4),))
-        assert aligned == ["actor", "actor", "critic", "critic", "__base__", "__base__"]
-
-    def test_leaves_non_divisible_mismatch_for_peft_to_report(self):
-        routing = ["actor", "critic", "__base__"]
-        # 7 is not a multiple of 3: don't guess, defer to PEFT's length check.
-        aligned = _align_routing_to_leading_dim(routing, (torch.ones(7, 4),))
-        assert aligned is routing
-
-    def test_returns_routing_unchanged_when_no_tensor_arg(self):
-        routing = ["actor"]
-        assert _align_routing_to_leading_dim(routing, ()) is routing
-        assert _align_routing_to_leading_dim(routing, ("not-a-tensor",)) is routing
-
-    def test_returns_routing_unchanged_when_routing_empty(self):
-        routing: list[str] = []
-        assert _align_routing_to_leading_dim(routing, (torch.ones(4, 2),)) is routing
-
-
-class _AdapterAwareLoraLayer(_DummyLoraLayer):
-    """Dummy layer exposing PEFT-style adapter containers for validation."""
-
-    adapter_layer_names = ("lora_A", "lora_B")
-
-    def __init__(self, adapters=("actor", "critic")) -> None:
-        super().__init__()
-        self.lora_A = nn.ModuleDict({name: nn.Identity() for name in adapters})
-        self.lora_B = nn.ModuleDict({name: nn.Identity() for name in adapters})
-
-
-class _AdapterAwareFusedModel(nn.Module):
-    def __init__(self) -> None:
-        super().__init__()
-        self.lora_a = _AdapterAwareLoraLayer()
-        self.lora_b = _AdapterAwareLoraLayer()
-
-
-class TestSetFusedAdapterRoutingGuards:
-    def test_set_raises_when_model_not_patched(self):
-        model = _DummyFusedModel()
-        with (
-            patch(
-                "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer",
-                _DummyLoraLayer,
-            ),
-            pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"),
-        ):
-            set_fused_adapter_routing(model, ["actor", "critic"])
-
-    def test_set_noops_when_model_has_no_lora_layers(self):
-        model = nn.Linear(2, 2)
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            set_fused_adapter_routing(model, ["actor"])
-
-    def test_clear_on_unpatched_model_does_not_mask_the_patch_check(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            clear_fused_adapter_routing(model)
-            assert not hasattr(model.lora_a, "_fused_adapter_routing")
-            with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
-                set_fused_adapter_routing(model, ["actor"])
-
-
-class TestSetFusedAdapterRoutingValidation:
-    def test_known_adapter_names_accepted(self):
-        model = _AdapterAwareFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["actor", "critic"])
-
-        assert model.lora_a._fused_adapter_routing == ["actor", "critic"]
-
-    def test_unknown_adapter_name_raises(self):
-        model = _AdapterAwareFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            with pytest.raises(ValueError, match="critc"):
-                set_fused_adapter_routing(model, ["actor", "critc"])
-
-    def test_base_adapter_name_always_allowed(self):
-        model = _AdapterAwareFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["__base__", "actor"])
-
-        assert model.lora_a._fused_adapter_routing == ["__base__", "actor"]
-
-    def test_adapter_names_unioned_across_layers(self):
-        model = nn.Module()
-        model.lora_a = _AdapterAwareLoraLayer(adapters=("actor",))
-        model.lora_b = _AdapterAwareLoraLayer(adapters=("critic",))
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["actor", "critic"])
-
-        assert model.lora_b._fused_adapter_routing == ["actor", "critic"]
-
-    def test_validation_skipped_when_no_adapter_containers(self):
-        # Layers that don't expose PEFT's adapter containers (opaque test
-        # doubles) keep the previous unvalidated behavior.
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["anything-goes"])
-
-        assert model.lora_a._fused_adapter_routing == ["anything-goes"]
-
-
-class TestPatchIdempotency:
-    def test_repatch_does_not_double_register_hooks(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            patch_lora_for_fused_forward(model)
-
-        for layer in (model.lora_a, model.lora_b):
-            assert len(layer._forward_pre_hooks) == 1
-
-    def test_repatch_hooks_layers_added_after_first_patch(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            model.lora_c = _DummyLoraLayer()
-            patch_lora_for_fused_forward(model)
-
-            assert len(model._fused_lora_layers) == 3
-            assert len(model.lora_c._forward_pre_hooks) == 1
-            assert model.lora_c._fused_adapter_routing is None
-            # Existing layers keep their single hook.
-            assert len(model.lora_a._forward_pre_hooks) == 1
-
-            set_fused_adapter_routing(model, ["actor"])
-            assert model.lora_c._fused_adapter_routing == ["actor"]
-
-
-class TestUnpatchLoraForFusedForward:
-    def test_unpatch_removes_hooks_state_and_cache(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["actor", "critic"])
-            unpatch_lora_for_fused_forward(model)
-
-            for layer in (model.lora_a, model.lora_b):
-                assert len(layer._forward_pre_hooks) == 0
-                assert not hasattr(layer, "_fused_adapter_routing")
-                assert not hasattr(layer, "_fused_routing_hook_handle")
-            assert not hasattr(model, "_fused_lora_layers")
-
-            # Forward no longer injects adapter_names.
-            _ = model.lora_a(torch.ones(1, 2))
-            assert model.lora_a.last_adapter_names is None
-
-            # And routing cannot be silently re-applied without re-patching.
-            with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
-                set_fused_adapter_routing(model, ["actor"])
-
-    def test_unpatch_then_repatch_restores_routing(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            unpatch_lora_for_fused_forward(model)
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["actor"])
-            _ = model.lora_a(torch.ones(1, 2))
-
-        assert model.lora_a.last_adapter_names == ["actor"]
-        assert len(model.lora_a._forward_pre_hooks) == 1
-
-    def test_unpatch_on_never_patched_model_is_noop(self):
-        model = _DummyFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            unpatch_lora_for_fused_forward(model)
-
         assert not hasattr(model, "_fused_lora_layers")
-        assert not hasattr(model.lora_a, "_fused_adapter_routing")
+        set_fused_adapter_routing(model, ["actor"] * 2)
+        _ = model(torch.randn(2, 8))
+        unpatch_lora_for_fused_forward(model)
+        assert "forward" not in model.proj.__dict__
 
-    def test_unpatch_tolerates_cache_delete_failure(self):
-        # A model that rejects the ``_fused_lora_layers`` cache attribute never
-        # stores it, so unpatch's ``del model._fused_lora_layers`` raises; the
-        # best-effort teardown must swallow it and still clear the layers.
-        model = _CacheRejectingFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            unpatch_lora_for_fused_forward(model)
-
-        assert not hasattr(model.lora_a, "_fused_adapter_routing")
-        assert not hasattr(model.lora_b, "_fused_adapter_routing")
-
-
-class TestBaseOutputCloneHook:
-    """The base_layer forward hook clones the frozen base output only while
-    fused routing is active (so PEFT's in-place LoRA accumulation can't mutate
-    a bnb custom-Function output view).
-    """
-
-    def test_clones_base_output_when_routing_active(self):
-        model = nn.Module()
-        model.lora_a = _BaseLayerLoraLayer()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            set_fused_adapter_routing(model, ["actor"])
-            x = torch.ones(2, 2)
-            out = model.lora_a.base_layer(x)
-
-        # Identity returns its input; a distinct, equal tensor means the hook
-        # cloned it.
-        assert out is not x
-        assert torch.equal(out, x)
-
-    def test_noop_when_routing_inactive(self):
-        model = nn.Module()
-        model.lora_a = _BaseLayerLoraLayer()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)  # routing defaults to None
-            x = torch.ones(2, 2)
-            out = model.lora_a.base_layer(x)
-
-        # No routing -> hook is a no-op -> Identity's input passes through.
-        assert out is x
-
-    def test_unpatch_removes_clone_handle(self):
-        model = nn.Module()
-        model.lora_a = _BaseLayerLoraLayer()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            patch_lora_for_fused_forward(model)
-            unpatch_lora_for_fused_forward(model)
-            assert not hasattr(model.lora_a, "_fused_base_clone_handle")
-            assert len(model.lora_a.base_layer._forward_hooks) == 0
-
-    def test_passes_through_non_tensor_base_output(self):
-        # Routing active but the base layer returns a non-Tensor (e.g. a tuple
-        # of hidden states): the hook must leave it untouched rather than try to
-        # clone it.
-        layer = _BaseLayerLoraLayer()
-        layer._fused_adapter_routing = ["actor"]
-        hook = _make_base_output_clone_hook(layer)
-        sentinel = ("not", "a", "tensor")
-        assert hook(layer.base_layer, (), sentinel) is None
-
-
-class TestGetCachedLoraLayers:
-    def test_get_cached_lora_layers_returns_empty_when_loralayer_none(self):
-        model = _DummyFusedModel()
-        with patch("agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", None):
-            layers = _get_cached_lora_layers(model)
-
-        assert layers == []
-        assert not hasattr(model, "_fused_lora_layers")
-
-    def test_get_cached_lora_layers_ignores_cache_assignment_errors(self):
-        model = _CacheRejectingFusedModel()
-        with patch(
-            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
-        ):
-            layers = _get_cached_lora_layers(model)
-
-        assert len(layers) == 2
-        assert all(isinstance(layer, _DummyLoraLayer) for layer in layers)
-        assert not hasattr(model, "_fused_lora_layers")
+    def test_cache_is_stored_and_reused(self):
+        model = _build_model()
+        layers = _get_cached_lora_layers(model)
+        assert layers == [model.proj]
+        assert model._fused_lora_layers is layers
+        assert _get_cached_lora_layers(model) is layers

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -1,4 +1,5 @@
 import copy
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -400,3 +401,24 @@ class TestLayerCache:
         assert layers == [model.proj]
         assert model._fused_lora_layers is layers
         assert _get_cached_lora_layers(model) is layers
+
+
+class TestPeftNotInstalled:
+    """When PEFT is absent, ``LoraLayer`` is ``None`` and the helpers degrade
+    to no-ops rather than crashing (the plain base model runs unfused).
+    """
+
+    def test_get_cached_lora_layers_returns_empty(self):
+        model = _build_model()
+        with patch("agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", None):
+            assert _get_cached_lora_layers(model) == []
+        # No LoRA layers were discovered, so nothing was cached.
+        assert not hasattr(model, "_fused_lora_layers")
+
+    def test_patch_is_a_noop(self):
+        model = _build_model()
+        with patch("agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", None):
+            patch_lora_for_fused_forward(model)
+        # The forward was not swapped and no routing state was installed.
+        assert "forward" not in model.proj.__dict__
+        assert not hasattr(model.proj, "_fused_adapter_routing")

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -7,10 +7,10 @@ from torch import nn
 
 from agilerl.algorithms.core.llm_ops.fused_lora import (
     _get_cached_lora_layers,
-    clear_fused_adapter_routing,
     patch_lora_for_fused_forward,
     set_fused_adapter_routing,
     unpatch_lora_for_fused_forward,
+    unset_fused_adapter_routing,
 )
 
 
@@ -194,7 +194,7 @@ class TestRoutedForward:
         assert torch.allclose(model(x), ref, atol=1e-6)
 
         set_fused_adapter_routing(model, ["critic"] * 4)
-        clear_fused_adapter_routing(model)
+        unset_fused_adapter_routing(model)
         assert torch.allclose(model(x), ref, atol=1e-6)
 
 
@@ -212,7 +212,7 @@ class TestGradients:
             name: layer.lora_A[name].weight.grad.clone() for name in ("actor", "critic")
         }
         model.zero_grad()
-        clear_fused_adapter_routing(model)
+        unset_fused_adapter_routing(model)
 
         for name, rows in (("actor", x[:2]), ("critic", x[2:])):
             layer.set_adapter(name)
@@ -307,7 +307,7 @@ class TestSetFusedAdapterRoutingGuards:
 
     def test_clear_on_unpatched_model_does_not_mask_the_patch_check(self):
         model = _build_model()
-        clear_fused_adapter_routing(model)
+        unset_fused_adapter_routing(model)
         assert not hasattr(model.proj, "_fused_adapter_routing")
         with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
             set_fused_adapter_routing(model, ["actor"])

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 
 from agilerl.algorithms.core.llm_ops.fused_lora import (
+    _align_routing_to_leading_dim,
     _fused_routing_pre_hook,
     _get_cached_lora_layers,
     _make_base_output_clone_hook,
@@ -126,6 +127,58 @@ class TestFusedRoutingPreHook:
         assert returned_args == args
         assert returned_kwargs["existing_kwarg"] == "present"
         assert "adapter_names" not in returned_kwargs
+
+    def test_fused_lora_hook_expands_routing_for_flattened_input(self):
+        # A model that flattens (batch, seq, hidden) -> (batch * seq, hidden)
+        # before a LoRA linear (e.g. OPT's MLP) makes x.shape[0] a multiple of
+        # the per-row routing length; the hook must expand names to match.
+        model = _DummyFusedModel()
+        routing = ["actor", "critic"]  # batch of 2
+        with patch(
+            "agilerl.algorithms.core.llm_ops.fused_lora.LoraLayer", _DummyLoraLayer
+        ):
+            patch_lora_for_fused_forward(model)
+            set_fused_adapter_routing(model, routing)
+            # (batch * seq, hidden) with batch=2, seq=3 -> leading dim 6.
+            _ = model.lora_a(torch.ones(6, 2))
+
+        assert model.lora_a.last_adapter_names == [
+            "actor",
+            "actor",
+            "actor",
+            "critic",
+            "critic",
+            "critic",
+        ]
+
+
+class TestAlignRoutingToLeadingDim:
+    def test_returns_routing_unchanged_when_leading_dim_matches(self):
+        # Common 3D path: (batch, seq, hidden) -> leading dim == batch.
+        routing = ["actor", "critic"]
+        aligned = _align_routing_to_leading_dim(routing, (torch.ones(2, 5, 4),))
+        assert aligned is routing
+
+    def test_expands_routing_when_leading_dim_is_multiple(self):
+        routing = ["actor", "critic", "__base__"]
+        # Flattened (batch=3, seq=2, hidden) -> leading dim 6, factor 2.
+        aligned = _align_routing_to_leading_dim(routing, (torch.ones(6, 4),))
+        assert aligned == ["actor", "actor", "critic", "critic", "__base__", "__base__"]
+
+    def test_leaves_non_divisible_mismatch_for_peft_to_report(self):
+        routing = ["actor", "critic", "__base__"]
+        # 7 is not a multiple of 3: don't guess, defer to PEFT's length check.
+        aligned = _align_routing_to_leading_dim(routing, (torch.ones(7, 4),))
+        assert aligned is routing
+
+    def test_returns_routing_unchanged_when_no_tensor_arg(self):
+        routing = ["actor"]
+        assert _align_routing_to_leading_dim(routing, ()) is routing
+        assert _align_routing_to_leading_dim(routing, ("not-a-tensor",)) is routing
+
+    def test_returns_routing_unchanged_when_routing_empty(self):
+        routing: list[str] = []
+        assert _align_routing_to_leading_dim(routing, (torch.ones(4, 2),)) is routing
 
 
 class _AdapterAwareLoraLayer(_DummyLoraLayer):

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -6,9 +6,7 @@ from peft import LoraConfig, inject_adapter_in_model
 from torch import nn
 
 from agilerl.algorithms.core.llm_ops.fused_lora import (
-    _contiguous_groups,
     _get_cached_lora_layers,
-    _groups_for_leading_dim,
     clear_fused_adapter_routing,
     patch_lora_for_fused_forward,
     set_fused_adapter_routing,
@@ -102,38 +100,6 @@ class _ViewLinear(nn.Module):
 
     def forward(self, x):
         return _ViewMatmul.apply(x, self.weight)
-
-
-class TestContiguousGroups:
-    def test_runs_are_compressed_in_order(self):
-        assert _contiguous_groups(["a", "a", "b", "a"]) == [
-            ("a", 0, 2),
-            ("b", 2, 3),
-            ("a", 3, 4),
-        ]
-
-    def test_empty_routing_raises(self):
-        with pytest.raises(ValueError, match="at least one row"):
-            _contiguous_groups([])
-
-
-class TestGroupsForLeadingDim:
-    def test_matching_leading_dim_returns_groups_unchanged(self):
-        groups = [("actor", 0, 2), ("critic", 2, 4)]
-        assert _groups_for_leading_dim(groups, 4) is groups
-
-    def test_whole_multiple_scales_each_run(self):
-        # Row-major flatten of (batch=4, seq=3): sample i covers rows
-        # [3i, 3i + 3), so every run scales by 3.
-        groups = [("actor", 0, 2), ("critic", 2, 4)]
-        assert _groups_for_leading_dim(groups, 12) == [
-            ("actor", 0, 6),
-            ("critic", 6, 12),
-        ]
-
-    def test_non_divisible_leading_dim_raises(self):
-        with pytest.raises(ValueError, match="covers 4 rows"):
-            _groups_for_leading_dim([("actor", 0, 4)], 7)
 
 
 class TestRoutedForward:
@@ -320,6 +286,12 @@ class TestSetFusedAdapterRoutingGuards:
         with pytest.raises(ValueError, match="critc"):
             set_fused_adapter_routing(model, ["actor", "critc"])
 
+    def test_empty_routing_raises(self):
+        model = _build_model()
+        patch_lora_for_fused_forward(model)
+        with pytest.raises(ValueError, match="at least one row"):
+            set_fused_adapter_routing(model, [])
+
     def test_merged_adapters_raise(self):
         model = _build_model(adapters=("actor",))
         patch_lora_for_fused_forward(model)
@@ -336,7 +308,7 @@ class TestSetFusedAdapterRoutingGuards:
     def test_clear_on_unpatched_model_does_not_mask_the_patch_check(self):
         model = _build_model()
         clear_fused_adapter_routing(model)
-        assert not hasattr(model.proj, "_fused_adapter_groups")
+        assert not hasattr(model.proj, "_fused_adapter_routing")
         with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
             set_fused_adapter_routing(model, ["actor"])
 
@@ -359,7 +331,7 @@ class TestPatchLifecycle:
 
         assert len(model._fused_lora_layers) == 2
         set_fused_adapter_routing(model, ["actor"])
-        assert model.late.proj._fused_adapter_groups == [("actor", 0, 1)]
+        assert model.late.proj._fused_adapter_routing == ["actor"]
 
     def test_unpatch_restores_original_forward_and_state(self):
         model = _build_model()
@@ -372,7 +344,7 @@ class TestPatchLifecycle:
         unpatch_lora_for_fused_forward(model)
 
         assert "forward" not in model.proj.__dict__
-        assert not hasattr(model.proj, "_fused_adapter_groups")
+        assert not hasattr(model.proj, "_fused_adapter_routing")
         assert not hasattr(model, "_fused_lora_layers")
         assert torch.allclose(model(x), ref, atol=1e-6)
         with pytest.raises(RuntimeError, match="patch_lora_for_fused_forward"):
@@ -381,7 +353,7 @@ class TestPatchLifecycle:
     def test_unpatch_on_never_patched_model_is_noop(self):
         model = _build_model()
         unpatch_lora_for_fused_forward(model)
-        assert not hasattr(model.proj, "_fused_adapter_groups")
+        assert not hasattr(model.proj, "_fused_adapter_routing")
 
     def test_deepcopy_rebinds_routed_forward_to_the_copy(self):
         model = _build_model()
@@ -393,7 +365,7 @@ class TestPatchLifecycle:
         set_fused_adapter_routing(clone, ["actor", "critic"])
         _ = clone(x)
         # The original stays unrouted.
-        assert model.proj._fused_adapter_groups is None
+        assert model.proj._fused_adapter_routing is None
 
 
 class _CacheRejectingModel(nn.Module):

--- a/tests/test_algorithms/test_llms/test_ppo_llm.py
+++ b/tests/test_algorithms/test_llms/test_ppo_llm.py
@@ -1521,9 +1521,9 @@ class TestPPOLearnWithLiger:
         # the use_liger_loss=True branch in learn() from the
         # actor/critic Liger forwards.
         ppo._ppo_loss_liger = MagicMock(return_value=(fake_loss, fake_metrics))
-        # ``clear_fused_adapter_routing`` walks the actor — stub it.
+        # ``unset_fused_adapter_routing`` walks the actor — stub it.
         monkeypatch.setattr(
-            "agilerl.algorithms.ppo_llm.clear_fused_adapter_routing",
+            "agilerl.algorithms.ppo_llm.unset_fused_adapter_routing",
             lambda actor: None,
         )
 


### PR DESCRIPTION
## Summary

Reworks the fused multi-adapter LoRA forward (running actor + critic in one pass over a shared frozen base) to be self-contained instead of driving PEFT's `_mixed_batch_forward` through forward hooks. Also folds in the #584 leading-dim fix.

The previous implementation used a forward pre-hook to inject `adapter_names` into every LoRA layer (triggering PEFT's mixed-batch path), plus a *second* forward hook that cloned each base output so PEFT's in-place LoRA accumulation never touched a bitsandbytes view. Two layers of hook machinery, coupled to PEFT internals.

## What changed

Own the LoRA layer's forward instead of smuggling `adapter_names` into PEFT's. Our routing is always contiguous runs (`["actor"] * B + ["critic"] * B`), so a replacement forward stores the per-row routing (a plain list of adapter names) and, in each layer's forward, walks the contiguous same-adapter runs with `itertools.groupby` — slicing each run with `narrow()`, adding that adapter's LoRA delta **out of place**, and `cat`-ing the pieces.

Adding out of place (rather than accumulating into the base output) is what lets it run unchanged on a quantized (bitsandbytes) base, whose forward returns a view of a custom autograd `Function` that autograd forbids editing in place — so **the separate clone hook is deleted**. Routing still lives in persistent per-layer state, so gradient-checkpoint recomputation sees it exactly as before. A single-group routing (GRPO-style `["actor"] * B`) short-circuits to `base + delta`.

The public API — `patch_lora_for_fused_forward` / `unpatch` / `set_fused_adapter_routing` / `clear`, plus the per-row `routing` argument — is unchanged, so `base.py` and `ppo_llm.py` need no edits.

**Validation moved to set-time and got stronger.** Because we no longer route through PEFT's `_check_forward_args`, `set_fused_adapter_routing` now guards merged adapters and DoRA itself, plus a routing-length-vs-batch check at forward. Embedding adapters and LoRA variants (aLoRA) still delegate to PEFT's own mixed forward, so nothing regresses silently.

## #584 (flattening models) folded in

Layers that flatten `(batch, seq, hidden)` → `(batch * seq, hidden)` before their linears (OPT's MLP, MoE experts) keep contiguous adapter runs under a row-major flatten, so each run simply **covers `seq` times as many rows** — the forward sizes its slices by `leading_dim // len(routing)`, raising a clear error when that isn't a whole multiple. This replaces the previous `_align_routing_to_leading_dim` hook helper. Closes #584.

## Why

Clarity and maintainability: no dependency on PEFT's internal `_mixed_batch_forward` inference gate, no forward-pre-hook + clone-hook pair to reason about, clearer names, and stronger up-front validation. This is a behaviour-preserving refactor, not a performance change.

## Verification

Run on an L4 GPU against real PEFT (tests rewritten to use actual PEFT layers instead of kwarg-recording mocks):

- **`test_fused_lora.py` — 25/25**, covering: per-row output parity vs each adapter run alone, gradient parity vs separate per-adapter passes, gradient-checkpoint recompute survival, a view-returning custom `Function` base that reproduces the bitsandbytes in-place restriction, the flattening-layer (#584) path, embedding delegation, and patch-lifecycle / deepcopy behaviour.
- `tests/test_algorithms/test_llm_ops/` — 34 passed, 1 skipped.
- `test_core_base.py` — 295 passed; `test_ppo_llm.py` — 58 passed.
- Real bitsandbytes 4-bit smoke: routing parity within one fp16 ULP and a clean fused backward.
- `ruff check` / `ruff format` clean; pre-commit hooks pass.

