### PR TITLE
chore: use `...` for empty stub bodies and drop stub-body coverage tests

### DIFF
--- a/agilerl/data/language_environment.py
+++ b/agilerl/data/language_environment.py
@@ -15,11 +15,10 @@ class Language_Observation(ABC):
         # returns a List of Tuples and a bool indicating terminal
         # each state Tuple should be: (str, None)
         # each action Tuple should be: (str, reward)
-        pass
+        ...
 
     @abstractmethod
-    def __str__(self) -> str:
-        pass
+    def __str__(self) -> str: ...
 
     def metadata(self) -> dict[str, Any] | None:
         return None
@@ -27,16 +26,13 @@ class Language_Observation(ABC):
 
 class Language_Environment(ABC):
     @abstractmethod
-    def step(self, action: str) -> tuple[Language_Observation, float, bool]:
-        pass
+    def step(self, action: str) -> tuple[Language_Observation, float, bool]: ...
 
     @abstractmethod
-    def reset(self) -> Language_Observation:
-        pass
+    def reset(self) -> Language_Observation: ...
 
     @abstractmethod
-    def is_terminal(self) -> bool:
-        pass
+    def is_terminal(self) -> bool: ...
 
 
 class Policy(ABC):
@@ -44,18 +40,17 @@ class Policy(ABC):
         self.cache = Cache()
 
     @abstractmethod
-    def act(self, obs: Language_Observation) -> str:
-        pass
+    def act(self, obs: Language_Observation) -> str: ...
 
     @abstractmethod
     def train(self) -> None:
         """Set policy to training mode; override in subclasses if needed."""
-        pass
+        ...
 
     @abstractmethod
     def eval(self) -> None:
         """Set policy to eval mode; override in subclasses if needed."""
-        pass
+        ...
 
 
 def interact_environment(

--- a/agilerl/data/rl_data.py
+++ b/agilerl/data/rl_data.py
@@ -16,8 +16,7 @@ from agilerl.data.tokenizer import Tokenizer
 
 class TokenReward(ABC):
     @abstractmethod
-    def get_token_reward(self, tokens: list[int]) -> list[float]:
-        pass
+    def get_token_reward(self, tokens: list[int]) -> list[float]: ...
 
 
 class ConstantTokenReward(TokenReward):
@@ -179,7 +178,7 @@ class RL_Dataset(ABC):
     @abstractmethod
     def __iter__(self) -> Iterator[DataPoint]:
         """Return an iterator over data points. Implemented by subclasses."""
-        pass
+        ...
 
     def __init__(
         self,
@@ -270,12 +269,10 @@ class RL_Dataset(ABC):
 
 class List_RL_Dataset(RL_Dataset):
     @abstractmethod
-    def get_item(self, idx: int) -> DataPoint:
-        pass
+    def get_item(self, idx: int) -> DataPoint: ...
 
     @abstractmethod
-    def size(self) -> int:
-        pass
+    def size(self) -> int: ...
 
     def __iter__(self) -> Iterator[DataPoint]:
         for i in range(self.size()):
@@ -284,8 +281,7 @@ class List_RL_Dataset(RL_Dataset):
 
 class Iterable_RL_Dataset(RL_Dataset):
     @abstractmethod
-    def sample_item(self) -> DataPoint:
-        pass
+    def sample_item(self) -> DataPoint: ...
 
     def __iter__(self) -> Iterator[DataPoint]:
         while True:

--- a/agilerl/data/tokenizer.py
+++ b/agilerl/data/tokenizer.py
@@ -33,8 +33,7 @@ class Tokenizer(ABC):
         self,
         str_: str | list[str],
         **kwargs: Any,
-    ) -> tuple[list[int] | list[list[int]], list[int] | list[list[int]]]:
-        pass
+    ) -> tuple[list[int] | list[list[int]], list[int] | list[list[int]]]: ...
 
     @overload
     def decode(self, tokens: list[int], **kwargs: Any) -> str: ...
@@ -43,21 +42,16 @@ class Tokenizer(ABC):
     @abstractmethod
     def decode(
         self, tokens: list[int] | list[list[int]], **kwargs: Any
-    ) -> str | list[str]:
-        pass
+    ) -> str | list[str]: ...
 
     @abstractmethod
-    def num_tokens(self) -> int:
-        pass
+    def num_tokens(self) -> int: ...
 
     @abstractmethod
-    def id_to_token(self, id_: int) -> str:
-        pass
+    def id_to_token(self, id_: int) -> str: ...
 
     @abstractmethod
-    def token_to_id(self, token: str) -> int:
-        pass
+    def token_to_id(self, token: str) -> int: ...
 
     @abstractmethod
-    def get_vocab(self) -> dict[str, int] | list[str]:
-        pass
+    def get_vocab(self) -> dict[str, int] | list[str]: ...

--- a/agilerl/protocols.py
+++ b/agilerl/protocols.py
@@ -83,7 +83,7 @@ class MutationMethodProtocol(Protocol):
     _recreate_kwargs: dict[str, Any]
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401 -- mutation methods take and return arbitrary values
-        pass
+        ...
 
 
 @runtime_checkable
@@ -96,7 +96,7 @@ class OptimizerLikeClass(Protocol):
         lr: float,
         **kwargs: Any,
     ) -> Optimizer | Any:  # noqa: ANN401 -- some optimizer-like classes return non-Optimizer handles
-        pass
+        ...
 
 
 @runtime_checkable
@@ -125,83 +125,64 @@ class EvolvableModuleProtocol(Protocol):
     # Read-only: implementations expose these as properties, and a mutable
     # member's invariance would reject every one of them.
     @property
-    def init_dict(self) -> dict[str, Any]:
-        pass
+    def init_dict(self) -> dict[str, Any]: ...
 
     @property
