### PR TITLE
Fix LLM PPO/REINFORCE silently training on CPU

### DIFF
--- a/agilerl/algorithms/dpo.py
+++ b/agilerl/algorithms/dpo.py
@@ -29,7 +29,7 @@ from agilerl.typing import (
     PreferencePrompts,
 )
 from agilerl.utils.algo_utils import get_experiences_samples
-from agilerl.utils.llm_utils import aggregate_metrics_dict
+from agilerl.utils.llm_utils import aggregate_metrics_dict, resolve_llm_device
 
 if HAS_LIGER_KERNEL:
     from agilerl.algorithms.core.llm_ops.fused_loss import LigerDPOWithAlpha
@@ -71,7 +71,8 @@ class DPO(LLMAlgorithm[PreferencePrompts]):
     :type calc_position_embeddings: bool, optional
     :param micro_batch_size_per_gpu: Micro batch size per GPU, defaults to None
     :type micro_batch_size_per_gpu: int, optional
-    :param device: Device for accelerated computing, 'cpu' or 'cuda', defaults to 'cpu'
+    :param device: Device to train on. Ignored when an accelerator is given (each rank
+        owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str, optional
     :param lora_config: Config for LoRA, defaults to None
     :type lora_config: LoraConfig, optional
@@ -144,7 +145,7 @@ class DPO(LLMAlgorithm[PreferencePrompts]):
         update_epochs: int = 1,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
-        device: str = "cpu",
+        device: str | torch.device | None = None,
         lora_config: LoraConfig | None = None,
         accelerator: Accelerator | None = None,
         wrap: bool = True,
@@ -161,17 +162,7 @@ class DPO(LLMAlgorithm[PreferencePrompts]):
         activation_offload: bool = False,
         lora_target_scope: str | None = None,
     ) -> None:
-        resolved_device = (
-            f"cuda:{accelerator.process_index}"
-            if accelerator is not None
-            else (
-                "cuda"
-                if torch.cuda.is_available()
-                else "mps"
-                if torch.backends.mps.is_available()
-                else "cpu"
-            )
-        )
+        resolved_device = resolve_llm_device(accelerator, device)
         super().__init__(
             index=index,
             batch_size=batch_size,

--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -15,6 +15,7 @@ import torch
 from agilerl import HAS_LIGER_KERNEL, HAS_LLM_DEPENDENCIES
 from agilerl.utils.llm_utils import (
     calculate_k3_kl,
+    resolve_llm_device,
 )
 
 if TYPE_CHECKING:
@@ -153,7 +154,8 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
     :type use_memory_efficient_params: bool
     :param accelerator: Accelerator for distributed computing, defaults to None
     :type accelerator: accelerate.Accelerator(), optional
-    :param device: Device for accelerated computing, 'cpu' or 'cuda', defaults to 'cpu'
+    :param device: Device to train on. Ignored when an accelerator is given (each rank
+        owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str, optional
     :param wrap: Wrap models for distributed training upon creation, defaults to True
     :type wrap: bool, optional
@@ -320,7 +322,7 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
         lora_config: LoraConfig | None = None,
         cosine_lr_schedule_config: CosineLRScheduleConfig | None = None,
         accelerator: Accelerator | None = None,
-        device: str = "cpu",
+        device: str | torch.device | None = None,
         wrap: bool = True,
         clone: bool = False,
         use_vllm: bool = False,
@@ -350,17 +352,7 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
         vllm_importance_sampling_cap: float = 2.0,
         use_sequence_packing: bool = False,
     ) -> None:
-        resolved_device = (
-            f"cuda:{accelerator.process_index}"
-            if accelerator is not None
-            else (
-                "cuda"
-                if torch.cuda.is_available()
-                else "mps"
-                if torch.backends.mps.is_available()
-                else "cpu"
-            )
-        )
+        resolved_device = resolve_llm_device(accelerator, device)
         super().__init__(
             index=index,
             batch_size=batch_size,

--- a/agilerl/algorithms/ppo_llm.py
+++ b/agilerl/algorithms/ppo_llm.py
@@ -55,6 +55,7 @@ from agilerl.utils.llm_utils import (
     normalize_reasoning_prompt_batch,
     pool_by_turns,
     prepare_prompt_hf_generate,
+    resolve_llm_device,
     stitch_completion_after_windowed_hf_generate,
     validate_importance_sampling_level,
     validate_llm_context_lengths,
@@ -136,7 +137,8 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
     :type cosine_lr_schedule_config: CosineLRScheduleConfig | None, optional
     :param accelerator: Optional HuggingFace ``Accelerator`` instance.
     :type accelerator: Accelerator | None, optional
-    :param device: Device string used when no accelerator is provided.
+    :param device: Device to train on. Ignored when an accelerator is given (each rank
+        owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str, optional
     :param wrap: Whether to wrap models for distributed execution.
     :type wrap: bool, optional
@@ -284,7 +286,7 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
         lora_config: LoraConfig | None = None,
         cosine_lr_schedule_config: CosineLRScheduleConfig | None = None,
         accelerator: Accelerator | None = None,
-        device: str = "cpu",
+        device: str | torch.device | None = None,
         wrap: bool = True,
         clone: bool = False,
         use_vllm: bool = False,
@@ -314,9 +316,7 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
         vllm_importance_sampling_cap: float = 2.0,
     ) -> None:
 
-        device = (
-            f"cuda:{accelerator.process_index}" if accelerator is not None else device
-        )
+        resolved_device = resolve_llm_device(accelerator, device)
         super().__init__(
             index=index,
             batch_size=batch_size,
@@ -342,7 +342,7 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
             hp_config=hp_config,
             use_memory_efficient_params=use_memory_efficient_params,
             wrap=wrap,
-            device=device,
+            device=resolved_device,
             accelerator=accelerator,
             name="LLMPPO",
             gradient_checkpointing=gradient_checkpointing,

--- a/agilerl/algorithms/reinforce_llm.py
+++ b/agilerl/algorithms/reinforce_llm.py
@@ -52,6 +52,7 @@ from agilerl.utils.llm_utils import (
     normalize_reasoning_prompt_batch,
     pool_by_turns,
     prepare_prompt_hf_generate,
+    resolve_llm_device,
     stitch_completion_after_windowed_hf_generate,
     validate_importance_sampling_level,
     validate_llm_context_lengths,
@@ -138,7 +139,8 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
     :type cosine_lr_schedule_config: CosineLRScheduleConfig | None
     :param accelerator: HuggingFace Accelerator for distributed training.
     :type accelerator: Accelerator | None
-    :param device: Device string.
+    :param device: Device to train on. Ignored when an accelerator is given (each rank
+        owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str
     :param wrap: Wrap models for distributed training upon creation.
     :type wrap: bool
@@ -264,7 +266,7 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
         lora_config: LoraConfig | None = None,
         cosine_lr_schedule_config: CosineLRScheduleConfig | None = None,
         accelerator: Accelerator | None = None,
-        device: str = "cpu",
+        device: str | torch.device | None = None,
         wrap: bool = True,
         clone: bool = False,
         use_vllm: bool = False,
@@ -288,9 +290,7 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
         vllm_importance_sampling_cap: float = 2.0,
     ) -> None:
 
-        device = (
-            f"cuda:{accelerator.process_index}" if accelerator is not None else device
-        )
+        resolved_device = resolve_llm_device(accelerator, device)
         super().__init__(
             index=index,
             batch_size=batch_size,
@@ -315,7 +315,7 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
             cosine_lr_schedule_config=cosine_lr_schedule_config,
             hp_config=hp_config,
             wrap=wrap,
-            device=device,
+            device=resolved_device,
             accelerator=accelerator,
             name="LLMREINFORCE",
             gradient_checkpointing=gradient_checkpointing,

--- a/agilerl/algorithms/sft.py
+++ b/agilerl/algorithms/sft.py
@@ -19,7 +19,7 @@ from agilerl.typing import (
     ObservationType,
     SFTPrompts,
 )
-from agilerl.utils.llm_utils import aggregate_metrics_dict
+from agilerl.utils.llm_utils import aggregate_metrics_dict, resolve_llm_device
 
 if TYPE_CHECKING:
     from accelerate import Accelerator
@@ -79,7 +79,8 @@ class SFT(LLMAlgorithm[SFTPrompts]):
     :param micro_batch_size_per_gpu: Micro-batch size for gradient accumulation.
         When None the full batch is used in a single forward pass.
     :type micro_batch_size_per_gpu: int, optional
-    :param device: Compute device, defaults to ``"cpu"``
+    :param device: Device to train on. Ignored when an accelerator is given (each rank
+        owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str, optional
     :param lora_config: LoRA config; when supplied the base model is wrapped with
         PEFT adapters, defaults to None
@@ -147,7 +148,7 @@ class SFT(LLMAlgorithm[SFTPrompts]):
         update_epochs: int = 1,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
-        device: str = "cpu",
+        device: str | torch.device | None = None,
         lora_config: LoraConfig | None = None,
         accelerator: Accelerator | None = None,
         wrap: bool = True,
@@ -162,17 +163,7 @@ class SFT(LLMAlgorithm[SFTPrompts]):
         activation_offload: bool = False,
         lora_target_scope: str | None = None,
     ) -> None:
-        resolved_device = (
-            f"cuda:{accelerator.process_index}"
-            if accelerator is not None
-            else (
-                "cuda"
-                if torch.cuda.is_available()
-                else "mps"
-                if torch.backends.mps.is_available()
-                else "cpu"
-            )
-        )
+        resolved_device = resolve_llm_device(accelerator, device)
         super().__init__(
             index=index,
             batch_size=batch_size,

--- a/agilerl/utils/llm_utils.py
+++ b/agilerl/utils/llm_utils.py
@@ -1555,6 +1555,35 @@ def collect_trainable_param_stats(pop: PopulationType) -> dict[str, Any]:
     return out
 
 
+def resolve_llm_device(
+    accelerator: Accelerator | None,
+    device: str | torch.device | None = None,
+) -> str:
+    """Resolve the training device for an LLM algorithm.
+
+    The accelerator outranks *device*: under ``accelerate``/DeepSpeed each rank
+    must own its own GPU, so a caller passing a bare ``"cuda"`` cannot be allowed
+    to collapse every rank onto device 0.
+
+    :param accelerator: Accelerator object, or ``None`` for single-process runs.
+    :type accelerator: accelerate.Accelerator | None
+    :param device: Caller-requested device, or ``None`` to auto-detect.
+    :type device: str | torch.device | None
+    :return: The rank's device under an accelerator, else *device*, else the best
+        locally available device.
+    :rtype: str
+    """
+    if accelerator is not None:
+        return f"cuda:{accelerator.process_index}"
+    if device is not None:
+        return str(device)
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
 def offload_colocated_trainer_from_gpu(unwrapped_model: torch.nn.Module) -> int:
     """Force the trainer module tree onto CPU before colocated vLLM ``LLM()`` init.
 

--- a/demos/llm/debugging/debugging_value.py
+++ b/demos/llm/debugging/debugging_value.py
@@ -46,11 +46,9 @@ def get_terminal_values(
     stacked_ids = stacked_ids.to(agent.device)
     stacked_masks = stacked_masks.to(agent.device)
 
-    _, values = agent._get_logprobs_and_values(
+    _, _, values = agent._fused_forward_no_grad(
         stacked_ids,
         batch_size=stacked_ids.shape[0],
-        use_reference=False,
-        eval_mode=True,
     )
 
     last_action_idx = stacked_masks.long().cumsum(dim=1).argmax(dim=1)
@@ -68,7 +66,7 @@ def main(cfg: dict) -> None:
 
     torch.manual_seed(0)
     tokenizer = TinyDigitTokenizer()
-    actor_network = build_tiny_actor_network()
+    actor_network = build_tiny_actor_network(use_value_head=True)
     train_dataset, test_dataset = make_dataset(int(dbg["dataset_size"]))
 
     conversation_template = [
@@ -128,7 +126,8 @@ def main(cfg: dict) -> None:
 
     prompts = env.reset(reset_dataloaders=True)
     with torch.no_grad():
-        init_ids, init_masks = agent.get_action(prompts, training=False)
+        init_result = agent.get_action(prompts, training=False)
+        init_ids, init_masks = init_result.completion_ids, init_result.action_masks
         init_values = get_terminal_values(agent, init_ids, init_masks)
 
     init_mean = float(init_values.mean().item())
@@ -141,17 +140,21 @@ def main(cfg: dict) -> None:
 
     for step in range(num_steps):
         agent.set_reference_policy(env.num_epochs)
-        completion_ids, action_masks = agent.get_action(prompts)
+        rollout = agent.get_action(prompts)
+        completion_ids, action_masks = rollout.completion_ids, rollout.action_masks
         next_prompts, rewards = env.step(completion_ids)
 
-        loss, kl, pg_loss, vf_loss, entropy = agent.learn(
+        metrics = agent.learn(
             (completion_ids, action_masks, rewards),
+            sampling_logps=rollout.sampling_logps,
         )
+        vf_loss = metrics["vf_loss"]
         prompts = next_prompts
 
         if (step + 1) % log_interval == 0:
             with torch.no_grad():
-                snap_ids, snap_masks = agent.get_action(prompts, training=False)
+                snap = agent.get_action(prompts, training=False)
+                snap_ids, snap_masks = snap.completion_ids, snap.action_masks
                 snap_values = get_terminal_values(agent, snap_ids, snap_masks)
             print(
                 f"[value-debug] step {step + 1:4d} | "
@@ -161,7 +164,11 @@ def main(cfg: dict) -> None:
             )
 
     with torch.no_grad():
-        final_ids, final_masks = agent.get_action(prompts, training=False)
+        final_result = agent.get_action(prompts, training=False)
+        final_ids, final_masks = (
+            final_result.completion_ids,
+            final_result.action_masks,
+        )
         final_values = get_terminal_values(agent, final_ids, final_masks)
 
     final_mean = float(final_values.mean().item())

--- a/tests/test_algorithms/test_llms/test_ppo_llm.py
+++ b/tests/test_algorithms/test_llms/test_ppo_llm.py
@@ -30,6 +30,7 @@ from tests import TINY_LLM_FIXTURE_PATH
 from tests.utils import (
     assert_vllm_get_action_contract,
     make_mock_vllm_instance,
+    spawn_new_process_for_each_test,
 )
 
 deepspeed_base_config = {
@@ -334,6 +335,24 @@ class _PPOStub:
 
 
 class TestPPOInit:
+    def test_init_auto_detects_device_when_none_given(self):
+        """Regression: no ``device`` must auto-detect, not silently fall back to CPU."""
+        with patch(
+            "agilerl.algorithms.ppo_llm.resolve_llm_device", return_value="cpu"
+        ) as mock_resolve:
+            ppo = _cpu_llmppo(device=None)
+
+        mock_resolve.assert_called_once_with(None, None)
+        assert ppo.device == "cpu"
+
+    def test_init_honours_an_explicitly_requested_device(self):
+        """An explicit ``device`` is used as-is when no accelerator is present."""
+        with patch("torch.cuda.is_available", return_value=True):
+            ppo = _cpu_llmppo(device="cpu")
+
+        assert ppo.device == "cpu"
+        assert all(param.device.type == "cpu" for param in ppo.actor.parameters())
+
     @patch("agilerl.algorithms.core.base.LLM")
     def test_init_llmppo_vllm_sleep_mode_calls_sleep(self, MockLLM):
         mock_instance = make_mock_vllm_instance()
@@ -1960,3 +1979,78 @@ class TestPPOSaveLoadValueHead:
         ppo.clean_up()
         new_ppo.clean_up()
         AcceleratorState._reset_state(True)
+
+
+class TestPPOColocatedVllm:
+    @spawn_new_process_for_each_test
+    @pytest.mark.vllm
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    @pytest.mark.parametrize("pretrained_model_name_or_path", [TINY_LLM_FIXTURE_PATH])
+    def test_colocated_learn_with_memory_efficient_params(
+        self, pretrained_model_name_or_path
+    ):
+        """Regression: colocated PPO with framework defaults trains on the GPU.
+
+        Constructed the way the docs and profiling harness do — no ``device``
+        argument, ``use_memory_efficient_params`` left at its default — the
+        trainer used to stay on CPU for the whole run, so ``learn`` fed CPU
+        tensors to the Liger Triton kernels patched into the base model.
+        """
+        input_size, max_tokens, batch_size = 8, 8, 2
+        ppo = LLMPPO(
+            model_name=pretrained_model_name_or_path,
+            pad_token_id=0,
+            pad_token="<pad>",
+            lora_config=LoraConfig(
+                r=8,
+                lora_alpha=16,
+                target_modules=["q_proj", "v_proj"],
+                task_type="CAUSAL_LM",
+            ),
+            use_vllm=True,
+            # Both knobs are load-bearing under parallel vLLM testing; see the
+            # rationale on ``generate_grpo`` in test_grpo.py.
+            vllm_config=VLLMConfig(
+                gpu_memory_utilization=0.22,
+                kv_cache_memory_bytes=32 * 1024 * 1024,
+                max_num_seqs=batch_size,
+                sleep_mode=True,
+            ),
+            max_output_tokens=max_tokens,
+            max_model_len=input_size + max_tokens + 4,
+            batch_size=batch_size,
+            micro_batch_size_per_gpu=1,
+            update_epochs=1,
+        )
+        assert ppo.use_memory_efficient_params
+        assert torch.device(ppo.device).type == "cuda"
+
+        vocab_size = ppo._get_unwrapped_actor().config.vocab_size
+        prompts = [
+            {
+                "input_ids": torch.randint(
+                    0, vocab_size, (1, input_size), device=ppo.device
+                ),
+                "attention_mask": torch.ones(1, input_size, device=ppo.device),
+                "text": "Write me a short story about a cat.",
+            }
+            for _ in range(batch_size)
+        ]
+
+        completion_ids, action_masks, sampling_logps = ppo.get_action(
+            prompts, training=True
+        )
+        # The rollout parks the trainer on CPU; ``learn`` must bring the whole
+        # tree — base weights and value head alike — back onto the GPU.
+        unwrapped = ppo._get_unwrapped_actor()
+        assert all(p.device.type == "cpu" for p in unwrapped.parameters())
+
+        rewards = torch.randn(len(completion_ids), device=ppo.device)
+        metrics = ppo.learn(
+            (completion_ids, action_masks, rewards),
+            sampling_logps=sampling_logps,
+        )
+        for key in ("loss", "pg_loss", "vf_loss"):
+            assert torch.isfinite(torch.tensor(metrics[key])), f"{key} not finite"
+
+        ppo.clean_up()

--- a/tests/test_utils/test_llm_utils.py
+++ b/tests/test_utils/test_llm_utils.py
@@ -69,6 +69,7 @@ from agilerl.utils.llm_utils import (
     pool_log_ratio_by_level,
     remap_peft_lora_key_for_vllm,
     resolve_attn_implementation,
+    resolve_llm_device,
     resolve_vllm_max_lora_rank,
     resolve_vllm_max_num_batched_tokens,
     sample_eval_prompts,
@@ -1354,6 +1355,47 @@ class TestLlmUtilsDeprecatedReexports:
         d = dir(llm_utils_module)
         assert "ReasoningGym" in d
         assert "PreferenceGym" in d
+
+
+class TestResolveLlmDevice:
+    """Accelerator outranks an explicit device, which outranks auto-detection."""
+
+    def test_accelerator_gives_the_ranks_device(self):
+        accelerator = MagicMock()
+        accelerator.process_index = 3
+        assert resolve_llm_device(accelerator) == "cuda:3"
+
+    def test_accelerator_outranks_an_explicit_device(self):
+        # A bare "cuda" from the caller would otherwise collapse every rank
+        # onto device 0.
+        accelerator = MagicMock()
+        accelerator.process_index = 2
+        assert resolve_llm_device(accelerator, "cuda") == "cuda:2"
+
+    def test_explicit_device_used_without_accelerator(self):
+        with patch("torch.cuda.is_available", return_value=True):
+            assert resolve_llm_device(None, "cpu") == "cpu"
+
+    def test_torch_device_is_stringified(self):
+        assert resolve_llm_device(None, torch.device("cuda", 1)) == "cuda:1"
+
+    def test_cuda_preferred_when_nothing_requested(self):
+        with patch("torch.cuda.is_available", return_value=True):
+            assert resolve_llm_device(None) == "cuda"
+
+    def test_mps_used_when_cuda_unavailable(self):
+        with (
+            patch("torch.cuda.is_available", return_value=False),
+            patch("torch.backends.mps.is_available", return_value=True),
+        ):
+            assert resolve_llm_device(None) == "mps"
+
+    def test_cpu_when_no_accelerator_available(self):
+        with (
+            patch("torch.cuda.is_available", return_value=False),
+            patch("torch.backends.mps.is_available", return_value=False),
+        ):
+            assert resolve_llm_device(None) == "cpu"
 
 
 def test_move_params_helpers_call_model_move_and_cuda_sync():


### PR DESCRIPTION
> [!NOTE]
> **Does not affect Arena** — this code path never activates there.

## Problem

LLM `PPO` and `REINFORCE` passed the caller's `device` argument straight through, and it
defaults to `"cpu"`. Constructed on a CUDA host without an accelerator and without an
explicit `device=`, the whole trainer stayed on CPU for the entire run. With colocated
vLLM that crashes rather than merely running slowly, because Liger patches Triton kernels
into the base model at construction:

```
ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)
```

`GRPO`, `SFT` and `DPO` avoided this with an inline block that resolves the device and
discards the caller's argument entirely — which leaves `device` silently inert, the very
thing that made this hard to spot.

## Fix

Replace all five copies with `resolve_llm_device(accelerator, device)`, which ranks the
three sources rather than picking one:

1. **accelerator** — each rank must own its own GPU, so a bare `"cuda"` from the caller
   can't collapse every rank onto device 0;
2. **explicit `device`**;
3. **auto-detection** (CUDA → MPS → CPU).

No existing caller changes behaviour: Arena always supplies an accelerator, and
`create_population`'s LLM branches pass no `device` at all. `device` now means what its
name says.

Also repairs three stale API uses in `demos/llm/debugging/debugging_value.py` that made
the PPO value-head benchmark unrunnable.
