### PR TITLE
v2.8.1: Fix GRPO post-eval rewards mismatch

### DIFF
--- a/agilerl/llm_envs/base.py
+++ b/agilerl/llm_envs/base.py
@@ -65,6 +65,8 @@ def apply_chat_template(
 class HuggingFaceGym(gym.Env, ABC):
     """Abstract base class for HuggingFace Gymnasium environments."""
 
+    _batch_state_attrs: tuple[str, ...] = ()
+
     def __init__(
         self,
         train_dataset: Dataset,
@@ -145,16 +147,18 @@ class HuggingFaceGym(gym.Env, ABC):
         """Context manager to switch to evaluation mode."""
         self.dataloader = self.test_dataloader_iter
         self.evaluation_mode = True
-        last_tokenized_prompts = None
-        if hasattr(self, "last_tokenized_prompts"):
-            last_tokenized_prompts = copy.deepcopy(self.last_tokenized_prompts)
+        batch_state = {
+            attr: copy.deepcopy(getattr(self, attr))
+            for attr in self._batch_state_attrs
+            if hasattr(self, attr)
+        }
         try:
             yield
         finally:
             self.dataloader = self.train_dataloader_iter
             self.evaluation_mode = False
-            if last_tokenized_prompts is not None:
-                self.last_tokenized_prompts = last_tokenized_prompts
+            for attr, value in batch_state.items():
+                setattr(self, attr, value)
 
     @abstractmethod
     def create_collate_fn(

--- a/agilerl/llm_envs/reasoning.py
+++ b/agilerl/llm_envs/reasoning.py
@@ -38,6 +38,8 @@ class ReasoningGym(HuggingFaceGym):
     :type seed: int
     """
 
+    _batch_state_attrs = ("last_tokenized_prompts", "questions", "answers")
+
     def __init__(
         self,
         train_dataset: Dataset,
@@ -108,7 +110,7 @@ class ReasoningGym(HuggingFaceGym):
         """Decode the completions and evaluate the rewards."""
         total_rewards = []
         for idx, (group_completion, answer, question) in enumerate(
-            zip(completions, self.answers, self.questions, strict=False),
+            zip(completions, self.answers, self.questions, strict=True),
         ):
             completion_to_decode = group_completion[
                 :,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.0"
+version = "2.8.1.dev0"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.1.dev0"
+version = "2.8.1"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/tests/test_wrappers/test_llm_envs.py
+++ b/tests/test_wrappers/test_llm_envs.py
@@ -554,6 +554,69 @@ class TestReasoningGymEvalMode:
         ):
             assert torch.equal(original, restored["input_ids"])
 
+    def test_eval_mode_restores_train_questions_and_answers(self):
+        """The first post-eval train step must be scored against train targets.
+
+        Regression test: eval used to leave ``questions``/``answers`` pointing
+        at the last test batch, so a remainder test batch shorter than the
+        train batch truncated the rewards and crashed ``learn()`` with a
+        rewards/completions length mismatch.
+        """
+        train_dataset = HFDataset.from_dict(
+            {
+                "question": [f"train question {i}?" for i in range(8)],
+                "answer": [f"train answer {i}" for i in range(8)],
+            },
+        )
+        # 6 test samples with batch size 4 -> the second test batch is a
+        # remainder of 2, shorter than the train batch.
+        test_dataset = HFDataset.from_dict(
+            {
+                "question": [f"test question {i}?" for i in range(6)],
+                "answer": [f"test answer {i}" for i in range(6)],
+            },
+        )
+        tokenizer = AutoTokenizer.from_pretrained(TINY_LLM_FIXTURE_PATH)
+        seen_answers = []
+
+        def recording_reward_fn(completion, answer, question):
+            seen_answers.append(answer)
+            return 1.0
+
+        env = ReasoningGym(
+            train_dataset=train_dataset,
+            test_dataset=test_dataset,
+            tokenizer=tokenizer,
+            reward_fn=recording_reward_fn,
+            conversation_template=DUMMY_CONVERSATION_TEMPLATE,
+            data_batch_size_per_gpu=4,
+        )
+        group_size = 8
+
+        def completions_for(prompt_batch):
+            return [torch.randint(0, 1000, (group_size, 356)) for _ in prompt_batch]
+
+        prompts = env.reset()
+        prompts, _ = env.step(completions_for(prompts))
+        train_answers = list(env.answers)
+        train_questions = list(env.questions)
+
+        # One eval pass as run by GRPO.test with eval_loop=1: reset scores the
+        # full first test batch, step advances to the remainder batch.
+        with env.eval_mode():
+            eval_prompts = env.reset()
+            _, eval_rewards = env.step(completions_for(eval_prompts))
+            assert eval_rewards.shape == (4, group_size)
+            assert len(env.answers) == 2
+
+        assert env.answers == train_answers
+        assert env.questions == train_questions
+
+        seen_answers.clear()
+        _, rewards = env.step(completions_for(prompts))
+        assert rewards.shape == (len(prompts), group_size)
+        assert set(seen_answers) == set(train_answers)
+
 
 class TestPreferenceGymInit:
     @pytest.mark.parametrize("use_accelerator", [True, False])

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.1.dev0"
+version = "2.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.0"
+version = "2.8.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -2852,7 +2852,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/da/91/6bc8bb503dc259e46
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/b9/dc76d7716e04dc7b3427cae52eaa32bd20771382d4d1dd9f4538a9dd2086/llguidance-1.7.6-cp39-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:e70fa25ed550c2b50c2fd70baa9e2808b4ecb859d01e453bd5459aff62ba38c3", size = 2899993, upload-time = "2026-06-03T20:13:13.563Z" },
     { url = "https://files.pythonhosted.org/packages/1a/64/d74336f22242ef94356a456057d4ff1be7c1bc9c7dbc867171c6982a5512/llguidance-1.7.6-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:ceec951d29a74309984e3be0fe7f5f56c1362434cd937abd517b259a60908b1e", size = 3074809, upload-time = "2026-06-03T20:13:15.498Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e6/6b61cecced5233739bc85e463d68d67d4b4c29fb6f91bd12e6b6a65647e3/llguidance-1.7.6-cp39-abi3-manylinux_2_39_riscv64.whl", hash = "sha256:e9f68206e0f3f89aceabb90aa1f8ed570db22fb7cb1fd9ebf96fa7727a65af55", size = 3603845, upload-time = "2026-06-03T20:13:19.473Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release **v2.8.1** — merges `nightly` into `main`. Two commits on top of the released `v2.8.0`:

- **Fix GRPO crash on first `learn()` after eval** ([#590](https://github.com/AgileRL/AgileRL/pull/590)) — `HuggingFaceGym.eval_mode` restored only `last_tokenized_prompts`, leaving `ReasoningGym`'s `questions`/`answers` pointing at the last test batch. The first training step after each evaluation window then scored train completions against leaked test answers: silently wrong rewards in the common case, and a hard crash (`Rewards must provide one scalar per trajectory after collapse`) when a short remainder test batch skewed the reward tensor. Hit in prod on GRPO reasoning runs with HPO/evolution (Arena exp 1520). Fix generalizes the `eval_mode` snapshot to restore all in-flight batch state, and makes the reward zip `strict=True` so any future skew fails loudly at the source.
- **Release version 2.8.1** — bump `pyproject.toml` + `uv.lock` from `2.8.1.dev0` to the final `2.8.1`.

## Scope

- Patch release over `v2.8.0` — a single bugfix, no API changes.
- Fix touches `agilerl/llm_envs/{base,reasoning}.py` and its regression test only.
- Validated: deterministic unit test + e2e GPU repro (the exact remainder that crashed prod no longer crashes on the fixed code); `2.8.1.dev0` was published to PyPI for pre-release testing.