-    def layer_mutation_methods(self) -> list[str]:
-        pass
+    def layer_mutation_methods(self) -> list[str]: ...
 
     @property
-    def node_mutation_methods(self) -> list[str]:
-        pass
+    def node_mutation_methods(self) -> list[str]: ...
 
     @property
-    def mutation_methods(self) -> list[str]:
-        pass
+    def mutation_methods(self) -> list[str]: ...
 
     @property
-    def last_mutation_attr(self) -> str | None:
-        pass
+    def last_mutation_attr(self) -> str | None: ...
 
     @property
-    def last_mutation(self) -> "MutationMethodProtocol | None":
-        pass
+    def last_mutation(self) -> "MutationMethodProtocol | None": ...
 
     @property
-    def rng(self) -> np.random.Generator | None:
-        pass
+    def rng(self) -> np.random.Generator | None: ...
 
     # Read-only: implementations narrow this (EvolvableModule exposes `str`),
     # which a mutable member's invariance would reject.
     @property
-    def device(self) -> DeviceType:
-        pass
+    def device(self) -> DeviceType: ...
 
     @property
-    def activation(self) -> str | None:
-        pass
+    def activation(self) -> str | None: ...
 
-    def change_activation(self, activation: str, output: bool) -> None:
-        pass
+    def change_activation(self, activation: str, output: bool) -> None: ...
 
     def forward(self, x: Any, /) -> Any:  # noqa: ANN401 -- protocol forward must accept and return whatever conforming modules do
-        pass
+        ...
 
-    def parameters(self) -> Iterator[torch.nn.Parameter]:
-        pass
+    def parameters(self) -> Iterator[torch.nn.Parameter]: ...
 
-    def to(self, device: DeviceType) -> Self:
-        pass
+    def to(self, device: DeviceType) -> Self: ...
 
-    def state_dict(self) -> dict[str, Any]:
-        pass
+    def state_dict(self) -> dict[str, Any]: ...
 
-    def disable_mutations(self) -> None:
-        pass
+    def disable_mutations(self) -> None: ...
 
-    def get_mutation_methods(self) -> dict[str, MutationMethodProtocol]:
-        pass
+    def get_mutation_methods(self) -> dict[str, MutationMethodProtocol]: ...
 
-    def get_mutation_probs(self, new_layer_prob: float) -> list[float]:
-        pass
+    def get_mutation_probs(self, new_layer_prob: float) -> list[float]: ...
 
     def sample_mutation_method(
         self,
         new_layer_prob: float,
         rng: np.random.Generator | None = None,
-    ) -> str:
-        pass
+    ) -> str: ...
 
-    def clone(self) -> Self:
-        pass
+    def clone(self) -> Self: ...
 
     def load_state_dict(
         self,
         state_dict: dict[str, Any],
         strict: bool = True,
-    ) -> None:
-        pass
+    ) -> None: ...
 
 
 @runtime_checkable
@@ -219,42 +200,35 @@ class EvolvableNetworkProtocol(EvolvableModuleProtocol, Protocol):
         /,
         *args: Any,
         **kwargs: Any,
-    ) -> torch.Tensor:
-        pass
+    ) -> torch.Tensor: ...
 
-    def extract_features(self, x: TorchObsType, /) -> torch.Tensor:
-        pass
+    def extract_features(self, x: TorchObsType, /) -> torch.Tensor: ...
 
-    def build_network_head(self, *args: Any, **kwargs: Any) -> None:
-        pass
+    def build_network_head(self, *args: Any, **kwargs: Any) -> None: ...
 
-    def add_latent_node(self, numb_new_nodes: int | None = None) -> "MutationApplyDict":
-        pass
+    def add_latent_node(
+        self, numb_new_nodes: int | None = None
+    ) -> "MutationApplyDict": ...
 
     def remove_latent_node(
         self,
         numb_new_nodes: int | None = None,
-    ) -> "MutationApplyDict":
-        pass
+    ) -> "MutationApplyDict": ...
 
-    def recreate_encoder(self) -> None:
-        pass
+    def recreate_encoder(self) -> None: ...
 
     def initialize_hidden_state(
         self,
         batch_size: int = 1,
-    ) -> dict[str, torch.Tensor]:
-        pass
+    ) -> dict[str, torch.Tensor]: ...
 
     def init_weights_gaussian(
         self,
         std_coeff: float = 4.0,
         output_coeff: float = 2.0,
-    ) -> None:
-        pass
+    ) -> None: ...
 
-    def _build_encoder(self, *args: Any, **kwargs: Any) -> Module:
-        pass
+    def _build_encoder(self, *args: Any, **kwargs: Any) -> Module: ...
 
 
 # Values may also be plain torch modules or torch.compile wrappers
