### PR TITLE
CI: cap Windows CPU-ISA dispatch at AVX2 to fix intermittent 0xc000001d worker crashes

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -49,13 +49,17 @@ jobs:
                   pip install uv
                   uv sync --locked --all-groups --extra all
 
+            - name: Show runner CPU
+              run: Get-CimInstance Win32_Processor | Select-Object Name, Manufacturer | Format-List
+
             - name: Test with pytest
               shell: bash
-              # Pin the CPU ISA to AVX2: some Windows runners lack AVX-512, and torch/MKL
-              # kernels dispatched for it fault the process (0xc000001d). Also cap xdist
-              # at 2 workers (overrides addopts' "-n auto") to bound the blast radius if a
-              # worker still dies.
+              # Cap CPU-ISA dispatch at AVX2: part of the heterogeneous Azure fleet
+              # behind windows-2025 runners faults (0xc000001d, illegal instruction)
+              # in torch's native kernel threads when an above-AVX2 code path is
+              # selected. AVX2 is supported fleet-wide.
               env:
                   ATEN_CPU_CAPABILITY: avx2
+                  ONEDNN_MAX_CPU_ISA: AVX2
                   MKL_ENABLE_INSTRUCTIONS: AVX2
-              run: bash scripts/run-tests.sh cov -n 2 --exitfirst -m "not llm" --cov-report=term-missing --durations=0 --durations-min=1.0
+              run: bash scripts/run-tests.sh cov --exitfirst -m "not llm" --cov-report=term-missing --durations=0 --durations-min=1.0

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -51,6 +51,11 @@ jobs:
 
             - name: Test with pytest
               shell: bash
-              # Cap xdist at 2 workers on Windows.
-              # The -n here overrides the "-n auto" in pyproject's addopts.
+              # Pin the CPU ISA to AVX2: some Windows runners lack AVX-512, and torch/MKL
+              # kernels dispatched for it fault the process (0xc000001d). Also cap xdist
+              # at 2 workers (overrides addopts' "-n auto") to bound the blast radius if a
+              # worker still dies.
+              env:
+                  ATEN_CPU_CAPABILITY: avx2
+                  MKL_ENABLE_INSTRUCTIONS: AVX2
               run: bash scripts/run-tests.sh cov -n 2 --exitfirst -m "not llm" --cov-report=term-missing --durations=0 --durations-min=1.0

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -51,9 +51,6 @@ jobs:
 
             - name: Test with pytest
               shell: bash
-              # Cap xdist at 2 workers on Windows: the runner intermittently crashes a
-              # worker with a native illegal-instruction fault (0xc000001d), after which
-              # pytest-xdist's loadgroup scheduler aborts the whole run with a KeyError
-              # on the dead worker. Fewer workers shrinks that crash surface. The -n
-              # here overrides the "-n auto" in pyproject's addopts.
+              # Cap xdist at 2 workers on Windows.
+              # The -n here overrides the "-n auto" in pyproject's addopts.
               run: bash scripts/run-tests.sh cov -n 2 --exitfirst -m "not llm" --cov-report=term-missing --durations=0 --durations-min=1.0

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -51,4 +51,9 @@ jobs:
 
             - name: Test with pytest
               shell: bash
-              run: bash scripts/run-tests.sh cov --exitfirst -m "not llm" --cov-report=term-missing --durations=0 --durations-min=1.0
+              # Cap xdist at 2 workers on Windows: the runner intermittently crashes a
+              # worker with a native illegal-instruction fault (0xc000001d), after which
+              # pytest-xdist's loadgroup scheduler aborts the whole run with a KeyError
+              # on the dead worker. Fewer workers shrinks that crash surface. The -n
+              # here overrides the "-n auto" in pyproject's addopts.
+              run: bash scripts/run-tests.sh cov -n 2 --exitfirst -m "not llm" --cov-report=term-missing --durations=0 --durations-min=1.0


