### PR TITLE
Fix fp16-checkpoint dtype mismatch in fused lm_head matmuls

### DIFF
--- a/agilerl/algorithms/core/llm_ops/fused_logprobs.py
+++ b/agilerl/algorithms/core/llm_ops/fused_logprobs.py
@@ -45,10 +45,7 @@ def _fused_logprob_chunk(
     :rtype: torch.Tensor
     """
     if h_chunk.dtype != lm_head_weight.dtype:
-        # Hidden and lm_head dtypes can diverge — e.g. an fp16 checkpoint under
-        # the bf16 autocast, where the final norm promotes hidden states to
-        # fp32 while the lm_head weight keeps the checkpoint dtype. The matmul
-        # requires matching operands; promote so neither side is downcast.
+        # fp16 checkpoint under bf16 autocast: fp32 hidden, fp16 head; promote to match.
         compute_dtype = torch.promote_types(h_chunk.dtype, lm_head_weight.dtype)
         h_chunk = h_chunk.to(compute_dtype)
         lm_head_weight = lm_head_weight.to(compute_dtype)

--- a/agilerl/algorithms/core/llm_ops/fused_logprobs.py
+++ b/agilerl/algorithms/core/llm_ops/fused_logprobs.py
@@ -44,6 +44,14 @@ def _fused_logprob_chunk(
     :return: ``(chunk_rows,)`` per-token logprobs.
     :rtype: torch.Tensor
     """
+    if h_chunk.dtype != lm_head_weight.dtype:
+        # Hidden and lm_head dtypes can diverge — e.g. an fp16 checkpoint under
+        # the bf16 autocast, where the final norm promotes hidden states to
+        # fp32 while the lm_head weight keeps the checkpoint dtype. The matmul
+        # requires matching operands; promote so neither side is downcast.
+        compute_dtype = torch.promote_types(h_chunk.dtype, lm_head_weight.dtype)
+        h_chunk = h_chunk.to(compute_dtype)
+        lm_head_weight = lm_head_weight.to(compute_dtype)
     logits = h_chunk @ lm_head_weight.t()
     if lm_head_bias is not None:
         logits = logits + lm_head_bias

--- a/agilerl/algorithms/core/llm_ops/fused_loss.py
+++ b/agilerl/algorithms/core/llm_ops/fused_loss.py
@@ -347,12 +347,7 @@ class LigerFusedLinearPolicyLossFunction(LigerFusedLinearPPOBase):
             # selective-logp kernel that doesn't compose with the grad_and_value
             # transform below, so inline the numerically identical 0.7.0 math.
             if input_chunk.dtype != weight_local.dtype:
-                # Hidden and lm_head dtypes can diverge — e.g. an fp16
-                # checkpoint under the bf16 autocast, where the final norm
-                # promotes hidden states to fp32 while the lm_head weight
-                # keeps the checkpoint dtype. The matmul requires matching
-                # operands; promote so neither side is downcast (grads still
-                # flow back to the original-dtype leaves through the cast).
+                # fp16 checkpoint under bf16 autocast: fp32 hidden, fp16 head.
                 compute_dtype = torch.promote_types(
                     input_chunk.dtype, weight_local.dtype
                 )

--- a/agilerl/algorithms/core/llm_ops/fused_loss.py
+++ b/agilerl/algorithms/core/llm_ops/fused_loss.py
@@ -346,6 +346,18 @@ class LigerFusedLinearPolicyLossFunction(LigerFusedLinearPPOBase):
             # Liger 0.8.0 rewrote ``LigerFusedLinearPPOBase.chunk_forward`` into a
             # selective-logp kernel that doesn't compose with the grad_and_value
             # transform below, so inline the numerically identical 0.7.0 math.
+            if input_chunk.dtype != weight_local.dtype:
+                # Hidden and lm_head dtypes can diverge — e.g. an fp16
+                # checkpoint under the bf16 autocast, where the final norm
+                # promotes hidden states to fp32 while the lm_head weight
+                # keeps the checkpoint dtype. The matmul requires matching
+                # operands; promote so neither side is downcast (grads still
+                # flow back to the original-dtype leaves through the cast).
+                compute_dtype = torch.promote_types(
+                    input_chunk.dtype, weight_local.dtype
+                )
+                input_chunk = input_chunk.to(compute_dtype)
+                weight_local = weight_local.to(compute_dtype)
             logits = torch.matmul(input_chunk, weight_local.t())
             if bias_local is not None:
                 logits = logits + bias_local

--- a/tests/test_algorithms/test_core_base.py
+++ b/tests/test_algorithms/test_core_base.py
@@ -2224,6 +2224,37 @@ class TestLogprobsFromHiddenFused:
         assert result.dtype == torch.bfloat16
         assert torch.equal(result, ref)
 
+    def test_mismatched_hidden_and_lm_head_dtypes(self) -> None:
+        """An fp16 checkpoint under the bf16 autocast yields fp32 hidden
+        states with an fp16 lm_head weight; the fused matmul promotes to a
+        common dtype instead of crashing, matching the pre-upcast reference
+        exactly (fp16 -> fp32 casts are lossless).
+        """
+        torch.manual_seed(3)
+        B, T, H, V = 2, 5, 32, 2048
+        hidden = torch.randn(B, T, H, dtype=torch.float32)
+        weight = (torch.randn(V, H) * 0.02).to(torch.float16)
+        targets = torch.randint(0, V, (B, T))
+
+        result = LLMAlgorithm._logprobs_from_hidden_fused(
+            hidden,
+            weight,
+            None,
+            targets,
+            temperature=0.9,
+            cast_to_fp32=True,
+        )
+        ref = LLMAlgorithm._logprobs_from_hidden_fused(
+            hidden,
+            weight.float(),
+            None,
+            targets,
+            temperature=0.9,
+            cast_to_fp32=True,
+        )
+        assert result.dtype == torch.float32
+        assert torch.equal(result, ref)
+
     def test_chunked_matches_unchunked(self) -> None:
         """Output is independent of ``chunk_rows`` — covers the loop
         boundary path.

--- a/tests/test_algorithms/test_llm_ops/test_fused_logprobs.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_logprobs.py
@@ -84,6 +84,45 @@ class TestFusedLogprobChunkDispatch:
         assert torch.allclose(again, expected)
 
 
+class TestMixedDtypeOperands:
+    """An fp16 checkpoint under the bf16 autocast reaches the fused matmul
+    with fp32 hidden states and an fp16 lm_head weight; the kernel must
+    promote to a common dtype rather than crash on the operand mismatch.
+    """
+
+    def test_chunk_promotes_mismatched_dtypes_to_common_dtype(self):
+        torch.manual_seed(0)
+        h = torch.randn(4, 8)  # fp32 hidden (autocast-promoted final norm)
+        w = (torch.randn(16, 8) * 0.02).to(torch.float16)  # checkpoint-dtype head
+        bias = torch.randn(16).to(torch.float16)
+        targets = torch.randint(0, 16, (4,))
+
+        out = _fused_logprob_chunk(h, w, bias, targets, 1.0, True)
+        # fp16 -> fp32 casts are exact, so promoting inside the kernel must
+        # bit-match computing with pre-upcast operands.
+        expected = _fused_logprob_chunk(h, w.float(), bias.float(), targets, 1.0, True)
+        assert out.dtype == torch.float32
+        assert torch.equal(out, expected)
+
+    def test_autograd_function_backward_with_mismatched_dtypes(self):
+        torch.manual_seed(0)
+        hidden = torch.randn(2, 4, 8, requires_grad=True)
+        weight = (torch.randn(16, 8) * 0.02).to(torch.float16).requires_grad_(True)
+        targets = torch.randint(0, 16, (2, 4))
+
+        logps = FusedLinearLogProbsFunction.apply(
+            hidden, weight, None, targets, 1.0, True, 3
+        )
+        logps.sum().backward()
+        # Gradients land on the leaves in their own dtypes.
+        assert hidden.grad is not None
+        assert hidden.grad.dtype == torch.float32
+        assert weight.grad is not None
+        assert weight.grad.dtype == torch.float16
+        assert hidden.grad.abs().sum() > 0
+        assert weight.grad.abs().sum() > 0
+
+
 def test_fused_logprob_backward_skips_when_no_inputs_require_grad():
     hidden = torch.randn(1, 4, 8)
     weight = torch.randn(16, 8)

--- a/tests/test_algorithms/test_llm_ops/test_fused_logprobs.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_logprobs.py
@@ -86,8 +86,8 @@ class TestFusedLogprobChunkDispatch:
 
 class TestMixedDtypeOperands:
     """An fp16 checkpoint under the bf16 autocast reaches the fused matmul
-    with fp32 hidden states and an fp16 lm_head weight; the kernel must
-    promote to a common dtype rather than crash on the operand mismatch.
+    with fp32 hidden states and an fp16 lm_head weight; the kernel
+    promotes to a common dtype rather than crashing on the operand mismatch.
     """
 
     def test_chunk_promotes_mismatched_dtypes_to_common_dtype(self):

--- a/tests/test_algorithms/test_llm_ops/test_fused_loss.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_loss.py
@@ -1000,6 +1000,45 @@ class TestLigerFusedLinearPolicyLossFunction:
         assert hidden.grad.abs().sum() > 0
         assert weight.grad.abs().sum() > 0
 
+    def test_backward_with_mismatched_hidden_and_weight_dtypes(self) -> None:
+        """An fp16 checkpoint under the bf16 autocast reaches the chunked
+        matmul with fp32 hidden states and an fp16 lm_head weight; the chunk
+        promotes to a common dtype and gradients land on the leaves in their
+        own dtypes.
+        """
+        B, T, V, H = 2, 4, 16, 8
+        hidden, weight_fp32, ids, mask, adv, old_lp, _ = self._build_inputs(
+            B, T, V, H, with_ref=False
+        )
+        weight = weight_fp32.detach().to(torch.float16).requires_grad_(True)
+        loss, _ = LigerFusedLinearPolicyLossFunction.apply(
+            hidden,
+            weight,
+            ids,
+            mask,
+            adv,
+            None,
+            None,
+            old_lp,
+            0.0,
+            0.2,
+            0.2,
+            1.0,
+            False,
+            1,
+            None,
+            None,
+            None,
+        )
+        loss.backward()
+        assert torch.isfinite(loss)
+        assert hidden.grad is not None
+        assert hidden.grad.dtype == torch.float32
+        assert weight.grad is not None
+        assert weight.grad.dtype == torch.float16
+        assert hidden.grad.abs().sum() > 0
+        assert weight.grad.abs().sum() > 0
+
     def test_turn_mode_forward_runs(self) -> None:
         """Smoke test for the turn-mode branch in the autograd Function."""
         B, T, V, H = 2, 6, 16, 8

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -3549,31 +3549,6 @@ class TestGRPOLearn:
                 sleep_mode=True,
                 use_liger_loss=use_liger_loss,
             )
-        if use_vllm and use_liger_loss:
-            pytest.skip("Skip vLLM learn path with liger in this mocked-call test.")
-        mock_llm_instance = make_mock_vllm_instance(vllm.LLM)
-        llm_patch_ctx = (
-            patch("agilerl.algorithms.core.base.LLM", return_value=mock_llm_instance)
-            if use_vllm
-            else nullcontext()
-        )
-        with llm_patch_ctx:
-            grpo = grpo_factory(
-                accelerator_factory,
-                model_factory,
-                config,
-                use_deepspeed_optimizer,
-                vocab_size,
-                input_size,
-                max_tokens,
-                group_size,
-                use_separate_reference_adapter,
-                use_vllm,
-                pretrained_model_name_or_path,
-                micro_batch_size_per_gpu,
-                sleep_mode=True,
-                use_liger_loss=use_liger_loss,
-            )
         completions = [
             torch.randint(
                 0,

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -3949,6 +3949,60 @@ class TestGRPOLearn:
         assert set(metrics.keys()) == {"loss", "kl", "completion_length"}
         grpo.clean_up()
 
+    @pytest.mark.gpu
+    def test_grpo_learn_with_natively_loaded_fp16_checkpoint(self):
+        """A checkpoint declaring fp16 trains without an explicit recast.
+
+        transformers honors the checkpoint's ``dtype`` (the tiny_llm fixture
+        stores float16), and under the bf16 autocast in ``_amp_ctx`` the final
+        norm promotes hidden states to fp32 while the lm_head weight stays
+        fp16 — the fused logprob matmul must reconcile the operand dtypes.
+        """
+        if not torch.cuda.is_available():
+            pytest.skip("The autocast/checkpoint dtype mismatch requires CUDA.")
+        from transformers import AutoModelForCausalLM
+
+        actor = AutoModelForCausalLM.from_pretrained(
+            TINY_LLM_FIXTURE_PATH, attn_implementation="sdpa"
+        )
+        # The fixture must keep declaring fp16 for this regression test to
+        # exercise the mixed-dtype path.
+        assert next(actor.parameters()).dtype == torch.float16
+
+        vocab_size, input_size, max_tokens, group_size = 1000, 5, 10, 2
+        grpo = GRPO(
+            actor_network=actor,
+            lr=1e-5,
+            pad_token_id=vocab_size - 1,
+            pad_token="<pad>",
+            device="cuda",
+            group_size=group_size,
+            lora_config=LoraConfig(
+                r=8,
+                lora_alpha=16,
+                target_modules=["q_proj", "v_proj"],
+                task_type="CAUSAL_LM",
+            ),
+            max_output_tokens=max_tokens,
+            max_model_len=input_size + max_tokens,
+        )
+        completions = [
+            torch.randint(
+                0, vocab_size, (group_size, input_size + max_tokens), device="cuda"
+            )
+            for _ in range(2)
+        ]
+        action_masks = [
+            torch.ones((group_size, input_size + max_tokens - 1), device="cuda")
+            for _ in range(2)
+        ]
+        rewards = torch.stack([torch.rand(group_size) for _ in range(2)], dim=0)
+
+        metrics = grpo.learn((completions, action_masks, rewards))
+        assert np.isfinite(metrics["loss"])
+        assert np.isfinite(metrics["kl"])
+        grpo.clean_up()
+
     def test_grpo_learn_calls_mps_empty_cache(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
A tiny fix to a niche problem - loading a checkpoint that was fp16 (as some older open source models are) causes a dtype mismatch crash with transformers 5+. This PR just does a cast to catch this potential error

## What

GRPO/CISPO/GSPO/PPO-LLM crash on CUDA when the actor is loaded in fp16:

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::Half
```

raised from `_fused_logprob_chunk` (`h_chunk @ lm_head_weight.t()`) during `learn()`. transformers 5.x honors the checkpoint's `dtype` in `config.json`, so a plain `from_pretrained` of an fp16 checkpoint yields an fp16 model — under the bf16 autocast in `_amp_ctx` the final norm promotes hidden states to fp32 (bf16 activations x fp16 norm weight type-promote), while the identity-patched lm_head weight keeps the checkpoint dtype. The fused matmul runs outside autocast, where operand dtypes must match. bf16 and fp32 checkpoints were unaffected.

Both seams that do this matmul now promote their operands to `torch.promote_types(hidden.dtype, weight.dtype)` first:

- `_fused_logprob_chunk` in `fused_logprobs.py` — one seam covers the no-grad forward, the gradient-checkpointed backward recompute, and the compiled path (casts fuse into the matmul prologue under `torch.compile`).
- The inlined chunk math in `LigerFusedLinearPolicyLossFunction` (`fused_loss.py`) — identical latent bug on the `use_liger_loss=True` path.

Promotion (never downcasting) is deliberate: casting hidden states down to fp16 could overflow bf16-magnitude activations. Gradients still land on the original-dtype leaves through the cast.

## Tests

- Unit tests for the chunk kernel and the autograd-Function backward with fp32-hidden/fp16-weight operands (both fail at the exact crash line without the fix).
- A mixed-dtype test at the `_logprobs_from_hidden_fused` seam asserting bit-equality with pre-upcast operands.
- A liger-gated mixed-dtype backward test for the fused policy loss.
- A `gpu`-marked GRPO learn-cycle test that loads the tiny_llm fixture via plain `from_pretrained` — the fixture's `config.json` declares `float16`, so this is the exact user-facing repro. The fixture deliberately stays fp16 (also keeps it under its size budget); the test asserts on the loaded dtype so a future regeneration can't silently defuse the regression coverage.

Also removes an accidentally duplicated agent-construction block in `test_grpo_learn` (verbatim copy/paste present since at least #503): the first GRPO instance was fully built, then immediately overwritten and never cleaned up.

## Validation

On an L4 box (torch 2.11 cu130, transformers 5.11, CUDA+bf16): with the fix reverted, the new GPU test reproduces the reported RuntimeError through both the compiled dispatch and the eager fallback; with the fix, the GPU test plus the full `test_llm_ops` suite pass (67 passed), and the deduped `test_grpo_learn` passes across all live parametrizations. CPU suites (`test_fused_logprobs`, core-base fused tests, `test_llm_packing`) all green locally.