@@ -274,41 +248,30 @@ class ModuleDictProtocol(Protocol, Generic[T]):
     """
 
     @property
-    def device(self) -> DeviceType:
-        pass
+    def device(self) -> DeviceType: ...
 
-    def __getitem__(self, key: str) -> T:
-        pass
+    def __getitem__(self, key: str) -> T: ...
 
-    def keys(self) -> Iterable[str]:
-        pass
+    def keys(self) -> Iterable[str]: ...
 
-    def values(self) -> Iterable[T]:
-        pass
+    def values(self) -> Iterable[T]: ...
 
-    def items(self) -> Iterable[tuple[str, T]]:
-        pass
+    def items(self) -> Iterable[tuple[str, T]]: ...
 
-    def evolvable_modules(self) -> dict[str, T]:
-        pass
+    def evolvable_modules(self) -> dict[str, T]: ...
 
-    def get_mutation_methods(self) -> dict[str, MutationMethodProtocol]:
-        pass
+    def get_mutation_methods(self) -> dict[str, MutationMethodProtocol]: ...
 
-    def filter_mutation_methods(self, method: str) -> None:
-        pass
+    def filter_mutation_methods(self, method: str) -> None: ...
 
     @property
-    def mutation_methods(self) -> list[str]:
-        pass
+    def mutation_methods(self) -> list[str]: ...
 
     @property
-    def layer_mutation_methods(self) -> list[str]:
-        pass
+    def layer_mutation_methods(self) -> list[str]: ...
 
     @property
-    def node_mutation_methods(self) -> list[str]:
-        pass
+    def node_mutation_methods(self) -> list[str]: ...
 
 
 EvolvableNetworkType = EvolvableModuleProtocol | ModuleDictProtocol
@@ -360,8 +323,7 @@ class OptimizerConfig(Protocol):
     optimizer_kwargs: dict[str, Any] | list[dict[str, Any]]
     multiagent: bool
 
-    def get_optimizer_cls(self) -> type[Optimizer] | list[type[Optimizer]]:
-        pass
+    def get_optimizer_cls(self) -> type[Optimizer] | list[type[Optimizer]]: ...
 
 
 @runtime_checkable
@@ -376,8 +338,7 @@ class MutationRegistryProtocol(Protocol):
     optimizers: list[OptimizerConfig]
     hooks: list[Callable[[], None]]
 
-    def networks(self) -> list[NetworkConfigProtocol]:
-        pass
+    def networks(self) -> list[NetworkConfigProtocol]: ...
 
 
 EvolvableAlgorithm = TypeVar(
@@ -414,11 +375,9 @@ class EvolvableAlgorithmProtocol(Protocol):
     @scores.setter
     def scores(self, value: list[float | list[float]]) -> None: ...
 
-    def unwrap_models(self) -> None:
-        pass
+    def unwrap_models(self) -> None: ...
 
-    def wrap_models(self) -> None:
-        pass
+    def wrap_models(self) -> None: ...
 
     @classmethod
     def load(
@@ -426,52 +385,43 @@ class EvolvableAlgorithmProtocol(Protocol):
         path: str,
         device: str | torch.device = "cpu",
         accelerator: Accelerator | None = None,
-    ) -> Self:
-        pass
+    ) -> Self: ...
 
-    def load_checkpoint(self, path: str) -> None:
-        pass
+    def load_checkpoint(self, path: str) -> None: ...
 
-    def save_checkpoint(self, path: str) -> None:
-        pass
+    def save_checkpoint(self, path: str) -> None: ...
 
     def learn(self, experiences: Any) -> Any:  # noqa: ANN401 -- experience format and loss return vary per algorithm
-        pass
+        ...
 
     def get_action(self, obs: Any, **kwargs: Any) -> Any:  # noqa: ANN401 -- obs and action types vary across RL/LLM/multi-agent algorithms
-        pass
+        ...
 
     def test(self, env: Any) -> Any:  # noqa: ANN401 -- env type and fitness return vary per algorithm
-        pass
+        ...
 
     def evolvable_attributes(
         self,
         networks_only: bool = False,
-    ) -> EvolvableAttributeDict:
-        pass
+    ) -> EvolvableAttributeDict: ...
 
     @staticmethod
     def inspect_attributes(
         agent: Any,  # noqa: ANN401 -- accepts any evolvable algorithm or wrapped agent
         input_args_only: bool = False,
-    ) -> dict[str, Any]:
-        pass
+    ) -> dict[str, Any]: ...
 
     def clone(
         self,
         index: int | None = None,
         wrap: bool = True,
-    ) -> Self:
-        pass
+    ) -> Self: ...
 
-    def clean_up(self) -> None:
-        pass
+    def clean_up(self) -> None: ...
 
-    def recompile(self) -> None:
-        pass
+    def recompile(self) -> None: ...
 
-    def mutation_hook(self) -> None:
-        pass
+    def mutation_hook(self) -> None: ...
 
 
 # Define a TypeVar for EvolvableAlgorithm that can be used for generic typing
@@ -489,20 +439,18 @@ class AgentWrapperProtocol(Protocol, Generic[EvolvableAlgorithmT]):
     agent: EvolvableAlgorithmT
 
     def get_action(self, obs: ObservationType, **kwargs: Any) -> Any:  # noqa: ANN401 -- action return type varies per wrapped algorithm
-        pass
+        ...
 
     def learn(
         self,
         experiences: tuple[Iterable[ObservationType], ...],
         **kwargs: Any,
-    ) -> None:
-        pass
+    ) -> None: ...
 
     def evolvable_attributes(
         self,
         networks_only: bool = False,
-    ) -> EvolvableAttributeDict:
-        pass
+    ) -> EvolvableAttributeDict: ...
 
 
 @runtime_checkable
@@ -533,34 +481,28 @@ class PretrainedConfigProtocol(Protocol):
     num_attention_heads: int
     num_hidden_layers: int
 
-    def to_dict(self) -> dict[str, Any]:
-        pass
+    def to_dict(self) -> dict[str, Any]: ...
 
-    def to_json_string(self) -> str:
-        pass
+    def to_json_string(self) -> str: ...
 
-    def save_pretrained(self, save_directory: str, **kwargs: Any) -> None:
-        pass
+    def save_pretrained(self, save_directory: str, **kwargs: Any) -> None: ...
 
     @classmethod
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: str,
         **kwargs: Any,
-    ) -> "PretrainedConfigProtocol":
-        pass
+    ) -> "PretrainedConfigProtocol": ...
 
     @classmethod
     def from_dict(
         cls,
         config_dict: dict[str, Any],
         **kwargs: Any,
-    ) -> "PretrainedConfigProtocol":
-        pass
+    ) -> "PretrainedConfigProtocol": ...
 
     @classmethod
-    def from_json_file(cls, json_file: str) -> "PretrainedConfigProtocol":
-        pass
+    def from_json_file(cls, json_file: str) -> "PretrainedConfigProtocol": ...
 
 
 @runtime_checkable
@@ -593,11 +535,9 @@ class PreTrainedModelProtocol(Protocol):
     device: DeviceType
     config: Any
 
-    def eval(self) -> "PreTrainedModelProtocol":
-        pass
+    def eval(self) -> "PreTrainedModelProtocol": ...
 
-    def train(self, mode: bool = True) -> "PreTrainedModelProtocol":
-        pass
+    def train(self, mode: bool = True) -> "PreTrainedModelProtocol": ...
 
     def generate(
         self,
@@ -605,27 +545,22 @@ class PreTrainedModelProtocol(Protocol):
         attention_mask: torch.Tensor | None = None,
         generation_config: GenerationConfigProtocol | None = None,
         **kwargs: Any,
-    ) -> torch.Tensor:
-        pass
+    ) -> torch.Tensor: ...
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401 -- model forward output type varies (logits, tuples, ModelOutput)
-        pass
+        ...
 
-    def parameters(self) -> Iterator[torch.nn.Parameter]:
-        pass
+    def parameters(self) -> Iterator[torch.nn.Parameter]: ...
 
-    def state_dict(self) -> dict[str, Any]:
-        pass
+    def state_dict(self) -> dict[str, Any]: ...
 
     def load_state_dict(
         self,
         state_dict: dict[str, Any],
         strict: bool = True,
-    ) -> None:
-        pass
+    ) -> None: ...
 
-    def to(self, device: DeviceType) -> "PreTrainedModelProtocol":
-        pass
+    def to(self, device: DeviceType) -> "PreTrainedModelProtocol": ...
 
 
 @runtime_checkable
@@ -638,11 +573,9 @@ class PeftModelProtocol(Protocol):
 
     peft_config: dict[str, Any]
 
-    def eval(self) -> "PeftModelProtocol":
-        pass
+    def eval(self) -> "PeftModelProtocol": ...
 
-    def train(self, mode: bool = True) -> "PeftModelProtocol":
-        pass
+    def train(self, mode: bool = True) -> "PeftModelProtocol": ...
 
     def generate(
         self,
@@ -650,27 +583,22 @@ class PeftModelProtocol(Protocol):
         attention_mask: torch.Tensor | None = None,
         generation_config: GenerationConfigProtocol | None = None,
         **kwargs: Any,
-    ) -> torch.Tensor:
-        pass
+    ) -> torch.Tensor: ...
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401 -- model forward output type varies (logits, tuples, ModelOutput)
-        pass
+        ...
 
-    def parameters(self) -> Iterator[torch.nn.Parameter]:
-        pass
+    def parameters(self) -> Iterator[torch.nn.Parameter]: ...
 
-    def state_dict(self) -> dict[str, Any]:
-        pass
+    def state_dict(self) -> dict[str, Any]: ...
 
     def load_state_dict(
         self,
         state_dict: dict[str, Any],
         strict: bool = True,
-    ) -> None:
-        pass
+    ) -> None: ...
 
-    def to(self, device: DeviceType) -> "PeftModelProtocol":
-        pass
+    def to(self, device: DeviceType) -> "PeftModelProtocol": ...
 
     @classmethod
     def from_pretrained(
@@ -678,8 +606,7 @@ class PeftModelProtocol(Protocol):
         base_model: PreTrainedModelProtocol,
         adapter_path: str,
         **kwargs: Any,
-    ) -> "PeftModelProtocol":
-        pass
+    ) -> "PeftModelProtocol": ...
 
 
 @runtime_checkable
@@ -711,11 +638,9 @@ class BanditEnvProtocol(Protocol):
     @property
     def single_action_space(self) -> spaces.Discrete: ...
 
-    def reset(self) -> npt.NDArray:
-        pass
+    def reset(self) -> npt.NDArray: ...
 
-    def step(self, k: int) -> tuple[npt.NDArray, float]:
-        pass
+    def step(self, k: int) -> tuple[npt.NDArray, float]: ...
 
 
 @runtime_checkable
@@ -726,16 +651,13 @@ class MultiTurnEnv(Protocol):
 
     def reset(
         self, seed: int | None = None
-    ) -> tuple[str | dict[str, Any], dict[str, Any]]:
-        pass
+    ) -> tuple[str | dict[str, Any], dict[str, Any]]: ...
 
     def step(
         self, action: str, **kwargs: Any
-    ) -> tuple[str | dict[str, Any], float, bool, bool, dict[str, Any]]:
-        pass
+    ) -> tuple[str | dict[str, Any], float, bool, bool, dict[str, Any]]: ...
 
-    def close(self) -> None:
-        pass
+    def close(self) -> None: ...
 
 
 @runtime_checkable
@@ -746,16 +668,12 @@ class TokenizedMultiTurnEnv(Protocol):
 
     def reset(
         self, seed: int | None = None
-    ) -> "tuple[ReasoningPrompts, dict[str, Any]]":
-        pass
+    ) -> "tuple[ReasoningPrompts, dict[str, Any]]": ...
 
-    def step(self, full_completion_ids: torch.Tensor, /) -> "TokenObsStepReturn":
-        pass
+    def step(self, full_completion_ids: torch.Tensor, /) -> "TokenObsStepReturn": ...
 
-    def close(self) -> None:
-        pass
+    def close(self) -> None: ...
 
     def get_episode_data(
         self,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        pass
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]: ...

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -39,7 +39,6 @@ from agilerl.networks import (
     ValueNetwork,
 )
 from agilerl.protocols import (
-    AgentWrapperProtocol,
     BanditEnvProtocol,
     EvolvableAlgorithmProtocol,
     EvolvableModuleProtocol,
@@ -47,12 +46,8 @@ from agilerl.protocols import (
     LoraConfigProtocol,
     ModuleDictProtocol,
     MutationMethodProtocol,
-    MutationRegistryProtocol,
     MutationType,
-    OptimizerConfig,
-    OptimizerLikeClass,
     PeftModelProtocol,
-    PretrainedConfigProtocol,
     PreTrainedModelProtocol,
 )
 from agilerl.wrappers.agent import RSNorm
@@ -129,80 +124,6 @@ class TestEvolvableAlgorithmProtocol:
 
         assert isinstance(instance, EvolvableAlgorithmProtocol)
 
-    @pytest.mark.parametrize(
-        ("algo_cls", "obs", "act"),
-        [
-            (
-                DQN,
-                generate_random_box_space(shape=(4,)),
-                generate_discrete_space(2),
-            ),
-            (
-                PPO,
-                generate_random_box_space(shape=(4,)),
-                generate_random_box_space(shape=(2,)),
-            ),
-        ],
-    )
-    def test_evolvable_algorithm_protocol_methods_executed(self, algo_cls, obs, act):
-        inst = algo_cls(obs, act)
-        EvolvableAlgorithmProtocol.unwrap_models(inst)
-        EvolvableAlgorithmProtocol.wrap_models(inst)
-        _ = EvolvableAlgorithmProtocol.get_action(inst, obs.sample())
-        _ = EvolvableAlgorithmProtocol.evolvable_attributes(inst)
-        _ = EvolvableAlgorithmProtocol.evolvable_attributes(inst, networks_only=True)
-        _ = EvolvableAlgorithmProtocol.inspect_attributes(inst)
-        _ = EvolvableAlgorithmProtocol.inspect_attributes(inst, input_args_only=True)
-        EvolvableAlgorithmProtocol.recompile(inst)
-        EvolvableAlgorithmProtocol.mutation_hook(inst)
-        EvolvableAlgorithmProtocol.clean_up(inst)
-        _ = EvolvableAlgorithmProtocol.scores.fget(inst)
-
-    @pytest.mark.parametrize(
-        ("algo_cls", "obs", "act"),
-        [
-            (
-                DQN,
-                generate_random_box_space(shape=(4,)),
-                generate_discrete_space(2),
-            ),
-            (
-                PPO,
-                generate_random_box_space(shape=(4,)),
-                generate_random_box_space(shape=(2,)),
-            ),
-        ],
-    )
-    def test_evolvable_algorithm_load_checkpoint_learn_test_clone(
-        self, algo_cls, obs, act, tmp_path
-    ):
-        inst = algo_cls(obs, act)
-        EvolvableAlgorithmProtocol.save_checkpoint(inst, str(tmp_path / "ckpt.pt"))
-        EvolvableAlgorithmProtocol.load_checkpoint(inst, str(tmp_path / "ckpt.pt"))
-        _ = EvolvableAlgorithmProtocol.load(algo_cls, str(tmp_path / "ckpt.pt"))
-        exp = (
-            (
-                torch.randn(4, 4),
-                torch.randn(4, 2),
-                torch.randn(4),
-                torch.randn(4, 4),
-                torch.zeros(4, dtype=torch.bool),
-            )
-            if algo_cls is DQN
-            else (
-                torch.randn(4, 4),
-                torch.randn(4, 2),
-                torch.randn(4),
-                torch.randn(4),
-                torch.randn(4),
-                torch.randn(4),
-                torch.zeros(4, dtype=torch.bool),
-            )
-        )
-        EvolvableAlgorithmProtocol.learn(inst, exp)
-        _ = EvolvableAlgorithmProtocol.test(inst, None)
-        _ = EvolvableAlgorithmProtocol.clone(inst, None, False)
-
 
 class TestEvolvableNetworkProtocol:
     """Test that classes implement the EvolvableNetwork protocol."""
@@ -242,29 +163,6 @@ class TestEvolvableNetworkProtocol:
         # Create network instance
         network = network_cls(observation_space, action_space, **kwargs)
         assert isinstance(network, EvolvableNetworkProtocol)
-
-    @pytest.mark.parametrize("network_cls", [QNetwork, ContinuousQNetwork])
-    def test_evolvable_network_protocol_methods_executed(self, network_cls):
-        obs = generate_random_box_space(shape=(4,))
-        act = (
-            generate_discrete_space(2)
-            if network_cls is QNetwork
-            else generate_random_box_space(shape=(2,))
-        )
-        net = network_cls(obs, act)
-        lat = torch.randn(2, 8)
-        x = torch.randn(2, 4)
-        _ = EvolvableNetworkProtocol.forward_head(net, lat)
-        _ = EvolvableNetworkProtocol.extract_features(net, x)
-        _ = EvolvableNetworkProtocol.add_latent_node(net, 1)
-        _ = EvolvableNetworkProtocol.remove_latent_node(net, 1)
-        EvolvableNetworkProtocol.recreate_encoder(net)
-        _ = EvolvableNetworkProtocol.initialize_hidden_state(net, 2)
-        EvolvableNetworkProtocol.init_weights_gaussian(net)
-        head_cfg = net.head_net.net_config
-        EvolvableNetworkProtocol.build_network_head(net, head_cfg)
-        enc_cfg = net.encoder_config
-        EvolvableNetworkProtocol._build_encoder(net, enc_cfg)
 
 
 class TestEvolvableModuleProtocol:
@@ -319,45 +217,6 @@ class TestEvolvableModuleProtocol:
                 f"Mutation method {method_name} does not implement MutationMethod protocol"
             )
 
-    @pytest.mark.parametrize("module_cls", [EvolvableMLP, EvolvableCNN])
-    def test_evolvable_module_protocol_methods_executed(self, module_cls):
-        if module_cls is EvolvableMLP:
-            kwargs = {"num_outputs": 4, "num_inputs": 4, "hidden_size": [8]}
-            x = torch.randn(2, 4)
-        else:
-            kwargs = {
-                "num_outputs": 4,
-                "input_shape": [3, 8, 8],
-                "channel_size": [4],
-                "kernel_size": [3],
-                "stride_size": [1],
-            }
-            x = torch.randn(2, 3, 8, 8)
-        mod = module_cls(**kwargs)
-        _ = EvolvableModuleProtocol.activation.fget(mod)
-        EvolvableModuleProtocol.change_activation(mod, "relu", False)
-        EvolvableModuleProtocol.forward(mod, x)
-        EvolvableModuleProtocol.parameters(mod)
-        EvolvableModuleProtocol.to(mod, "cpu")
-        _ = EvolvableModuleProtocol.state_dict(mod)
-        EvolvableModuleProtocol.disable_mutations(mod)
-        _ = EvolvableModuleProtocol.get_mutation_methods(mod)
-        _ = EvolvableModuleProtocol.get_mutation_probs(mod, 0.5)
-        _ = EvolvableModuleProtocol.sample_mutation_method(mod, 0.5, None)
-        _ = EvolvableModuleProtocol.clone(mod)
-        EvolvableModuleProtocol.load_state_dict(mod, mod.state_dict())
-        # Read-only property bodies.
-        _ = EvolvableModuleProtocol.init_dict.fget(mod)
-        _ = EvolvableModuleProtocol.layer_mutation_methods.fget(mod)
-        _ = EvolvableModuleProtocol.node_mutation_methods.fget(mod)
-        _ = EvolvableModuleProtocol.mutation_methods.fget(mod)
-        _ = EvolvableModuleProtocol.last_mutation_attr.fget(mod)
-        _ = EvolvableModuleProtocol.last_mutation.fget(mod)
-        _ = EvolvableModuleProtocol.rng.fget(mod)
-        _ = EvolvableModuleProtocol.device.fget(mod)
-        for m in mod.get_mutation_methods().values():
-            MutationMethodProtocol.__call__(m, mod)
-
 
 class TestPreTrainedModelProtocol:
     """Test that HuggingFace PreTrainedModel instances satisfy PreTrainedModelProtocol."""
@@ -376,55 +235,6 @@ class TestPreTrainedModelProtocol:
         )
         model = GPT2LMHeadModel(config)
         assert isinstance(model, PreTrainedModelProtocol)
-
-    def test_pretrained_and_peft_protocol_methods_executed(self, tmp_path):
-        pytest.importorskip("transformers")
-        from transformers import GPT2Config, GPT2LMHeadModel
-
-        config = GPT2Config(
-            vocab_size=100, n_positions=64, n_embd=32, n_layer=1, n_head=2
-        )
-        model = GPT2LMHeadModel(config)
-        PreTrainedModelProtocol.eval(model)
-        PreTrainedModelProtocol.train(model, True)
-        PreTrainedModelProtocol.forward(model, torch.randint(0, 100, (1, 4)))
-        PreTrainedModelProtocol.parameters(model)
-        _ = PreTrainedModelProtocol.state_dict(model)
-        PreTrainedModelProtocol.load_state_dict(model, model.state_dict())
-        PreTrainedModelProtocol.to(model, "cpu")
-        _ = PreTrainedModelProtocol.generate(
-            model, torch.randint(0, 100, (1, 4)), generation_config=None
-        )
-
-        pytest.importorskip("peft")
-        from peft import LoraConfig, get_peft_model
-
-        base = GPT2LMHeadModel(config)
-        peft_model = get_peft_model(
-            base,
-            LoraConfig(
-                r=4,
-                lora_alpha=8,
-                target_modules=["c_attn"],
-                lora_dropout=0.0,
-                task_type="CAUSAL_LM",
-            ),
-        )
-        PeftModelProtocol.eval(peft_model)
-        PeftModelProtocol.train(peft_model, True)
-        PeftModelProtocol.forward(peft_model, torch.randint(0, 100, (1, 4)))
-        PeftModelProtocol.parameters(peft_model)
-        _ = PeftModelProtocol.state_dict(peft_model)
-        PeftModelProtocol.load_state_dict(
-            peft_model, peft_model.state_dict(), strict=True
-        )
-        PeftModelProtocol.to(peft_model, "cpu")
-        _ = PeftModelProtocol.generate(
-            peft_model, torch.randint(0, 100, (1, 4)), generation_config=None
-        )
-        peft_model.save_pretrained(str(tmp_path))
-        base2 = GPT2LMHeadModel(config)
-        _ = PeftModelProtocol.from_pretrained(base2, str(tmp_path))
 
 
 class TestPeftModelProtocol:
@@ -457,43 +267,11 @@ class TestPeftModelProtocol:
 
 
 class TestModuleDictProtocol:
-    def test_module_dict_protocol_methods_executed(self):
+    def test_module_dict_implements_protocol(self):
         mdl = ModuleDict(
             {"a": EvolvableMLP(num_inputs=4, num_outputs=2, hidden_size=[8])},
         )
         assert isinstance(mdl, ModuleDictProtocol)
-        _ = ModuleDictProtocol.__getitem__(mdl, "a")
-        _ = ModuleDictProtocol.keys(mdl)
-        _ = ModuleDictProtocol.values(mdl)
-        _ = ModuleDictProtocol.items(mdl)
-        _ = ModuleDictProtocol.evolvable_modules(mdl)
-        _ = ModuleDictProtocol.get_mutation_methods(mdl)
-        ModuleDictProtocol.filter_mutation_methods(mdl, "add")
-        _ = ModuleDictProtocol.mutation_methods.fget(mdl)
-        _ = ModuleDictProtocol.layer_mutation_methods.fget(mdl)
-        _ = ModuleDictProtocol.node_mutation_methods.fget(mdl)
-        _ = ModuleDictProtocol.device.fget(mdl)
-
-
-class TestOptimizerConfig:
-    def test_optimizer_config_and_registry_protocols_executed(self):
-        from agilerl.algorithms.core.registry import (
-            MutationRegistry,
-        )
-        from agilerl.algorithms.core.registry import (
-            OptimizerConfig as RegistryOptimizerConfig,
-        )
-
-        opt_cfg = RegistryOptimizerConfig(
-            name="opt",
-            networks="net",
-            lr="1e-3",
-            optimizer_cls=torch.optim.Adam,
-            optimizer_kwargs={},
-        )
-        _ = OptimizerConfig.get_optimizer_cls(opt_cfg)
-        reg = MutationRegistry()
-        _ = MutationRegistryProtocol.networks(reg)
 
 
 class TestNStepAgentAccess:
@@ -525,49 +303,11 @@ class TestNStepAgentAccess:
         assert rainbow.beta == pytest.approx(start + 0.1)
 
 
-class TestAgentWrapperProtocol:
-    def test_agent_wrapper_protocol_methods_executed(self):
-        from agilerl.wrappers.agent import RSNorm
-
-        obs = generate_random_box_space(shape=(4,))
-        act = generate_discrete_space(2)
-        algo = DQN(obs, act)
-        wrapper = RSNorm(algo)
-        _ = AgentWrapperProtocol.get_action(wrapper, obs.sample())
-        AgentWrapperProtocol.learn(
-            wrapper,
-            (
-                torch.randn(4, 4),
-                torch.randn(4, 1).long(),
-                torch.randn(4),
-                torch.randn(4, 4),
-                torch.zeros(4, dtype=torch.bool),
-            ),
-        )
-        _ = AgentWrapperProtocol.evolvable_attributes(wrapper)
-
-
-class TestTokenizedMultiTurnEnvProtocol:
-    def test_protocol_methods_executed(self):
-        from unittest.mock import MagicMock
-
-        from agilerl.protocols import TokenizedMultiTurnEnv
-
-        env = MagicMock()
-        _ = TokenizedMultiTurnEnv.reset(env)
-        _ = TokenizedMultiTurnEnv.step(env, torch.zeros(1, dtype=torch.long))
-        TokenizedMultiTurnEnv.close(env)
-        _ = TokenizedMultiTurnEnv.get_episode_data(env)
-
-
 class TestLoraConfigProtocol:
-    def test_lora_config_pretrained_config_generation_config_protocols_executed(
-        self, tmp_path
-    ):
+    def test_lora_config_implements_protocol(self):
         pytest.importorskip("transformers")
         pytest.importorskip("peft")
         from peft import LoraConfig
-        from transformers import GenerationConfig, GPT2Config
 
         lora = LoraConfig(
             r=4,
@@ -577,35 +317,6 @@ class TestLoraConfigProtocol:
             task_type="CAUSAL_LM",
         )
         assert isinstance(lora, LoraConfigProtocol)
-        _ = lora.r
-        _ = lora.lora_alpha
-        _ = lora.target_modules
-        _ = lora.task_type
-        _ = lora.lora_dropout
-
-        config = GPT2Config(
-            vocab_size=100, n_positions=64, n_embd=32, n_layer=1, n_head=2
-        )
-        _ = PretrainedConfigProtocol.to_dict(config)
-        _ = PretrainedConfigProtocol.to_json_string(config)
-        PretrainedConfigProtocol.save_pretrained(config, str(tmp_path))
-        _ = PretrainedConfigProtocol.from_dict(config.to_dict())
-        _ = PretrainedConfigProtocol.from_pretrained(str(tmp_path))
-        _ = PretrainedConfigProtocol.from_json_file(str(tmp_path / "config.json"))
-
-        gen_cfg = GenerationConfig()
-        _ = gen_cfg.do_sample
-        _ = gen_cfg.temperature
-        _ = gen_cfg.pad_token_id
-
-
-class TestOptimizerLikeClass:
-    def test_optimizer_like_class_protocol_executed(self):
-        OptimizerLikeClass.__call__(
-            torch.optim.SGD,
-            [torch.nn.Parameter(torch.zeros(1))],
-            0.01,
-        )
 
 
 class TestMutationType:
@@ -625,45 +336,8 @@ def test_protocol_type_aliases_importable():
     assert TorchObsType is not None
 
 
-class TestMultiTurnEnvProtocol:
-    """Cover the ``pass`` bodies of :class:`agilerl.protocols.MultiTurnEnv`
-    protocol methods. A subclass that doesn't override them inherits the
-    base implementation (the bare ``pass``), so invoking the inherited
-    methods runs those statements and registers coverage.
-    """
-
-    def test_protocol_default_method_bodies_execute(self):
-        from agilerl.protocols import MultiTurnEnv
-
-        class _PassthroughEnv(MultiTurnEnv):
-            max_turns = 1
-
-        env = _PassthroughEnv()
-        # Each call executes the inherited ``pass`` body in the protocol
-        # method. Returns ``None`` (the implicit return after ``pass``);
-        # the line gets covered regardless.
-        assert env.reset(seed=0) is None
-        assert env.step(action="noop") is None
-        assert env.close() is None
-
-
 class TestBanditEnvProtocol:
-    """Cover :class:`agilerl.protocols.BanditEnvProtocol` stub bodies and the
-    reference :class:`~agilerl.wrappers.learning.BanditEnv` implementation.
-    """
-
-    def test_protocol_default_method_bodies_execute(self):
-        class _PassthroughBanditEnv(BanditEnvProtocol):
-            arms = 2
-            num_envs = 1
-            single_observation_space = gym.spaces.Box(
-                low=0.0, high=1.0, shape=(4,), dtype=np.float32
-            )
-            single_action_space = gym.spaces.Discrete(2)
-
-        env = _PassthroughBanditEnv()
-        assert env.reset() is None
-        assert env.step(0) is None
+    """Test the reference :class:`~agilerl.wrappers.learning.BanditEnv` implementation."""
 
     def test_bandit_env_implements_protocol(self):
         features = pd.DataFrame(np.random.uniform(0, 1, size=(10, 1)), columns=["x"])


### PR DESCRIPTION
Finishes the job #618 started: that PR converted all 60 `@overload` stubs to `...`, this one converts the remaining 112 `pass` stub bodies so the codebase is internally consistent.

Depends on #618 (merged) — see "Why this needed #618 first" below.

## Why `...` rather than `pass`

- **PEP 484** establishes `...` as the body for stub definitions and `@overload` declarations; typeshed follows this universally. **PEP 544** uses `...` for Protocol method bodies throughout its examples.
- `pass` and `...` are semantically identical — both are no-ops leaving the function returning `None`. There is **no behavioural change**, including for subclasses that inherit a Protocol/ABC default body.
- coverage.py excludes a `...`-only body by default, because such bodies are unreachable by design. `pass` is counted as a real statement, so an unreachable `pass` becomes a permanent uncoverable miss — coverable only by tests that invoke the stub purely to execute it.

## Scope

| File | Converted | Kind |
|---|---|---|
| `agilerl/protocols.py` | 93 | Protocol methods (file already had 5 `...` bodies — inconsistent with itself) |
| `agilerl/data/language_environment.py` | 8 | `@abstractmethod` |
| `agilerl/data/tokenizer.py` | 6 | `@abstractmethod` (file already had 4 `...` overloads) |
| `agilerl/data/rl_data.py` | 5 | `@abstractmethod` |
| `agilerl/logger.py` | **0 — deliberately left as `pass`** | see below |

### `StdOutLogger.close()` keeps its `pass`

It is a *concrete no-op implementation* of the abstract `Logger.close()`, not a stub — it is called for real from `population.py:631` and `tests/test_logger.py:171`. Excluding it from coverage would hide a live code path rather than an unreachable stub.

For `agilerl/data/*` there are no `super()` calls and no unbound calls into any of the 19 abstract methods, so no genuinely-executed body was excluded. Confirmed by the coverage diff below.

## Deleted stub-body coverage tests

With the bodies excluded, 13 tests in `tests/test_protocols.py` no longer assert anything. They existed solely to make stub bodies register as covered, in two shapes:

- `_Passthrough` subclasses that inherit the stub and call it (`assert env.reset() is None`). The old docstring said so outright: *"invoking the inherited methods runs those statements and registers coverage."*
- `test_*_protocol_methods_executed`, which call **unbound** protocol functions with a real instance as `self` — e.g. `PreTrainedModelProtocol.forward(model, ...)` runs the protocol's `pass`, not the model's `forward`.

Kept: every genuine `isinstance` conformance assertion against a `runtime_checkable` protocol, `TestNStepAgentAccess`, the enum test, and the reference `BanditEnv` test. `TestModuleDictProtocol` and `TestLoraConfigProtocol` were trimmed to their conformance assertion rather than deleted, and renamed to match.

One thing to note for review: `TestLoraConfigProtocol` also exercised `PretrainedConfigProtocol` stubs, so `GPT2Config`'s conformance to that protocol is no longer asserted anywhere. Adding `assert isinstance(config, PretrainedConfigProtocol)` would restore it as a real check against transformers — happy to add if wanted.

## Why this needed #618 first

#618 changed `[tool.coverage.report]` from `exclude_lines` to `exclude_also`. `exclude_lines` **replaces** coverage.py's built-in default exclusions, one of which is the `...` stub-body rule. Verified empirically on coverage.py 7.14.0 with a standalone `...` body:

| config | Stmts | `...` body |
|---|---|---|
| `exclude_lines` | 18 | counted, **missing** |
| `exclude_also` | 14 | excluded |

Under the old `exclude_lines`, this PR would have *dropped* coverage instead of preserving it.

## Verification

Full `bash scripts/run-tests.sh cov --cov-report=term-missing`, before and after:

| File | Before | After |
|---|---|---|
| `agilerl/protocols.py` | 335 stmts, 0 miss, 100% | 139 stmts, 0 miss, 100% |
| `agilerl/data/rl_data.py` | 148, 0, 100% | 135, 0, 100% |
| `agilerl/data/language_environment.py` | 46, 0, 100% | 28, 0, 100% |
| `agilerl/data/tokenizer.py` | 28, 0, 100% | 10, 0, 100% |
| `agilerl/logger.py` | 111, 0, 100% | 111, 0, 100% |

**No new missing lines. Total misses unchanged at 2594; overall coverage held** (27724 → 27479 statements — the drop is the now-excluded stub definitions leaving both numerator and denominator). 4427 passed, 1048 skipped, 0 failed.

The 91% overall figure is a local macOS run where 1048 GPU/vLLM tests skip, so it is a relative before/after on one machine — CI is the real check.

`ruff check` / `ruff format` (v0.16.0), the full pre-commit suite, and `ty` all pass. Ruff collapses `def f(...) -> X:` + `...` onto one line, except where a trailing `# noqa` on the `def` line prevents it.
