### PR TITLE
test: run the test session in a temporary working directory

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -202,11 +202,9 @@ class ClassicRLPopulationFactory(Protocol):
         index: int,
         device: DeviceType = "cpu",
         **kwargs: Any,
-    ) -> None:
-        pass
+    ) -> None: ...
 
-    def load_checkpoint(self, path: str) -> None:
-        pass
+    def load_checkpoint(self, path: str) -> None: ...
 
 
 ClassicRLAlgoT = TypeVar("ClassicRLAlgoT", bound=ClassicRLPopulationFactory)
@@ -2009,8 +2007,7 @@ class MultiAgentRLAlgorithm(
         net_config: NetConfigType | None = ...,
         flatten: bool = ...,
         return_encoders: Literal[False] = ...,
-    ) -> NetConfigType:
-        pass
+    ) -> NetConfigType: ...
 
     @overload
     def build_net_config(
@@ -2019,8 +2016,7 @@ class MultiAgentRLAlgorithm(
         flatten: bool = ...,
         *,
         return_encoders: Literal[True],
-    ) -> tuple[NetConfigType, dict[str, NetConfigType]]:
-        pass
+    ) -> tuple[NetConfigType, dict[str, NetConfigType]]: ...
 
     def build_net_config(
         self,

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -155,29 +155,25 @@ def to_agent_tensors(per_agent: TensorDict, device: DeviceType) -> TensorMapping
 
 
 @overload
-def get_input_size_from_space(observation_space: LeafSpace) -> tuple[int, ...]:
-    pass
+def get_input_size_from_space(observation_space: LeafSpace) -> tuple[int, ...]: ...
 
 
 @overload
 def get_input_size_from_space(
     observation_space: spaces.Dict | dict[str, spaces.Space],
-) -> dict[str, tuple[int, ...]]:
-    pass
+) -> dict[str, tuple[int, ...]]: ...
 
 
 @overload
 def get_input_size_from_space(
     observation_space: spaces.Tuple | list[spaces.Space] | tuple[spaces.Space, ...],
-) -> tuple[tuple[int, ...] | dict[str, tuple[int, ...]], ...]:
-    pass
+) -> tuple[tuple[int, ...] | dict[str, tuple[int, ...]], ...]: ...
 
 
 @overload
 def get_input_size_from_space(
     observation_space: SpaceLike,
-) -> InputSizeFromSpace:
-    pass
+) -> InputSizeFromSpace: ...
 
 
 def get_input_size_from_space(observation_space: SpaceLike) -> InputSizeFromSpace:
@@ -237,29 +233,25 @@ def _input_size(space: spaces.Space) -> InputSizeFromSpace:
 
 
 @overload
-def get_output_size_from_space(action_space: LeafSpace) -> int:
-    pass
+def get_output_size_from_space(action_space: LeafSpace) -> int: ...
 
 
 @overload
 def get_output_size_from_space(
     action_space: spaces.Dict | dict[str, spaces.Space],
-) -> dict[str, int]:
-    pass
+) -> dict[str, int]: ...
 
 
 @overload
 def get_output_size_from_space(
     action_space: list[spaces.Space] | tuple[spaces.Space, ...],
-) -> tuple[int | dict[str, int], ...]:
-    pass
+) -> tuple[int | dict[str, int], ...]: ...
 
 
 @overload
 def get_output_size_from_space(
     action_space: SpaceLike,
-) -> OutputSizeFromSpace:
-    pass
+) -> OutputSizeFromSpace: ...
 
 
 def get_output_size_from_space(action_space: SpaceLike) -> OutputSizeFromSpace:
@@ -530,29 +522,25 @@ def transpose_image_space(space: spaces.Space) -> spaces.Space:
 @overload
 def transpose_image_observation(
     observation: torch.Tensor, original_space: spaces.Space
-) -> torch.Tensor:
-    pass
+) -> torch.Tensor: ...
 
 
 @overload
 def transpose_image_observation(
     observation: np.ndarray, original_space: spaces.Space
-) -> np.ndarray:
-    pass
+) -> np.ndarray: ...
 
 
 @overload
 def transpose_image_observation(
     observation: dict[str, np.ndarray], original_space: spaces.Space
-) -> dict[str, np.ndarray]:
-    pass
+) -> dict[str, np.ndarray]: ...
 
 
 @overload
 def transpose_image_observation(
     observation: tuple[np.ndarray, ...], original_space: spaces.Space
-) -> tuple[np.ndarray, ...]:
-    pass
+) -> tuple[np.ndarray, ...]: ...
 
 
 def transpose_image_observation(
@@ -624,23 +612,19 @@ def transpose_image_observation(
 
 
 @overload
-def get_obs_shape(space: LeafSpace) -> tuple[int, ...]:
-    pass
+def get_obs_shape(space: LeafSpace) -> tuple[int, ...]: ...
 
 
 @overload
-def get_obs_shape(space: spaces.Dict) -> dict[str, tuple[int, ...]]:
-    pass
+def get_obs_shape(space: spaces.Dict) -> dict[str, tuple[int, ...]]: ...
 
 
 @overload
-def get_obs_shape(space: spaces.Tuple) -> tuple[tuple[int, ...], ...]:
-    pass
+def get_obs_shape(space: spaces.Tuple) -> tuple[tuple[int, ...], ...]: ...
 
 
 @overload
-def get_obs_shape(space: spaces.Space) -> ObsShape:
-    pass
+def get_obs_shape(space: spaces.Space) -> ObsShape: ...
 
 
 def get_obs_shape(space: spaces.Space) -> ObsShape:
@@ -737,25 +721,21 @@ CopyT3 = TypeVar("CopyT3")
 
 
 @overload
-def make_safe_deepcopies(args: list[ModuleT], /) -> list[ModuleT]:
-    pass
+def make_safe_deepcopies(args: list[ModuleT], /) -> list[ModuleT]: ...
 
 
 @overload
-def make_safe_deepcopies(args: ModuleT, /) -> ModuleT:
-    pass
+def make_safe_deepcopies(args: ModuleT, /) -> ModuleT: ...
 
 
 @overload
-def make_safe_deepcopies(a: CopyT1, b: CopyT2, /) -> tuple[CopyT1, CopyT2]:
-    pass
+def make_safe_deepcopies(a: CopyT1, b: CopyT2, /) -> tuple[CopyT1, CopyT2]: ...
 
 
 @overload
 def make_safe_deepcopies(
     a: CopyT1, b: CopyT2, c: CopyT3, /
-) -> tuple[CopyT1, CopyT2, CopyT3]:
-    pass
+) -> tuple[CopyT1, CopyT2, CopyT3]: ...
 
 
 def make_safe_deepcopies(
@@ -847,16 +827,14 @@ def recursive_check_module_attrs(obj: object, networks_only: bool = False) -> bo
 def chkpt_attribute_to_device(
     chkpt_dict: dict[str, Any],
     device: str | torch.device,
-) -> dict[str, Any]:
-    pass
+) -> dict[str, Any]: ...
 
 
 @overload
 def chkpt_attribute_to_device(
     chkpt_dict: list[dict[str, Any]],
     device: str | torch.device,
-) -> list[dict[str, Any]]:
-    pass
+) -> list[dict[str, Any]]: ...
 
 
 def chkpt_attribute_to_device(
@@ -1160,41 +1138,35 @@ def concatenate_spaces(space_list: list[spaces.Space]) -> spaces.Space:
 
 
 @overload
-def obs_to_tensor(obs: TensorDict, device: str | torch.device) -> TensorDict:
-    pass
+def obs_to_tensor(obs: TensorDict, device: str | torch.device) -> TensorDict: ...
 
 
 @overload
 def obs_to_tensor(
     obs: ArrayOrTensor | Number | list[Any], device: str | torch.device
-) -> torch.Tensor:
-    pass
+) -> torch.Tensor: ...
 
 
 @overload
 def obs_to_tensor(
     obs: Mapping[str, ArrayOrTensor], device: str | torch.device
-) -> dict[str, torch.Tensor]:
-    pass
+) -> dict[str, torch.Tensor]: ...
 
 
 @overload
 def obs_to_tensor(
     obs: tuple[ArrayOrTensor, ...], device: str | torch.device
-) -> tuple[torch.Tensor, ...]:
-    pass
+) -> tuple[torch.Tensor, ...]: ...
 
 
 @overload