### PR DESCRIPTION
## What

Fix the intermittent Windows CI aborts:

```
Windows fatal exception: code 0xc000001d
[gw0] node down: Not properly terminated
[gw1] node down: Not properly terminated
INTERNALERROR> ... KeyError: <WorkerController gw3>
```

by capping torch's CPU instruction-set dispatch at **AVX2** on the Windows job:

- `ATEN_CPU_CAPABILITY=avx2` — ATen's vectorized kernels
- `ONEDNN_MAX_CPU_ISA=AVX2` — oneDNN's JIT codegen (convs, matmuls)
- `MKL_ENABLE_INSTRUCTIONS=AVX2` — MKL BLAS

Also adds a "Show runner CPU" step so any future crash can be correlated with the CPU model, and **reverts the earlier `-n 2` xdist cap** (back to addopts' `-n auto`) — worker count was never a factor, see below.

## Diagnosis

`0xc000001d` is `STATUS_ILLEGAL_INSTRUCTION`: the runner's CPU executed an instruction it doesn't support, inside native code. Digging through the run history:

- **It is not branch-specific.** `nightly` itself ([run 29578272149](https://github.com/AgileRL/AgileRL/actions/runs/29578272149)) and dependabot branches (nightly + one pure-Python bump, e.g. [29583872970](https://github.com/AgileRL/AgileRL/actions/runs/29583872970), [29583893116](https://github.com/AgileRL/AgileRL/actions/runs/29583893116)) crash with the identical signature, alongside `feat/openenv` ([29591242903](https://github.com/AgileRL/AgileRL/actions/runs/29591242903), [29328186562](https://github.com/AgileRL/AgileRL/actions/runs/29328186562), [29325575124](https://github.com/AgileRL/AgileRL/actions/runs/29325575124)).
- **Deterministic location, stochastic occurrence.** Every crash lands at the same suite position (~24%: 879 skipped + 450–460 passed, the `tests/test_algorithms/test_single_agent/` DQN/DDPG region — the first dense torch-CPU work after the LLM skips). But *which* jobs crash is random: 3.10+3.12 in one run, 3.13 in the next, only 3.10 in another, and whole runs pass in between. The failing instruction always executes; it is only *illegal* on some machines.
- **The crashing thread is native.** faulthandler shows the "Current thread" with no Python frames — torch's intra-op kernel thread pool, not test code. The `execnet ... read` frames in the dumps are just the worker's I/O thread.
- **Everything repo-side is ruled out.** torch 2.11.0 + numpy 2.2.6 were already installed in fully green runs (e.g. 2026-07-10); the crash-region tests are unchanged since June; the same runner image versions (`20260624.560`, `20260707.563`) hosted both crashes and successes; and a `-n 2` run crashed the same way, so concurrency is irrelevant.
- **First crash ever: 2026-07-14**, with no correlated change on our side — pointing at a change in the Azure hardware fleet backing `windows-2025` runners. GitHub's pool is CPU-heterogeneous (AVX2-only AMD Rome/Milan mixed with AVX-512-capable SKUs), and torch's Windows binaries are a known source of above-baseline instructions (pytorch/pytorch#145042, pytorch/pytorch#145702: VS2022-built wheels emitting AVX-512 in AVX2-max binaries).

Per-VM lottery + fixed crash site = ISA dispatch above what the VM actually executes. Pinning dispatch to AVX2 (supported fleet-wide) removes the illegal path deterministically, at a small kernel-speed cost that is irrelevant for CI.

The trailing `INTERNALERROR KeyError: <WorkerController gwN>` is secondary: xdist's crashed-worker replacement racing the `--exitfirst` shutdown. It disappears once workers stop dying.

## Notes

- Windows-only; Linux/macOS jobs unchanged.
- If a crash ever reappears with these pins active, the stray instruction is in some wheel's baseline code rather than a dispatch path — the new CPU-model log will show which hardware to chase.
