### PR TITLE
Remove unused VLLMConfig.swap_space field

### DIFF
--- a/agilerl-arena/agilerl/arena/models/networks.py
+++ b/agilerl-arena/agilerl/arena/models/networks.py
@@ -349,7 +349,6 @@ class VLLMConfig(BaseModel):
     tensor_parallel_size: int = Field(default=1, ge=1)
     gpu_memory_utilization: float = Field(default=0.3, ge=0.0, le=1.0)
     max_num_seqs: int = Field(default=8, ge=1)
-    swap_space: float | None = Field(default=None, ge=0.0)
     enforce_eager: bool | None = Field(default=None)
     sleep_mode: bool = Field(default=False)
 

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -1692,7 +1692,6 @@ class VLLMConfig:
     gpu_memory_utilization: float = 0.3
     max_num_seqs: int = 8
     max_num_batched_tokens: int | None = None
-    swap_space: float | None = None
     enforce_eager: bool | None = None
     sleep_mode: bool = False
     sleep_mode_level: int = 1

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -366,7 +366,6 @@ def generate_grpo(
             kv_cache_memory_bytes=32 * 1024 * 1024,
             max_num_seqs=1,
             sleep_mode=sleep_mode,
-            swap_space=0,
             enforce_eager=False,
         )
 


### PR DESCRIPTION
## What

Deletes `VLLMConfig.swap_space` from the algorithm config dataclass, the arena manifest model, and the one test that set it (3 one-line deletions).

## Why

`swap_space` is no longer used by vLLM: swap-based preemption was a V0-engine feature, and on the V1 engine (the only engine in our supported range, `vllm>=0.23`) the kwarg is deprecated and ignored — current vLLM pops it in `LLM.__init__` with a `DeprecationWarning`.

On our side it was dead config from the start: added in #503 alongside `enforce_eager`, but never forwarded to the `LLM` constructor (`build_vllm_llm_init_kwargs`), so setting it has never had any effect. Forwarding it now would only emit deprecation warnings and eventually break when vLLM removes the kwarg, so deletion is the honest fix.

Removing the arena manifest field in the same change keeps manifest validation in sync with the dataclass: manifests that still specify `swap_space` are silently ignored by Pydantic (same observable no-op as today) instead of crashing on an unexpected kwarg at build time.