-def obs_to_tensor(obs: ObservationType, device: str | torch.device) -> TorchObsType:
-    pass
+def obs_to_tensor(obs: ObservationType, device: str | torch.device) -> TorchObsType: ...
 
 
 @overload
 def obs_to_tensor(
     obs: dict[str, ObservationType], device: str | torch.device
-) -> dict[str, TorchObsType]:
-    pass
+) -> dict[str, TorchObsType]: ...
 
 
 def obs_to_tensor(
@@ -1663,16 +1635,14 @@ def preprocess_multibinary_observation(
 def apply_image_normalization(
     observation: torch.Tensor,
     observation_space: spaces.Box,
-) -> torch.Tensor:
-    pass
+) -> torch.Tensor: ...
 
 
 @overload
 def apply_image_normalization(
     observation: npt.NDArray,
     observation_space: spaces.Box,
-) -> np.ndarray:
-    pass
+) -> np.ndarray: ...
 
 
 def apply_image_normalization(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ concurrency = ["multiprocessing", "thread"]
 sigterm = true
 
 [tool.coverage.report]
-exclude_lines = [
+exclude_also = [
     "pragma: no cover",
     "if TYPE_CHECKING:",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,14 @@ def cleanup():
         gc.collect()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_working_directory(tmp_path_factory):
+    """Run the test session in a temporary working directory."""
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.chdir(tmp_path_factory.mktemp("cwd"))
+        yield
+
+
 @pytest.fixture(autouse=True)
 def skip_cuda_parametrization_when_unavailable(request):
     """Skip CUDA-specific parametrized tests on environments without CUDA."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,10 @@ def cleanup():
 def isolate_working_directory(tmp_path_factory):
     """Run the test session in a temporary working directory."""
     with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv(
+            "COVERAGE_FILE",
+            os.path.abspath(os.environ.get("COVERAGE_FILE", ".coverage")),
+        )
         monkeypatch.chdir(tmp_path_factory.mktemp("cwd"))
         yield
 

--- a/tests/test_algorithms/test_base.py
+++ b/tests/test_algorithms/test_base.py
@@ -1201,7 +1201,7 @@ class TestRLAlgorithmLoadCheckpoint:
 
         test_script = f"""
 import sys
-sys.path.insert(0, "{os.getcwd()}")
+sys.path.insert(0, "{Path(__file__).parents[2]}")
 import torch
 import numpy as np
 from pathlib import Path
@@ -1240,6 +1240,7 @@ print("SUCCESS: GPU-saved checkpoint loaded via load_checkpoint in no-CUDA envir
         result = subprocess.run(
             [sys.executable, str(script_path)],
             env=env,
+            cwd=Path(__file__).parents[2],
             capture_output=True,
             text=True,
             check=False,
@@ -1404,7 +1405,7 @@ class TestMultiAgentRLAlgorithmLoadCheckpoint:
 
         test_script = f"""
 import sys
-sys.path.insert(0, "{os.getcwd()}")
+sys.path.insert(0, "{Path(__file__).parents[2]}")
 import torch
 import numpy as np
 from pathlib import Path
@@ -1445,6 +1446,7 @@ print("SUCCESS: GPU-saved multi-agent checkpoint loaded via load_checkpoint in n
         result = subprocess.run(
             [sys.executable, str(script_path)],
             env=env,
+            cwd=Path(__file__).parents[2],
             capture_output=True,
             text=True,
             check=False,
@@ -1537,7 +1539,7 @@ class TestRLAlgorithmLoad:
         # Create a subprocess that runs with CUDA_VISIBLE_DEVICES="" to simulate no GPU environment
         test_script = f"""
 import sys
-sys.path.insert(0, "{os.getcwd()}")
+sys.path.insert(0, "{Path(__file__).parents[2]}")
 import torch
 from pathlib import Path
 from tests.test_algorithms.test_base import DummyRLAlgorithm
@@ -1566,6 +1568,7 @@ print("SUCCESS: GPU-saved checkpoint loaded successfully in no-CUDA environment"
         result = subprocess.run(
             [sys.executable, str(script_path)],
             env=env,
+            cwd=Path(__file__).parents[2],
             capture_output=True,
             text=True,
             check=False,
@@ -1724,7 +1727,7 @@ class TestMultiAgentRLAlgorithmLoad:
         # Create a subprocess that runs with CUDA_VISIBLE_DEVICES="" to simulate no GPU environment
         test_script = f"""
 import sys
-sys.path.insert(0, "{os.getcwd()}")
+sys.path.insert(0, "{Path(__file__).parents[2]}")
 import torch
 from pathlib import Path
 from tests.test_algorithms.test_base import DummyMARLAlgorithm
@@ -1755,6 +1758,7 @@ print("SUCCESS: GPU-saved multi-agent checkpoint loaded successfully in no-CUDA 
         result = subprocess.run(
             [sys.executable, str(script_path)],
             env=env,
+            cwd=Path(__file__).parents[2],
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import types
+from pathlib import Path
 from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
@@ -971,7 +972,8 @@ class TestArenaTrainerFromManifest:
     def test_from_yaml_manifest_train_round_trip(self, mock_client):
         """YAML ``from_manifest(...).train()`` round-trips through arena validation."""
         trainer = ArenaTrainer.from_manifest(
-            "configs/training/ppo/ppo.yaml", client=mock_client
+            str(Path(__file__).parents[2] / "configs/training/ppo/ppo.yaml"),
+            client=mock_client,
         )
         result = trainer.train()
 
@@ -1007,7 +1009,8 @@ class TestArenaTrainerFromManifest:
     def test_from_yaml_file(self):
         mock_client = MagicMock()
         trainer = ArenaTrainer.from_manifest(
-            "configs/training/ppo/ppo.yaml", client=mock_client
+            str(Path(__file__).parents[2] / "configs/training/ppo/ppo.yaml"),
+            client=mock_client,
         )
         assert isinstance(trainer, ArenaTrainer)
         assert trainer.algorithm_spec.name == "PPO"
@@ -2188,7 +2191,8 @@ class TestGetValidatedManifest:
         from agilerl.models.manifest import TrainingManifest
 
         manifest = TrainingManifest.get_validated(
-            "configs/training/ppo/ppo.yaml", mode="python"
+            str(Path(__file__).parents[2] / "configs/training/ppo/ppo.yaml"),
+            mode="python",
         )
         assert manifest.algorithm.name == "PPO"
         assert manifest.training.max_steps == 6_000_000

--- a/tests/test_utils/test_ilql_utils.py
+++ b/tests/test_utils/test_ilql_utils.py
@@ -5,6 +5,7 @@ import os
 
 import accelerate
 
+from agilerl.utils import ilql_utils
 from agilerl.utils.ilql_utils import (
     add_system_configs,
     convert_path,
@@ -24,7 +25,7 @@ class TestConvertPath:
         path = "example_path"
         converted_path = convert_path(path)
         assert converted_path == os.path.join(
-            os.path.dirname(os.path.realpath("agilerl/utils/ilql_utils.py")),
+            os.path.dirname(os.path.realpath(ilql_utils.__file__)),
             "../../",
             path,
         )


### PR DESCRIPTION
### TLDR: Run each test worker in its own temporary CWD that gets cleaned up automatically to prevent temporary test artifacts polluting the repo.

`pytest tests/` recreated `env_name-elite_Rainbow DQN.pt` in the repo root: `tournament_selection_and_mutation` saves the elite relative to the CWD when no `elite_path` is given, and the RainbowDQN fixture returns a real agent whose `save_checkpoint` does an actual `torch.save`.

An autouse fixture now chdirs into a temp dir. This also contains the `models/{env_name}` dir the accelerator branch creates, which `/models/` in .gitignore was masking from `git status`.

**Session-scoped, not per-test.** - no impact on test suite completion time.

Some tests updated to prevent failures:
Three CWD-dependent spots anchored to `__file__`: `test_base.py` (subprocess `sys.path` + explicit `cwd=` so coverage fragments still land beside `.coverage`), `test_trainer.py` (ppo.yaml), `test_ilql_utils.py` (expected value was itself CWD-relative, so it only passed from the repo root).
