### PR TITLE
Fix GRPO crash on first learn() after eval: restore env batch state on eval_mode exit

### DIFF
--- a/agilerl/llm_envs/base.py
+++ b/agilerl/llm_envs/base.py
@@ -65,9 +65,6 @@ def apply_chat_template(
 class HuggingFaceGym(gym.Env, ABC):
     """Abstract base class for HuggingFace Gymnasium environments."""
 
-    #: Attributes holding the in-flight batch state. ``eval_mode`` snapshots
-    #: them on entry and restores them on exit, so the first post-eval training
-    #: ``step`` is scored against the train batch its completions came from.
     _batch_state_attrs: tuple[str, ...] = ()
 
     def __init__(

--- a/agilerl/llm_envs/base.py
+++ b/agilerl/llm_envs/base.py
@@ -65,6 +65,11 @@ def apply_chat_template(
 class HuggingFaceGym(gym.Env, ABC):
     """Abstract base class for HuggingFace Gymnasium environments."""
 
+    #: Attributes holding the in-flight batch state. ``eval_mode`` snapshots
+    #: them on entry and restores them on exit, so the first post-eval training
+    #: ``step`` is scored against the train batch its completions came from.
+    _batch_state_attrs: tuple[str, ...] = ()
+
     def __init__(
         self,
         train_dataset: Dataset,
@@ -145,16 +150,18 @@ class HuggingFaceGym(gym.Env, ABC):
         """Context manager to switch to evaluation mode."""
         self.dataloader = self.test_dataloader_iter
         self.evaluation_mode = True
-        last_tokenized_prompts = None
-        if hasattr(self, "last_tokenized_prompts"):
-            last_tokenized_prompts = copy.deepcopy(self.last_tokenized_prompts)
+        batch_state = {
+            attr: copy.deepcopy(getattr(self, attr))
+            for attr in self._batch_state_attrs
+            if hasattr(self, attr)
+        }
         try:
             yield
         finally:
             self.dataloader = self.train_dataloader_iter
             self.evaluation_mode = False
-            if last_tokenized_prompts is not None:
-                self.last_tokenized_prompts = last_tokenized_prompts
+            for attr, value in batch_state.items():
+                setattr(self, attr, value)
 
     @abstractmethod
     def create_collate_fn(

--- a/agilerl/llm_envs/reasoning.py
+++ b/agilerl/llm_envs/reasoning.py
@@ -38,6 +38,8 @@ class ReasoningGym(HuggingFaceGym):
     :type seed: int
     """
 
+    _batch_state_attrs = ("last_tokenized_prompts", "questions", "answers")
+
     def __init__(
         self,
         train_dataset: Dataset,
@@ -108,7 +110,7 @@ class ReasoningGym(HuggingFaceGym):
         """Decode the completions and evaluate the rewards."""
         total_rewards = []
         for idx, (group_completion, answer, question) in enumerate(
-            zip(completions, self.answers, self.questions, strict=False),
+            zip(completions, self.answers, self.questions, strict=True),
         ):
             completion_to_decode = group_completion[
                 :,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.0"
+version = "2.8.1.dev0"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/tests/test_wrappers/test_llm_envs.py
+++ b/tests/test_wrappers/test_llm_envs.py
@@ -554,6 +554,69 @@ class TestReasoningGymEvalMode:
         ):
             assert torch.equal(original, restored["input_ids"])
 
+    def test_eval_mode_restores_train_questions_and_answers(self):
+        """The first post-eval train step must be scored against train targets.
+
+        Regression test: eval used to leave ``questions``/``answers`` pointing
+        at the last test batch, so a remainder test batch shorter than the
+        train batch truncated the rewards and crashed ``learn()`` with a
+        rewards/completions length mismatch.
+        """
+        train_dataset = HFDataset.from_dict(
+            {
+                "question": [f"train question {i}?" for i in range(8)],
+                "answer": [f"train answer {i}" for i in range(8)],
+            },
+        )
+        # 6 test samples with batch size 4 -> the second test batch is a
+        # remainder of 2, shorter than the train batch.
+        test_dataset = HFDataset.from_dict(
+            {
+                "question": [f"test question {i}?" for i in range(6)],
+                "answer": [f"test answer {i}" for i in range(6)],
+            },
+        )
+        tokenizer = AutoTokenizer.from_pretrained(TINY_LLM_FIXTURE_PATH)
+        seen_answers = []
+
+        def recording_reward_fn(completion, answer, question):
+            seen_answers.append(answer)
+            return 1.0
+
+        env = ReasoningGym(
+            train_dataset=train_dataset,
+            test_dataset=test_dataset,
+            tokenizer=tokenizer,
+            reward_fn=recording_reward_fn,
+            conversation_template=DUMMY_CONVERSATION_TEMPLATE,
+            data_batch_size_per_gpu=4,
+        )
+        group_size = 8
+
+        def completions_for(prompt_batch):
+            return [torch.randint(0, 1000, (group_size, 356)) for _ in prompt_batch]
+
+        prompts = env.reset()
+        prompts, _ = env.step(completions_for(prompts))
+        train_answers = list(env.answers)
+        train_questions = list(env.questions)
+
+        # One eval pass as run by GRPO.test with eval_loop=1: reset scores the
+        # full first test batch, step advances to the remainder batch.
+        with env.eval_mode():
+            eval_prompts = env.reset()
+            _, eval_rewards = env.step(completions_for(eval_prompts))
+            assert eval_rewards.shape == (4, group_size)
+            assert len(env.answers) == 2
+
+        assert env.answers == train_answers
+        assert env.questions == train_questions
+
+        seen_answers.clear()
+        _, rewards = env.step(completions_for(prompts))
+        assert rewards.shape == (len(prompts), group_size)
+        assert set(seen_answers) == set(train_answers)
+
 
 class TestPreferenceGymInit:
     @pytest.mark.parametrize("use_accelerator", [True, False])

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.0"
+version = "2.8.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -2852,7 +2852,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/da/91/6bc8bb503dc259e46
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/b9/dc76d7716e04dc7b3427cae52eaa32bd20771382d4d1dd9f4538a9dd2086/llguidance-1.7.6-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:e70fa25ed550c2b50c2fd70baa9e2808b4ecb859d01e453bd5459aff62ba38c3", size = 2899993, upload-time = "2026-06-03T20:13:13.563Z" },
     { url = "https://files.pythonhosted.org/packages/1a/64/d74336f22242ef94356a456057d4ff1be7c1bc9c7dbc867171c6982a5512/llguidance-1.7.6-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:ceec951d29a74309984e3be0fe7f5f56c1362434cd937abd517b259a60908b1e", size = 3074809, upload-time = "2026-06-03T20:13:15.498Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e6/6b61cecced5233739bc85e463d68d67d4b4c29fb6f91bd12e6b6a65647e3/llguidance-1.7.6-cp39-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:e9f68206e0f3f89aceabb90aa1f8ed570db22fb7cb1fd9ebf96fa7727a65af55", size = 3603845, upload-time = "2026-06-03T20:13:19.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

GRPO reasoning runs crash on the first `learn()` after an evaluation window with:

```
ValueError: Rewards must provide one scalar per trajectory after collapse: got rewards=(16,) and completion_ids=(128, 1024).
```

(observed in production with `batch_size=16`, `group_size=8`, HPO enabled, `evo_steps=20`, `eval_loop=1` — the crash landed on the evolution boundary, which made it look like a tournament/mutation bug; it isn't.)

## Root cause

`HuggingFaceGym.eval_mode` saved/restored only `last_tokenized_prompts`. `ReasoningGym._get_next_batch` also mutates `self.questions` / `self.answers` on every batch, so after every eval those stayed pointing at the **last test batch loaded** (`GRPO.test` with `eval_loop=1` does `reset()` + `step()`, leaving the *second* test batch loaded on exit).

The first post-eval training step then generated completions from the restored **train** prompts (`B` groups) but `_decode_and_evaluate` scored them against the leaked **test** answers (`A` entries) via `zip(..., strict=False)`:

- `A == B` (full-size leaked batch): shapes match → **silently wrong rewards** for that step.
- `A < B` (remainder batch, `drop_last=False`): rewards truncated to `A × G` → the crash above (`A=2`, `G=8` → 16 rewards for 128 trajectories).

## Fix

- `eval_mode` now snapshots/restores a `_batch_state_attrs` tuple declared per subclass; `ReasoningGym` declares `("last_tokenized_prompts", "questions", "answers")`. This replaces the previous hardcoded `last_tokenized_prompts` special case.
- `_decode_and_evaluate` zips with `strict=True`, so any future completions/answers length skew fails loudly at the source instead of silently truncating.

Fixes `GRPO`, `LLMPPO`, and `LLMREINFORCE` reasoning flows alike (all run `test()` under `env.eval_mode()`).

## Evidence

**Regression unit test** (`test_eval_mode_restores_train_questions_and_answers`): eval pass ending on a 2-sample remainder batch, then a post-eval train step. Fails on the previous code (env holds the 2 leaked test answers), passes with the fix (rewards `(B, G)`, scored against train answers).

**End-to-end repro** with a real `GRPO` agent (vendored tiny Qwen2 fixture, CPU) mirroring `finetune_llm_reasoning`'s call sequence with `evaluation_interval=1` and a remainder test batch, scaled down from prod (`B=4`, `G=4`, `A=2`):

Before the fix — exact production failure:

```
ValueError: Rewards must provide one scalar per trajectory after collapse: got rewards=(8,) and completion_ids=(16, 30).
```

After the fix:

```
train step 1 OK: rewards=(4, 4) (16 scalars) for 16 trajectories
eval  after 1 OK: fitness=2.75
train step 2 OK: rewards=(4, 4) (16 scalars) for 16 trajectories
eval  after 2 OK: fitness=2.5
RUN COMPLETED WITHOUT ERROR
```

Full `tests/test_wrappers/test_llm_envs.py` (53) and `tests/test_utils/test_llm_utils.py` (228+) suites pass.


### GPU validation (L4, torch 2.11 cu130, transformers 5.11, vllm 0.23 — lockfile-matched venv)

The same e2e repro on CUDA (bf16 model, LoRA adapters, compiled fused-logprob path): the unfixed parent crashes with the identical `ValueError` on the first post-eval `learn()`; this branch completes all train/eval rounds.

Full LLM suite (`tests/test_algorithms/test_llms/ tests/test_wrappers/test_llm_envs.py tests/test_utils/test_llm_utils.py`, 940 tests) on this branch: **822 passed, 117 failed, 1 skipped** — every failure is `RuntimeError: Unable to JIT load the fused_adam op due to ninja not being installed` (box has no ninja/nvcc on PATH and a CUDA 12.9 toolkit vs cu130 torch; these pass in the CI cuda13 container). Re-running those test functions on the unfixed parent commit in the same environment reproduces the **identical 117-test failure set** (one order-dependent `pytest.warns` flake aside, which passes in isolation on both), i.e. all pre-existing environment failures, zero regressions from this change. All `llm_envs`/`llm_utils` tests, including the new regression test, pass on GPU.
