### PR TITLE
Arena manifest Pydantic validation simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The simplest way to train an RL agent with AgileRL is through the
 [`LocalTrainer`](https://docs.agilerl.com/en/latest/trainers/index.html). Here is an example of training a DQN agent on the `LunarLander-v3` environment:
 
 ```python
-from agilerl.training.trainer import LocalTrainer
+from agilerl import LocalTrainer
 
 trainer = LocalTrainer(algorithm="DQN", environment="LunarLander-v3")
 population, fitnesses = trainer.train()

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -5,10 +5,20 @@ from __future__ import annotations
 import copy
 import logging
 from pathlib import Path
-from typing import Annotated, Any, Literal, get_args
+from typing import Annotated, Any, Literal
+
+import yaml
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    model_validator,
+)
+from typing_extensions import Self
 
 import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
-import yaml
 from agilerl.arena.models.algo import (
     ARENA_REGISTRY,
     AlgoSpecT,
@@ -20,15 +30,6 @@ from agilerl.arena.models.networks import (
     NetworkSpec,
 )
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    model_validator,
-)
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -302,32 +303,18 @@ class TrainingManifest(BaseModel):
     @model_validator(mode="after")
     def _process_manifest(self) -> Self:
         """Process the manifest for submission to Arena."""
-        # 'network' component of manifest corresponds to algorithm's underlying networks
+        # 'network' component of manifest corresponds to algorithm's underlying
+        # networks. `arch` is resolved server-side, so `net_config` is never
+        # populated on the algorithm spec here (the platform rejects a set
+        # `net_config`).
         algo_spec_cls = type(self.algorithm)
-        if self.network is not None:
-            # Resolve the raw dict into the algorithm's concrete NetworkSpec
-            # if `net_config` field is present in the algorithm spec.
-            net_config_field = algo_spec_cls.model_fields.get("net_config")
-            if net_config_field is not None:
-                # get the NetworkSpec class from the type annotation and validate
-                spec_cls: NetworkSpec = next(
-                    (
-                        t
-                        for t in get_args(net_config_field.annotation)
-                        if t is not type(None)
-                    ),
-                    None,
-                )
-                # Skip when the network has no resolvable `arch`
-                if spec_cls is not None and _network_has_arch(self.network):
-                    self.algorithm.net_config = spec_cls.model_validate(self.network)
-            # LLM algorithms expect a pretrained model
-            elif issubclass(algo_spec_cls, LLMAlgorithmSpec):
-                llm_network = FinetuningNetworkSpec.model_validate(self.network)
-                self.algorithm.pretrained_model_name_or_path = (
-                    llm_network.pretrained_model_name_or_path
-                )
-                self.algorithm.max_model_len = llm_network.max_context_length
+        # LLM algorithms expect a pretrained model
+        if self.network is not None and issubclass(algo_spec_cls, LLMAlgorithmSpec):
+            llm_network = FinetuningNetworkSpec.model_validate(self.network)
+            self.algorithm.pretrained_model_name_or_path = (
+                llm_network.pretrained_model_name_or_path
+            )
+            self.algorithm.max_model_len = llm_network.max_context_length
 
         if (
             issubclass(algo_spec_cls, LLMAlgorithmSpec)
@@ -341,13 +328,7 @@ class TrainingManifest(BaseModel):
             raise ValueError(msg)
 
         recurrent = bool(getattr(self.algorithm, "recurrent", False))
-        net_config = getattr(self.algorithm, "net_config", None)
-        if net_config is not None:
-            simba = bool(getattr(net_config, "simba", False))
-        elif isinstance(self.network, dict):
-            simba = bool(self.network.get("simba", False))
-        else:
-            simba = False
+        simba = isinstance(self.network, dict) and bool(self.network.get("simba"))
         if recurrent and simba:
             msg = (
                 "`simba` and `recurrent` cannot both be set: a network cannot use "

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -25,36 +25,10 @@ from agilerl.arena.models.algo import (
     LLMAlgorithmSpec,
 )
 from agilerl.arena.models.hpo import MutationSpec, TournamentSelectionSpec
-from agilerl.arena.models.networks import (
-    FinetuningNetworkSpec,
-    NetworkSpec,
-)
+from agilerl.arena.models.networks import FinetuningNetworkSpec
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
 
 logger = logging.getLogger(__name__)
-
-_MANIFEST_ENCODER_ARCHS = ("mlp", "cnn", "lstm", "simba", "multiinput")
-
-_ARCH_TO_NAME: dict[str, str] = {
-    "mlp": "EvolvableMLP",
-    "cnn": "EvolvableCNN",
-    "simba": "EvolvableSimBa",
-    "multiinput": "EvolvableMultiInput",
-    "lstm": "EvolvableLSTM",
-}
-
-
-def _normalize_network_for_platform(network: dict[str, Any]) -> None:
-    """Move ``arch`` from encoder_config to network top level and add ``name``."""
-    encoder = network.get("encoder_config")
-    if isinstance(encoder, dict):
-        arch = encoder.pop("arch", None)
-        if arch:
-            network.setdefault("arch", arch)
-
-    arch = network.get("arch")
-    if arch and "name" not in network:
-        network["name"] = _ARCH_TO_NAME.get(arch, "EvolvableMLP")
 
 
 def _ensure_platform_run_spec_keys(data: dict[str, Any]) -> None:
@@ -65,54 +39,6 @@ def _ensure_platform_run_spec_keys(data: dict[str, Any]) -> None:
     """
     for key in ("mutation", "tournament_selection", "network"):
         data.setdefault(key, {})
-
-    if data["network"]:
-        _normalize_network_for_platform(data["network"])
-
-
-def _normalize_network_arch(
-    data: dict[str, Any] | BaseModel,
-) -> dict[str, Any] | BaseModel:
-    """Move a top-level ``arch`` key into ``encoder_config.arch`` for proper
-    Pydantic validation client-side. If missing, resolution is deferred to the server.
-    """
-    # If passing a network spec we already have the correct structure
-    if not isinstance(data, dict):
-        return data
-
-    data = dict(data)
-    top_level_arch: str | None = data.pop("arch", None)
-    encoder_config = data.get("encoder_config")
-    nested_arch: str | None = (
-        encoder_config.get("arch") if isinstance(encoder_config, dict) else None
-    )
-    arch = top_level_arch or nested_arch
-
-    if encoder_config is None:
-        data["encoder_config"] = {"arch": arch}
-    else:
-        data["encoder_config"] = dict(encoder_config)
-        data["encoder_config"].setdefault("arch", arch)
-
-    return data
-
-
-def _network_has_arch(network: dict[str, Any]) -> bool:
-    """Whether a raw network dict declares a resolvable ``arch``.
-
-    Checks both the network root and ``encoder_config`` (the two places a
-    manifest may place it). Used to decide whether the network section can be
-    validated client-side, or must be deferred to the server.
-
-    :param network: Raw network section dict.
-    :type network: dict[str, Any]
-    :returns: ``True`` if ``arch`` is present at either location.
-    :rtype: bool
-    """
-    if network.get("arch"):
-        return True
-    encoder_config = network.get("encoder_config")
-    return isinstance(encoder_config, dict) and bool(encoder_config.get("arch"))
 
 
 def _resolve_algorithm(data: Any) -> AlgoSpecT:
@@ -167,12 +93,11 @@ def _coerce_environment(data: Any) -> dict[str, Any]:
 
 
 def _resolve_network(data: dict[str, Any] | BaseModel) -> dict[str, Any]:
-    """Normalise the network section to a validated dict with all defaults filled in.
+    """Normalise the network section to a plain dict for manifest storage.
 
-    Raw dicts are validated through :class:`NetworkSpec` so that default values are included in the serialized output.
-
-    If the raw dict has no resolvable ``arch`` (at the network root or nested
-    in ``encoder_config``), the network section is returned unchanged.
+    The encoder architecture is resolved server-side, so the network section is
+    passed through untouched. Only the LLM finetuning spec is materialised
+    client-side, since its fields feed the algorithm section.
 
     :param data: Network config dict or spec instance.
     :type data: Any
@@ -181,23 +106,11 @@ def _resolve_network(data: dict[str, Any] | BaseModel) -> dict[str, Any]:
     """
     if isinstance(data, FinetuningNetworkSpec):
         return data.model_dump(mode="json")
-    if isinstance(data, BaseModel):
-        data_dict = data.model_dump()
-        if isinstance(data, NetworkSpec):
-            data_dict["encoder_config"]["arch"] = data.encoder_config.arch
-        return data_dict
-
     if isinstance(data, dict) and "pretrained_model_name_or_path" in data:
         return FinetuningNetworkSpec.model_validate(data).model_dump(mode="json")
-
-    if isinstance(data, dict) and not _network_has_arch(data):
-        return data
-
-    normalized = _normalize_network_arch(data)
-    spec = NetworkSpec.model_validate(normalized)
-    data_dict = spec.model_dump()
-    data_dict["encoder_config"]["arch"] = spec.encoder_config.arch
-    return data_dict
+    if isinstance(data, BaseModel):
+        return data.model_dump()
+    return data
 
 
 def _serialize_algorithm(spec: AlgoSpecT) -> dict[str, Any]:

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -7,7 +7,16 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
+import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
 import yaml
+from agilerl.arena.models.algo import (
+    ARENA_REGISTRY,
+    AlgoSpecT,
+    LLMAlgorithmSpec,
+)
+from agilerl.arena.models.hpo import MutationSpec, TournamentSelectionSpec
+from agilerl.arena.models.networks import FinetuningNetworkSpec
+from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
 from pydantic import (
     AliasChoices,
     BaseModel,
@@ -17,16 +26,6 @@ from pydantic import (
     model_validator,
 )
 from typing_extensions import Self
-
-import agilerl.arena.models.algorithms as _arena_algorithms  # noqa: F401
-from agilerl.arena.models.algo import (
-    ARENA_REGISTRY,
-    AlgoSpecT,
-    LLMAlgorithmSpec,
-)
-from agilerl.arena.models.hpo import MutationSpec, TournamentSelectionSpec
-from agilerl.arena.models.networks import FinetuningNetworkSpec
-from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
 
 logger = logging.getLogger(__name__)
 

--- a/agilerl-arena/pyproject.toml
+++ b/agilerl-arena/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl-arena"
-version = "0.1.0"
+version = "0.1.1"
 description = "Arena Platform Client Library and CLI."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -23,7 +23,6 @@ from agilerl.arena.models.algorithms.dqn import DQNSpec
 from agilerl.arena.models.env import EnvSpec, LLMEnvType
 from agilerl.arena.models.manifest import (
     _coerce_environment,
-    _normalize_network_arch,
     _resolve_algorithm,
     _resolve_network,
 )
@@ -163,22 +162,6 @@ def test_get_validated_accepts_env_spec_objects() -> None:
         "num_envs": 8,
         "version": "v9",
     }
-
-
-def test_get_validated_normalizes_network_for_platform() -> None:
-    payload = TrainingManifest.get_validated(
-        _manifest(
-            network={
-                "arch": "mlp",
-                "encoder_config": {"hidden_size": [64], "activation": "ReLU"},
-                "head_config": {"hidden_size": [64], "activation": "ReLU"},
-            }
-        )
-    )
-    network = payload["network"]
-    assert network["arch"] == "mlp"
-    assert network["name"] == "EvolvableMLP"
-    assert "arch" not in network["encoder_config"]
 
 
 def test_get_validated_passes_network_raw_when_arch_missing() -> None:
@@ -345,18 +328,6 @@ def test_coerce_environment_rejects_invalid_type() -> None:
         _coerce_environment("not-an-env")
 
 
-def test_normalize_network_arch_passthrough_for_spec() -> None:
-    spec = MlpSpec(hidden_size=[64])
-    assert _normalize_network_arch(spec) is spec
-
-
-def test_normalize_network_arch_creates_encoder_from_top_level_arch() -> None:
-    normalized = _normalize_network_arch(
-        {"arch": "mlp", "head_config": {"hidden_size": [64]}}
-    )
-    assert normalized["encoder_config"]["arch"] == "mlp"
-
-
 def test_resolve_network_accepts_finetuning_spec() -> None:
     spec = FinetuningNetworkSpec(
         pretrained_model_name_or_path="gpt2",
@@ -378,4 +349,5 @@ def test_python_manifest_accepts_network_spec_object() -> None:
         }
     )
     assert manifest.network is not None
-    assert manifest.network["encoder_config"]["arch"] == "mlp"
+    assert manifest.network["encoder_config"]["hidden_size"] == [64]
+    assert "arch" not in manifest.network["encoder_config"]

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,6 +6,13 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
+
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -25,12 +32,6 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -116,8 +117,9 @@ def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
 
 
 def test_known_field_names_includes_all_alias_forms() -> None:
-    from agilerl.arena.models.manifest import _known_field_names
     from pydantic import AliasChoices, BaseModel, Field
+
+    from agilerl.arena.models.manifest import _known_field_names
 
     class _M(BaseModel):
         plain: int = Field(default=0)
@@ -187,6 +189,26 @@ def test_get_validated_passes_network_raw_when_arch_missing() -> None:
     }
     payload = TrainingManifest.get_validated(_manifest(network=network))
     assert payload["network"] == network
+
+
+def test_net_config_never_set_when_arch_present() -> None:
+    """`arch` is resolved server-side, so `net_config` must never be populated on
+    the algorithm spec (a set `net_config` is rejected server-side).
+    """
+    network = {
+        "arch": "mlp",
+        "encoder_config": {"hidden_size": [64], "activation": "ReLU"},
+        "head_config": {"hidden_size": [64], "activation": "ReLU"},
+    }
+    manifest = TrainingManifest.get_validated(
+        _manifest(algorithm={"name": "DQN"}, network=network), mode="python"
+    )
+    assert manifest.algorithm.net_config is None
+
+    payload = TrainingManifest.get_validated(
+        _manifest(algorithm={"name": "DQN"}, network=network)
+    )
+    assert "net_config" not in payload["algorithm"]
 
 
 def test_get_validated_raises_for_unknown_algorithm() -> None:

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -6,13 +6,6 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from generate_arena_manifests import (
-    arena_algorithm_names,
-    generate_arena_manifests,
-    write_arena_manifest,
-)
-from pydantic import ValidationError
-
 from agilerl.arena.models import (
     ARENA_REGISTRY,
     ReplayBufferSpec,
@@ -31,6 +24,12 @@ from agilerl.arena.models.networks import (
     MlpSpec,
     QNetworkSpec,
 )
+from generate_arena_manifests import (
+    arena_algorithm_names,
+    generate_arena_manifests,
+    write_arena_manifest,
+)
+from pydantic import ValidationError
 
 
 def _manifest(**sections) -> dict:
@@ -116,9 +115,8 @@ def test_collect_unknown_fields_ignores_non_dict_raw() -> None:
 
 
 def test_known_field_names_includes_all_alias_forms() -> None:
-    from pydantic import AliasChoices, BaseModel, Field
-
     from agilerl.arena.models.manifest import _known_field_names
+    from pydantic import AliasChoices, BaseModel, Field
 
     class _M(BaseModel):
         plain: int = Field(default=0)

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from click.testing import CliRunner
+
 from agilerl.arena.cli_manifest import (
     _manifest_spec_to_click_option,
     _parse_json_cli_value,
@@ -18,7 +20,6 @@ from agilerl.arena.cli_manifest import (
 from agilerl.arena.client import ArenaClient
 from agilerl.arena.config import CommandConfig
 from agilerl.arena.exceptions import ArenaValidationError
-from click.testing import CliRunner
 
 
 def _command_config() -> CommandConfig:
@@ -607,8 +608,8 @@ class TestArenaSimbaRecurrentConflict:
     ``agilerl.models.manifest.TrainingManifest._process_manifest``.
     """
 
-    def test_deferred_raises(self) -> None:
-        """No ``arch``: the network section stays a raw dict when the conflict fires."""
+    def test_simba_and_recurrent_raises(self) -> None:
+        """A top-level ``simba`` flag with ``recurrent`` is a contradiction."""
         from agilerl.arena.models.manifest import TrainingManifest
 
         raw = {
@@ -619,23 +620,8 @@ class TestArenaSimbaRecurrentConflict:
         with pytest.raises(ValueError, match="cannot both be set"):
             TrainingManifest.model_validate(raw)
 
-    def test_eager_raises(self) -> None:
-        """``arch: simba`` declared: ``net_config`` is a validated ``NetworkSpec``."""
-        from agilerl.arena.models.manifest import TrainingManifest
-
-        raw = {
-            "algorithm": {"name": "PPO", "recurrent": True},
-            "environment": {"name": "merge-env", "version": "v1"},
-            "network": {
-                "arch": "simba",
-                "encoder_config": {"hidden_size": 128, "num_blocks": 2},
-                "head_config": {"hidden_size": [64]},
-            },
-        }
-        with pytest.raises(ValueError, match="cannot both be set"):
-            TrainingManifest.model_validate(raw)
-
     def test_only_simba_validates(self) -> None:
+        """Either request on its own is fine; only the combination is rejected."""
         from agilerl.arena.models.manifest import TrainingManifest
 
         raw = {
@@ -645,28 +631,6 @@ class TestArenaSimbaRecurrentConflict:
         }
         manifest = TrainingManifest.model_validate(raw)
         assert manifest.network.get("simba") is True
-
-    def test_only_recurrent_validates(self) -> None:
-        from agilerl.arena.models.manifest import TrainingManifest
-
-        raw = {
-            "algorithm": {"name": "PPO", "recurrent": True},
-            "environment": {"name": "merge-env", "version": "v1"},
-            "network": {"head_config": {"hidden_size": [64]}},
-        }
-        manifest = TrainingManifest.model_validate(raw)
-        assert manifest.algorithm.recurrent is True
-
-    def test_neither_validates(self) -> None:
-        from agilerl.arena.models.manifest import TrainingManifest
-
-        raw = {
-            "algorithm": {"name": "PPO"},
-            "environment": {"name": "merge-env", "version": "v1"},
-            "network": {"head_config": {"hidden_size": [64]}},
-        }
-        manifest = TrainingManifest.model_validate(raw)
-        assert manifest.algorithm.recurrent is False
 
 
 class TestAttachManifestTree:

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -565,7 +565,7 @@ class TestManifestCommandCallbackBinary:
 
 
 class TestArenaArchOptional:
-    def test_arch_present_validates(self) -> None:
+    def test_arch_present_passes_network_raw(self) -> None:
         from agilerl.arena.models.manifest import TrainingManifest
 
         raw = {
@@ -578,10 +578,9 @@ class TestArenaArchOptional:
             },
         }
         out = TrainingManifest.get_validated(raw, mode="json")
-        # _ensure_platform_run_spec_keys promotes arch to the network root
-        # (and adds `name`) for the Arena platform run-spec payload shape.
-        assert out["network"]["arch"] == "mlp"
-        assert "arch" not in out["network"]["encoder_config"]
+        # `arch` is resolved server-side: the network section is passed through
+        # untouched, with no promotion or `name` injection.
+        assert out["network"] == raw["network"]
 
     def test_arch_absent_passes_network_raw(self) -> None:
         from agilerl.arena.models.manifest import TrainingManifest

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
-from click.testing import CliRunner
-
 from agilerl.arena.cli_manifest import (
     _manifest_spec_to_click_option,
     _parse_json_cli_value,
@@ -20,6 +18,7 @@ from agilerl.arena.cli_manifest import (
 from agilerl.arena.client import ArenaClient
 from agilerl.arena.config import CommandConfig
 from agilerl.arena.exceptions import ArenaValidationError
+from click.testing import CliRunner
 
 
 def _command_config() -> CommandConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ llm = [
     "vllm>=0.23; sys_platform == 'linux'",
 ]
 arena = [
-    "agilerl-arena==0.1.0",
+    "agilerl-arena==0.1.1",
 ]
 all = [
     "swig>=4.4.1; sys_platform != 'win32'",
@@ -70,7 +70,7 @@ all = [
     "peft==0.19.1",
     "transformers==5.11.0",
     "vllm>=0.23; sys_platform == 'linux'",
-    "agilerl-arena==0.1.0",
+    "agilerl-arena==0.1.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.1"
+version = "2.8.2"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.1"
+version = "2.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ docs = [
 
 [[package]]
 name = "agilerl-arena"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "agilerl-arena" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
  Arena resolves the network encoder architecture server-side, so the client should never populate architecture-derived fields on a training manifest. Two problems followed from it doing so:

  1. TrainingManifest._process_manifest resolved the manifest's network section into the algorithm's concrete NetworkSpec and assigned it to algorithm.net_config whenever a resolvable arch was present. A set net_config is rejected server-side, so these manifests failed on submission.
  2. The client did a pile of arch normalization/validation (_normalize_network_arch, _network_has_arch, _normalize_network_for_platform, _ARCH_TO_NAME) that only mattered because it was reasoning about arch at all.

  This PR makes the client stop reasoning about arch entirely. The network section is passed through untouched for the server to resolve.

###  Changes

  - Never set net_config. Dropped the net_config-resolution branch in _process_manifest. Since net_config defaults to None and payloads are dumped with exclude_none=True, it no longer reaches the server.
  - simba/recurrent guard simplified. The client-side contradiction check now reads only the top-level simba flag of the network section against recurrent on the algorithm — no arch inspection.
  - Removed all arch processing. _resolve_network is now a raw passthrough (only the LLM FinetuningNetworkSpec is still materialised client-side, since its fields feed the algorithm section). Deleted _normalize_network_arch, _network_has_arch, _normalize_network_for_platform,
  _ARCH_TO_NAME, and the unused _MANIFEST_ENCODER_ARCHS. An arch-bearing manifest is now submitted as-is.
  - Version bumps. agilerl-arena 0.1.0 → 0.1.1 (+ the arena/all extra pins in the root pyproject.toml); agilerl 2.8.1 → 2.8.2. uv.lock updated accordingly.