### PR TITLE
chore: make `just typecheck` reproduce the CI type-check setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,13 +54,6 @@ test *args:
 # Static type checking with ty (config in pyproject.toml [tool.ty]).
 # Runs the pinned ty pre-commit hook so local type-checking stays identical to
 # CI, reproducing the two setup steps the Type checks workflow performs first.
-#
-# ty resolves imports from .venv, so without the extras every LLM import reads
-# as unresolved. Off Linux the platform-gated ones (vllm, deepspeed,
-# liger-kernel, bitsandbytes; box2d on Windows) are skipped by their markers,
-# so this resolves on every platform. agilerl.arena is a namespace portion
-# shipped by agilerl-arena, which ty only sees through the dev symlink; the
-# arena-symlink hook creates it, and `pre-commit run` takes one hook at a time.
 typecheck:
     uv sync --all-groups --extra all
     uv run pre-commit run arena-symlink --all-files

--- a/justfile
+++ b/justfile
@@ -53,8 +53,15 @@ test *args:
 
 # Static type checking with ty (config in pyproject.toml [tool.ty]).
 # Runs the pinned ty pre-commit hook so local type-checking stays identical to
-# CI. The hook creates the agilerl/arena dev symlink (agilerl.arena is a
-# namespace portion shipped by agilerl-arena, which ty resolves through the
-# symlink) and checks both trees.
+# CI, reproducing the two setup steps the Type checks workflow performs first.
+#
+# ty resolves imports from .venv, so without the extras every LLM import reads
+# as unresolved. Off Linux the platform-gated ones (vllm, deepspeed,
+# liger-kernel, bitsandbytes; box2d on Windows) are skipped by their markers,
+# so this resolves on every platform. agilerl.arena is a namespace portion
+# shipped by agilerl-arena, which ty only sees through the dev symlink; the
+# arena-symlink hook creates it, and `pre-commit run` takes one hook at a time.
 typecheck:
+    uv sync --all-groups --extra all
+    uv run pre-commit run arena-symlink --all-files
     uv run pre-commit run ty --all-files


### PR DESCRIPTION
## Why

`just typecheck` only gave a correct answer in a checkout that already happened to be synced with the extras. On a fresh clone or a new worktree it reported **40 `unresolved-import` errors** — none of which are real, and all of which look alarming the first time you run it. That is a bad first experience for a new contributor, and it also trains existing ones to ignore the recipe's output.

The recipe ran the ty hook without either of the two setup steps `type-checks.yml` performs first:

```yaml
- run: uv sync --locked --all-groups --extra all
- run: ln -s ../agilerl-arena/agilerl/arena agilerl/arena
- run: uv run pre-commit run ty --all-files
```

Two independent causes:

1. **Extras were never installed.** `uv run` syncs the *default* dependency set, so `transformers`, `peft` and `datasets` were absent and every LLM import read as unresolved. uv has no `default-extras` setting to make this implicit — `uv 0.11.2` accepts only `default-groups` — so the sync has to be explicit in the recipe.
2. **The arena symlink was never created.** `pre-commit run` takes a single hook id, so `run ty` never fired the `arena-symlink` hook and `agilerl.arena` resolved only if the symlink happened to exist already. The recipe's own comment claimed the ty hook created it, which was wrong.

## Why `--extra all` is fine on macOS and Windows

Every extra that is not portable is already marker-gated in `pyproject.toml`, so uv skips it off Linux rather than failing to resolve:

| Package | Marker |
|---|---|
| `vllm`, `deepspeed`, `liger-kernel`, `bitsandbytes` | `sys_platform == 'linux'` |
| `swig`, `gymnasium[box2d]` | `sys_platform != 'win32'` |
| `transformers`, `peft`, `datasets`, `agilerl-arena` | none — install everywhere |

So `--extra all` resolves on all three platforms; off Linux it simply installs fewer packages (332 resolved, 189 installed on macOS here). The six files that import the Linux-only packages are already covered by the `unresolved-import` override in `[[tool.ty.overrides]]`, which is what lets a macOS run come out clean.

This does mean non-Linux contributors check slightly *less* than CI does — the Linux-only import graphs stay invisible locally. That was already true and is not made worse here; it is the reason the override block exists.
