### PR TITLE
perf: fuse algorithm hot paths and vectorize the DQN curriculum tutorial

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -404,40 +404,6 @@ class EvolvableAlgorithm(ABC, Generic[ExperiencesT], metaclass=RegistryMeta):
         self.registry = MutationRegistry(hp_config)
         self.training = True
 
-    @torch.no_grad()
-    def _soft_update(
-        self,
-        source: torch.nn.Module,
-        target: torch.nn.Module,
-        tau: float,
-    ) -> None:
-        """Polyak update ``target <- tau * source + (1 - tau) * target``, fused across parameters.
-
-        :param source: Network whose parameters are copied from.
-        :type source: torch.nn.Module
-        :param target: Target network updated in place.
-        :type target: torch.nn.Module
-        :param tau: Interpolation weight toward ``source``.
-        :type tau: float
-        """
-        torch._foreach_lerp_(list(target.parameters()), list(source.parameters()), tau)
-
-    def _adam_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-        """Add ``fused=True`` to Adam kwargs when the fused CUDA kernel is usable.
-
-        :param kwargs: Base optimizer keyword arguments to augment.
-        :return: ``kwargs``, with ``fused=True`` added when applicable.
-        :rtype: dict[str, Any]
-        """
-        if (
-            "fused" not in kwargs
-            and not kwargs.get("capturable")
-            and self.accelerator is None
-            and "cuda" in str(self.device)
-        ):
-            kwargs["fused"] = True
-        return kwargs
-
     @property
     def index(self) -> int:
         """Return the index of the algorithm."""

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -404,6 +404,40 @@ class EvolvableAlgorithm(ABC, Generic[ExperiencesT], metaclass=RegistryMeta):
         self.registry = MutationRegistry(hp_config)
         self.training = True
 
+    @torch.no_grad()
+    def _soft_update(
+        self,
+        source: torch.nn.Module,
+        target: torch.nn.Module,
+        tau: float,
+    ) -> None:
+        """Polyak update ``target <- tau * source + (1 - tau) * target``, fused across parameters.
+
+        :param source: Network whose parameters are copied from.
+        :type source: torch.nn.Module
+        :param target: Target network updated in place.
+        :type target: torch.nn.Module
+        :param tau: Interpolation weight toward ``source``.
+        :type tau: float
+        """
+        torch._foreach_lerp_(list(target.parameters()), list(source.parameters()), tau)
+
+    def _adam_kwargs(self, **kwargs: Any) -> dict[str, Any]:
+        """Add ``fused=True`` to Adam kwargs when the fused CUDA kernel is usable.
+
+        :param kwargs: Base optimizer keyword arguments to augment.
+        :return: ``kwargs``, with ``fused=True`` added when applicable.
+        :rtype: dict[str, Any]
+        """
+        if (
+            "fused" not in kwargs
+            and not kwargs.get("capturable")
+            and self.accelerator is None
+            and "cuda" in str(self.device)
+        ):
+            kwargs["fused"] = True
+        return kwargs
+
     @property
     def index(self) -> int:
         """Return the index of the algorithm."""

--- a/agilerl/algorithms/cqn.py
+++ b/agilerl/algorithms/cqn.py
@@ -28,7 +28,7 @@ from agilerl.typing import (
     ReplayBatch,
     numpy_action_mask,
 )
-from agilerl.utils.algo_utils import make_safe_deepcopies
+from agilerl.utils.algo_utils import is_train_eval_invariant, make_safe_deepcopies
 
 
 class CQN(RLAlgorithm[TensorDict]):
@@ -172,11 +172,14 @@ class CQN(RLAlgorithm[TensorDict]):
 
         self.actor_target.load_state_dict(self.actor.state_dict())
 
+        self._actor_mode_invariant = is_train_eval_invariant(self.actor)
+
         # Initialize optimizer
         self.optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.actor,
             lr=self.lr,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         if self.accelerator is not None and wrap:
@@ -231,10 +234,13 @@ class CQN(RLAlgorithm[TensorDict]):
                     axis=1,
                 )
         else:
-            self.actor.eval()
+            toggle_mode = not self._actor_mode_invariant
+            if toggle_mode:
+                self.actor.eval()
             with torch.no_grad():
                 action_values = self.actor(obs).cpu().data.numpy()
-            self.actor.train()
+            if toggle_mode:
+                self.actor.train()
 
             if action_mask is None:
                 action = np.argmax(action_values, axis=-1)
@@ -307,14 +313,7 @@ class CQN(RLAlgorithm[TensorDict]):
 
     def soft_update(self) -> None:
         """Soft updates target network."""
-        for eval_param, target_param in zip(
-            self.actor.parameters(),
-            self.actor_target.parameters(),
-            strict=False,
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(self.actor, self.actor_target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/cqn.py
+++ b/agilerl/algorithms/cqn.py
@@ -28,7 +28,13 @@ from agilerl.typing import (
     ReplayBatch,
     numpy_action_mask,
 )
-from agilerl.utils.algo_utils import is_train_eval_invariant, make_safe_deepcopies
+from agilerl.utils.algo_utils import (
+    adam_kwargs,
+    eval_mode,
+    is_train_eval_invariant,
+    make_safe_deepcopies,
+    polyak_update,
+)
 
 
 class CQN(RLAlgorithm[TensorDict]):
@@ -179,7 +185,7 @@ class CQN(RLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actor,
             lr=self.lr,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         if self.accelerator is not None and wrap:
@@ -234,13 +240,9 @@ class CQN(RLAlgorithm[TensorDict]):
                     axis=1,
                 )
         else:
-            toggle_mode = not self._actor_mode_invariant
-            if toggle_mode:
-                self.actor.eval()
-            with torch.no_grad():
-                action_values = self.actor(obs).cpu().data.numpy()
-            if toggle_mode:
-                self.actor.train()
+            with eval_mode(self.actor, mode_invariant=self._actor_mode_invariant):
+                with torch.no_grad():
+                    action_values = self.actor(obs).cpu().data.numpy()
 
             if action_mask is None:
                 action = np.argmax(action_values, axis=-1)
@@ -313,7 +315,7 @@ class CQN(RLAlgorithm[TensorDict]):
 
     def soft_update(self) -> None:
         """Soft updates target network."""
-        self._soft_update(self.actor, self.actor_target, self.tau)
+        polyak_update(self.actor, self.actor_target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/ddpg.py
+++ b/agilerl/algorithms/ddpg.py
@@ -33,6 +33,7 @@ from agilerl.typing import (
     SupportedObservationSpace,
 )
 from agilerl.utils.algo_utils import (
+    is_train_eval_invariant,
     make_safe_deepcopies,
     multi_dim_clamp,
     share_encoder_parameters,
@@ -320,16 +321,20 @@ class DDPG(RLAlgorithm[TensorDict]):
         self.actor_target.load_state_dict(self.actor.state_dict())
         self.critic_target.load_state_dict(self.critic.state_dict())
 
+        self._actor_mode_invariant = is_train_eval_invariant(self.actor)
+
         # Optimizers
         self.actor_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.actor,
             lr=lr_actor,
+            optimizer_kwargs=self._adam_kwargs(),
         )
         self.critic_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.critic,
             lr=lr_critic,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         if self.accelerator is not None and wrap:
@@ -397,11 +402,13 @@ class DDPG(RLAlgorithm[TensorDict]):
         :rtype: numpy.ndarray[float]
         """
         obs = self.preprocess_observation(obs)
-        self.actor.eval()
+        toggle_mode = not self._actor_mode_invariant
+        if toggle_mode:
+            self.actor.eval()
         with torch.no_grad():
             action: torch.Tensor = self.actor(obs)
-
-        self.actor.train()
+        if toggle_mode:
+            self.actor.train()
 
         # Add noise for exploration
         if training:
@@ -537,12 +544,7 @@ class DDPG(RLAlgorithm[TensorDict]):
         :param target: Target network with parameters to be updated
         :type target: nn.Module
         """
-        for eval_param, target_param in zip(
-            net.parameters(), target.parameters(), strict=False
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/ddpg.py
+++ b/agilerl/algorithms/ddpg.py
@@ -33,9 +33,12 @@ from agilerl.typing import (
     SupportedObservationSpace,
 )
 from agilerl.utils.algo_utils import (
+    adam_kwargs,
+    eval_mode,
     is_train_eval_invariant,
     make_safe_deepcopies,
     multi_dim_clamp,
+    polyak_update,
     share_encoder_parameters,
 )
 from agilerl.utils.evolvable_networks import (
@@ -328,13 +331,13 @@ class DDPG(RLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actor,
             lr=lr_actor,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
         self.critic_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.critic,
             lr=lr_critic,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         if self.accelerator is not None and wrap:
@@ -402,13 +405,9 @@ class DDPG(RLAlgorithm[TensorDict]):
         :rtype: numpy.ndarray[float]
         """
         obs = self.preprocess_observation(obs)
-        toggle_mode = not self._actor_mode_invariant
-        if toggle_mode:
-            self.actor.eval()
-        with torch.no_grad():
-            action: torch.Tensor = self.actor(obs)
-        if toggle_mode:
-            self.actor.train()
+        with eval_mode(self.actor, mode_invariant=self._actor_mode_invariant):
+            with torch.no_grad():
+                action: torch.Tensor = self.actor(obs)
 
         # Add noise for exploration
         if training:
@@ -544,7 +543,7 @@ class DDPG(RLAlgorithm[TensorDict]):
         :param target: Target network with parameters to be updated
         :type target: nn.Module
         """
-        self._soft_update(net, target, self.tau)
+        polyak_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/dqn.py
+++ b/agilerl/algorithms/dqn.py
@@ -31,7 +31,7 @@ from agilerl.typing import (
     TorchObsType,
     numpy_action_mask,
 )
-from agilerl.utils.algo_utils import make_safe_deepcopies
+from agilerl.utils.algo_utils import is_train_eval_invariant, make_safe_deepcopies
 
 
 class DQN(RLAlgorithm[TensorDict]):
@@ -85,7 +85,7 @@ class DQN(RLAlgorithm[TensorDict]):
 
     # Hot-path callables: bound methods by default, CudaGraph wrappers when enabled.
     _get_action_impl: Callable[
-        [TorchObsType, torch.Tensor, torch.Tensor],
+        [TorchObsType, torch.Tensor | float, torch.Tensor],
         torch.Tensor,
     ]
     _update_impl: Callable[
@@ -190,12 +190,14 @@ class DQN(RLAlgorithm[TensorDict]):
         # Initialize target network (same pattern as DDPG; post-mutation sync via reinit_shared_networks)
         self.actor_target.load_state_dict(self.actor.state_dict())
 
+        self._actor_mode_invariant = is_train_eval_invariant(self.actor)
+
         # Initialize optimizer with OptimizerWrapper
         self.optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.actor,
             lr=self.lr,
-            optimizer_kwargs={"capturable": self.capturable},
+            optimizer_kwargs=self._adam_kwargs(capturable=self.capturable),
         )
 
         if self.accelerator is not None and wrap:
@@ -254,7 +256,8 @@ class DQN(RLAlgorithm[TensorDict]):
         """
         # Preprocess observations and convert inputs to torch tensors
         torch_obs = self.preprocess_observation(obs)
-        eps = torch.tensor(epsilon, device=self.device)
+        # Graph capture needs epsilon as a device tensor; eager compares the float.
+        eps = torch.tensor(epsilon, device=self.device) if self.cudagraphs else epsilon
         if action_mask is not None:
             mask = torch.as_tensor(
                 numpy_action_mask(action_mask),
@@ -283,7 +286,7 @@ class DQN(RLAlgorithm[TensorDict]):
     def _get_action(
         self,
         obs: TorchObsType,
-        epsilon: torch.Tensor,
+        epsilon: torch.Tensor | float,
         action_mask: torch.Tensor,
     ) -> torch.Tensor:
         """Return the next action to take in the environment.
@@ -299,11 +302,13 @@ class DQN(RLAlgorithm[TensorDict]):
         :return: Selected action(s) as tensor
         :rtype: torch.Tensor
         """
-        self.actor.eval()
+        toggle_mode = not self._actor_mode_invariant
+        if toggle_mode:
+            self.actor.eval()
         with torch.no_grad():
             q_values = self.actor(obs)
-
-        self.actor.train()
+        if toggle_mode:
+            self.actor.train()
 
         # Masked random actions
         masked_random_values = torch.rand_like(q_values) * action_mask
@@ -346,23 +351,41 @@ class DQN(RLAlgorithm[TensorDict]):
         :return: Loss value from the update step
         :rtype: torch.Tensor
         """
-        with torch.no_grad():
-            if self.double:  # Double Q-learning
-                q_idx = self.actor(next_obs).argmax(dim=1).unsqueeze(1)
-                q_target = (
-                    self.actor_target(next_obs).gather(dim=1, index=q_idx).detach()
-                )
-            else:
-                q_target = self.actor_target(next_obs).max(dim=1)[0].unsqueeze(1)
-
-            # target, if terminal then y_j = rewards
-            y_j = rewards + self.gamma * q_target * (1 - dones)
-
         if actions.ndim == 1:
             actions = actions.unsqueeze(-1)
+        actions = actions.long()
 
-        # Compute Q-values for actions taken and loss
-        q_eval = self.actor(obs).gather(1, actions.long())
+        # One online forward over cat(obs, next_obs); the next_obs half is detached
+        # for greedy action selection, so gradients match two separate forwards.
+        if (
+            self.double
+            and self._actor_mode_invariant
+            and isinstance(obs, torch.Tensor)
+            and isinstance(next_obs, torch.Tensor)
+        ):
+            batch_size = obs.shape[0]
+            q_online = self.actor(torch.cat((obs, next_obs), dim=0))
+            q_eval = q_online[:batch_size].gather(1, actions)
+            with torch.no_grad():
+                q_idx = q_online[batch_size:].detach().argmax(dim=1, keepdim=True)
+                q_target = self.actor_target(next_obs).gather(dim=1, index=q_idx)
+                y_j = rewards + self.gamma * q_target * (1 - dones)
+        else:
+            with torch.no_grad():
+                if self.double:  # Double Q-learning
+                    q_idx = self.actor(next_obs).argmax(dim=1).unsqueeze(1)
+                    q_target = (
+                        self.actor_target(next_obs).gather(dim=1, index=q_idx).detach()
+                    )
+                else:
+                    q_target = self.actor_target(next_obs).max(dim=1)[0].unsqueeze(1)
+
+                # target, if terminal then y_j = rewards
+                y_j = rewards + self.gamma * q_target * (1 - dones)
+
+            # Compute Q-values for actions taken
+            q_eval = self.actor(obs).gather(1, actions)
+
         loss: torch.Tensor = self.criterion(q_eval, y_j)
 
         # zero gradients, perform a backward pass, and update the weights
@@ -403,14 +426,7 @@ class DQN(RLAlgorithm[TensorDict]):
 
     def soft_update(self) -> None:
         """Soft updates target network."""
-        for eval_param, target_param in zip(
-            self.actor.parameters(),
-            self.actor_target.parameters(),
-            strict=False,
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(self.actor, self.actor_target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/dqn.py
+++ b/agilerl/algorithms/dqn.py
@@ -31,7 +31,13 @@ from agilerl.typing import (
     TorchObsType,
     numpy_action_mask,
 )
-from agilerl.utils.algo_utils import is_train_eval_invariant, make_safe_deepcopies
+from agilerl.utils.algo_utils import (
+    adam_kwargs,
+    eval_mode,
+    is_train_eval_invariant,
+    make_safe_deepcopies,
+    polyak_update,
+)
 
 
 class DQN(RLAlgorithm[TensorDict]):
@@ -197,7 +203,9 @@ class DQN(RLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actor,
             lr=self.lr,
-            optimizer_kwargs=self._adam_kwargs(capturable=self.capturable),
+            optimizer_kwargs=adam_kwargs(
+                self.device, self.accelerator, capturable=self.capturable
+            ),
         )
 
         if self.accelerator is not None and wrap:
@@ -302,13 +310,9 @@ class DQN(RLAlgorithm[TensorDict]):
         :return: Selected action(s) as tensor
         :rtype: torch.Tensor
         """
-        toggle_mode = not self._actor_mode_invariant
-        if toggle_mode:
-            self.actor.eval()
-        with torch.no_grad():
-            q_values = self.actor(obs)
-        if toggle_mode:
-            self.actor.train()
+        with eval_mode(self.actor, mode_invariant=self._actor_mode_invariant):
+            with torch.no_grad():
+                q_values = self.actor(obs)
 
         # Masked random actions
         masked_random_values = torch.rand_like(q_values) * action_mask
@@ -426,7 +430,7 @@ class DQN(RLAlgorithm[TensorDict]):
 
     def soft_update(self) -> None:
         """Soft updates target network."""
-        self._soft_update(self.actor, self.actor_target, self.tau)
+        polyak_update(self.actor, self.actor_target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/dqn_rainbow.py
+++ b/agilerl/algorithms/dqn_rainbow.py
@@ -248,7 +248,12 @@ class RainbowDQN(RLAlgorithm[TensorDict]):
         self.actor_target.load_state_dict(self.actor.state_dict())
 
         # Optimizer
-        self.optimizer = OptimizerWrapper(optim.Adam, networks=self.actor, lr=self.lr)
+        self.optimizer = OptimizerWrapper(
+            optim.Adam,
+            networks=self.actor,
+            lr=self.lr,
+            optimizer_kwargs=self._adam_kwargs(),
+        )
 
         if self.accelerator is not None and wrap:
             self.wrap_models()
@@ -532,14 +537,7 @@ class RainbowDQN(RLAlgorithm[TensorDict]):
 
     def soft_update(self) -> None:
         """Soft updates target network."""
-        for eval_param, target_param in zip(
-            self.actor.parameters(),
-            self.actor_target.parameters(),
-            strict=False,
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(self.actor, self.actor_target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/dqn_rainbow.py
+++ b/agilerl/algorithms/dqn_rainbow.py
@@ -31,7 +31,11 @@ from agilerl.typing import (
     TorchObsType,
     numpy_action_mask,
 )
-from agilerl.utils.algo_utils import make_safe_deepcopies
+from agilerl.utils.algo_utils import (
+    adam_kwargs,
+    make_safe_deepcopies,
+    polyak_update,
+)
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 
 
@@ -252,7 +256,7 @@ class RainbowDQN(RLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actor,
             lr=self.lr,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         if self.accelerator is not None and wrap:
@@ -537,7 +541,7 @@ class RainbowDQN(RLAlgorithm[TensorDict]):
 
     def soft_update(self) -> None:
         """Soft updates target network."""
-        self._soft_update(self.actor, self.actor_target, self.tau)
+        polyak_update(self.actor, self.actor_target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/ilql.py
+++ b/agilerl/algorithms/ilql.py
@@ -1115,52 +1115,34 @@ class ILQL(nn.Module):
             action_mask,
         )
 
+    @torch.no_grad()
     def soft_update(self) -> None:
         """Soft updates target networks."""
-        for target_param, local_param in zip(
-            self.target_q.parameters(),
-            self.q.parameters(),
-            strict=False,
-        ):
-            target_param.data.copy_(
-                self.alpha * local_param.data + (1.0 - self.alpha) * target_param.data,
-            )
+        pairs = [(self.q, self.target_q)]
         if self.double_q:
-            for target_param, local_param in zip(
-                self.target_q2.parameters(),
-                self.q2.parameters(),
-                strict=False,
-            ):
-                target_param.data.copy_(
-                    self.alpha * local_param.data
-                    + (1.0 - self.alpha) * target_param.data,
-                )
+            pairs.append((self.q2, self.target_q2))
         if self.actor_target is not None:
-            for target_param, local_param in zip(
-                self.actor_target.parameters(),
-                self.model.parameters(),
-                strict=False,
-            ):
-                target_param.data.copy_(
-                    self.alpha * local_param.data
-                    + (1.0 - self.alpha) * target_param.data,
-                )
+            pairs.append((self.model, self.actor_target))
 
+        for source, target in pairs:
+            torch._foreach_lerp_(
+                list(target.parameters()),
+                list(source.parameters()),
+                self.alpha,
+            )
+
+    @torch.no_grad()
     def hard_update(self) -> None:
         """Hard update target networks."""
-        for target_param, local_param in zip(
-            self.target_q.parameters(),
-            self.q.parameters(),
-            strict=False,
-        ):
-            target_param.data.copy_(local_param.data)
+        torch._foreach_copy_(
+            list(self.target_q.parameters()),
+            list(self.q.parameters()),
+        )
         if self.double_q:
-            for target_param, local_param in zip(
-                self.target_q2.parameters(),
-                self.q2.parameters(),
-                strict=False,
-            ):
-                target_param.data.copy_(local_param.data)
+            torch._foreach_copy_(
+                list(self.target_q2.parameters()),
+                list(self.q2.parameters()),
+            )
         if self.actor_target is not None:
             del self.actor_target
             self.actor_target = copy.deepcopy(self.model)
@@ -2278,7 +2260,8 @@ def to_decorator(
 
 
 def parameter_norm(model: nn.Module) -> float:
-    norm = 0.0
-    for param in model.parameters():
-        norm += (param.norm() ** 2).item()
-    return math.sqrt(norm)
+    params: list[torch.Tensor] = list(model.parameters())
+    if not params:
+        return 0.0
+    # One device-to-host sync for the whole model rather than one per parameter.
+    return torch.linalg.vector_norm(torch.stack(torch._foreach_norm(params))).item()

--- a/agilerl/algorithms/ilql.py
+++ b/agilerl/algorithms/ilql.py
@@ -24,6 +24,7 @@ from agilerl.data.tokenizer import Tokenizer
 from agilerl.modules.gpt import EvolvableGPT
 from agilerl.modules.mlp import EvolvableMLP
 from agilerl.typing import DeviceType, NetConfigType, PastKeyValues
+from agilerl.utils.algo_utils import polyak_update
 from agilerl.utils.sampling_utils import (
     always_terminate,
     map_all_kvs,
@@ -1125,11 +1126,7 @@ class ILQL(nn.Module):
             pairs.append((self.model, self.actor_target))
 
         for source, target in pairs:
-            torch._foreach_lerp_(
-                list(target.parameters()),
-                list(source.parameters()),
-                self.alpha,
-            )
+            polyak_update(source, target, self.alpha)
 
     @torch.no_grad()
     def hard_update(self) -> None:

--- a/agilerl/algorithms/ilql.py
+++ b/agilerl/algorithms/ilql.py
@@ -2257,11 +2257,3 @@ def to_decorator(
         return to(f(*args, **kwargs), device)
 
     return new_f
-
-
-def parameter_norm(model: nn.Module) -> float:
-    params: list[torch.Tensor] = list(model.parameters())
-    if not params:
-        return 0.0
-    # One device-to-host sync for the whole model rather than one per parameter.
-    return torch.linalg.vector_norm(torch.stack(torch._foreach_norm(params))).item()

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -38,9 +38,11 @@ from agilerl.typing import (
     TorchObsType,
 )
 from agilerl.utils.algo_utils import (
+    adam_kwargs,
     apply_env_defined_actions,
     concatenate_spaces,
     configure_tf32_precision,
+    eval_mode,
     format_shared_critic_encoder,
     get_deepest_head_config,
     get_num_envs,
@@ -48,6 +50,7 @@ from agilerl.utils.algo_utils import (
     is_train_eval_invariant,
     key_in_nested_dict,
     make_safe_deepcopies,
+    polyak_update,
     to_agent_tensors,
 )
 from agilerl.vector.pz_vec_env import PettingZooVecEnv
@@ -433,13 +436,13 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actors,
             lr=self.lr_actor,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
         self.critic_optimizers = OptimizerWrapper(
             optim.Adam,
             networks=self.critics,
             lr=self.lr_critic,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         if self.accelerator is not None and wrap:
@@ -549,18 +552,19 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
         )
 
         grouped_actions: dict[str, npt.NDArray] = {}
-        for group_id in grouped_agents:
-            actor = self.actors[group_id]
-            if not self._actors_mode_invariant:
-                actor.eval()
-            grouped_obs = preprocessed_states[group_id]
-            if self.accelerator is not None:
-                with self.accelerator.no_sync(actor), torch.no_grad():
-                    actions = actor(grouped_obs)
-            else:
-                with torch.no_grad():
-                    actions = actor(grouped_obs)
-            grouped_actions[group_id] = actions.cpu().numpy()
+        with eval_mode(
+            *self.actors.values(), mode_invariant=self._actors_mode_invariant
+        ):
+            for group_id in grouped_agents:
+                actor = self.actors[group_id]
+                grouped_obs = preprocessed_states[group_id]
+                if self.accelerator is not None:
+                    with self.accelerator.no_sync(actor), torch.no_grad():
+                        actions = actor(grouped_obs)
+                else:
+                    with torch.no_grad():
+                        actions = actor(grouped_obs)
+                grouped_actions[group_id] = actions.cpu().numpy()
 
         tensor_actions: dict[str, torch.Tensor] = {}
         for group_id, group_actions in grouped_actions.items():
@@ -575,9 +579,6 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
                 start = end
 
         for agent_id, actions in tensor_actions.items():
-            actor = self.actors[self.get_network_id(agent_id)]
-            if not self._actors_mode_invariant:
-                actor.train()
             if self.training:
                 if isinstance(self.possible_action_spaces[agent_id], spaces.Discrete):
                     min_output, max_output = 0, 1
@@ -889,7 +890,7 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
         :param target: Target network
         :type target: nn.Module
         """
-        self._soft_update(net, target, self.tau)
+        polyak_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/maddpg.py
+++ b/agilerl/algorithms/maddpg.py
@@ -45,6 +45,7 @@ from agilerl.utils.algo_utils import (
     get_deepest_head_config,
     get_num_envs,
     get_vect_dim,
+    is_train_eval_invariant,
     key_in_nested_dict,
     make_safe_deepcopies,
     to_agent_tensors,
@@ -432,11 +433,13 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actors,
             lr=self.lr_actor,
+            optimizer_kwargs=self._adam_kwargs(),
         )
         self.critic_optimizers = OptimizerWrapper(
             optim.Adam,
             networks=self.critics,
             lr=self.lr_critic,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         if self.accelerator is not None and wrap:
@@ -460,6 +463,10 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
             self.recompile()
 
         self.criterion = nn.MSELoss()
+
+        self._actors_mode_invariant = all(
+            is_train_eval_invariant(actor) for actor in self.actors.values()
+        )
 
         # Register network groups for mutations
         self.register_network_group(
@@ -544,7 +551,8 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
         grouped_actions: dict[str, npt.NDArray] = {}
         for group_id in grouped_agents:
             actor = self.actors[group_id]
-            actor.eval()
+            if not self._actors_mode_invariant:
+                actor.eval()
             grouped_obs = preprocessed_states[group_id]
             if self.accelerator is not None:
                 with self.accelerator.no_sync(actor), torch.no_grad():
@@ -568,7 +576,8 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
 
         for agent_id, actions in tensor_actions.items():
             actor = self.actors[self.get_network_id(agent_id)]
-            actor.train()
+            if not self._actors_mode_invariant:
+                actor.train()
             if self.training:
                 if isinstance(self.possible_action_spaces[agent_id], spaces.Discrete):
                     min_output, max_output = 0, 1
@@ -880,12 +889,7 @@ class MADDPG(MultiAgentRLAlgorithm[TensorDict]):
         :param target: Target network
         :type target: nn.Module
         """
-        for eval_param, target_param in zip(
-            net.parameters(), target.parameters(), strict=False
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -46,6 +46,7 @@ from agilerl.utils.algo_utils import (
     get_deepest_head_config,
     get_num_envs,
     get_vect_dim,
+    is_train_eval_invariant,
     key_in_nested_dict,
     make_safe_deepcopies,
     to_agent_tensors,
@@ -466,18 +467,21 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actors,
             lr=lr_actor,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         self.critic_1_optimizers = OptimizerWrapper(
             optim.Adam,
             networks=self.critics_1,
             lr=lr_critic,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         self.critic_2_optimizers = OptimizerWrapper(
             optim.Adam,
             networks=self.critics_2,
             lr=lr_critic,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         if self.accelerator is not None and wrap:
@@ -500,6 +504,10 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
             self.recompile()
 
         self.criterion = nn.MSELoss()
+
+        self._actors_mode_invariant = all(
+            is_train_eval_invariant(actor) for actor in self.actors.values()
+        )
 
         # Register network groups for mutations
         self.register_network_group(
@@ -591,7 +599,8 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
         grouped_actions: dict[str, npt.NDArray] = {}
         for group_id in grouped_agents:
             actor = self.actors[group_id]
-            actor.eval()
+            if not self._actors_mode_invariant:
+                actor.eval()
             grouped_obs = preprocessed_states[group_id]
             if self.accelerator is not None:
                 with self.accelerator.no_sync(actor), torch.no_grad():
@@ -615,7 +624,8 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
 
         for agent_id, actions in tensor_actions.items():
             actor = self.actors[self.get_network_id(agent_id)]
-            actor.train()
+            if not self._actors_mode_invariant:
+                actor.train()
             if self.training:
                 if isinstance(self.possible_action_spaces[agent_id], spaces.Discrete):
                     min_output, max_output = 0, 1
@@ -964,12 +974,7 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
         :param target: Target network
         :type target: nn.Module
         """
-        for eval_param, target_param in zip(
-            net.parameters(), target.parameters(), strict=False
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/matd3.py
+++ b/agilerl/algorithms/matd3.py
@@ -39,9 +39,11 @@ from agilerl.typing import (
     TorchObsType,
 )
 from agilerl.utils.algo_utils import (
+    adam_kwargs,
     apply_env_defined_actions,
     concatenate_spaces,
     configure_tf32_precision,
+    eval_mode,
     format_shared_critic_encoder,
     get_deepest_head_config,
     get_num_envs,
@@ -49,6 +51,7 @@ from agilerl.utils.algo_utils import (
     is_train_eval_invariant,
     key_in_nested_dict,
     make_safe_deepcopies,
+    polyak_update,
     to_agent_tensors,
 )
 from agilerl.vector.pz_vec_env import PettingZooVecEnv
@@ -467,21 +470,21 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actors,
             lr=lr_actor,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         self.critic_1_optimizers = OptimizerWrapper(
             optim.Adam,
             networks=self.critics_1,
             lr=lr_critic,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         self.critic_2_optimizers = OptimizerWrapper(
             optim.Adam,
             networks=self.critics_2,
             lr=lr_critic,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         if self.accelerator is not None and wrap:
@@ -597,18 +600,19 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
         )
 
         grouped_actions: dict[str, npt.NDArray] = {}
-        for group_id in grouped_agents:
-            actor = self.actors[group_id]
-            if not self._actors_mode_invariant:
-                actor.eval()
-            grouped_obs = preprocessed_states[group_id]
-            if self.accelerator is not None:
-                with self.accelerator.no_sync(actor), torch.no_grad():
-                    actions = actor(grouped_obs)
-            else:
-                with torch.no_grad():
-                    actions = actor(grouped_obs)
-            grouped_actions[group_id] = actions.cpu().numpy()
+        with eval_mode(
+            *self.actors.values(), mode_invariant=self._actors_mode_invariant
+        ):
+            for group_id in grouped_agents:
+                actor = self.actors[group_id]
+                grouped_obs = preprocessed_states[group_id]
+                if self.accelerator is not None:
+                    with self.accelerator.no_sync(actor), torch.no_grad():
+                        actions = actor(grouped_obs)
+                else:
+                    with torch.no_grad():
+                        actions = actor(grouped_obs)
+                grouped_actions[group_id] = actions.cpu().numpy()
 
         tensor_actions: dict[str, torch.Tensor] = {}
         for group_id, group_actions in grouped_actions.items():
@@ -623,9 +627,6 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
                 start = end
 
         for agent_id, actions in tensor_actions.items():
-            actor = self.actors[self.get_network_id(agent_id)]
-            if not self._actors_mode_invariant:
-                actor.train()
             if self.training:
                 if isinstance(self.possible_action_spaces[agent_id], spaces.Discrete):
                     min_output, max_output = 0, 1
@@ -974,7 +975,7 @@ class MATD3(MultiAgentRLAlgorithm[TensorDict]):
         :param target: Target network
         :type target: nn.Module
         """
-        self._soft_update(net, target, self.tau)
+        polyak_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/neural_ts_bandit.py
+++ b/agilerl/algorithms/neural_ts_bandit.py
@@ -245,11 +245,11 @@ class NeuralTS(RLAlgorithm[TensorDict]):
             mu_raw[0].backward(retain_graph=True)
             grad_vec = torch.cat(
                 [
-                    w.grad.detach().flatten() / np.sqrt(self.exp_layer.weight.size(0))
+                    w.grad.detach().flatten()
                     for w in self.exp_layer.parameters()
                     if w.requires_grad and w.grad is not None
                 ],
-            )
+            ) / np.sqrt(self.exp_layer.weight.size(0))
             g[:] = grad_vec
         else:
             for k, fx in enumerate(mu):
@@ -258,11 +258,10 @@ class NeuralTS(RLAlgorithm[TensorDict]):
                 g[k] = torch.cat(
                     [
                         w.grad.detach().flatten()
-                        / np.sqrt(self.exp_layer.weight.size(0))
                         for w in self.exp_layer.parameters()
                         if w.requires_grad and w.grad is not None
                     ],
-                )
+                ) / np.sqrt(self.exp_layer.weight.size(0))
 
         with torch.no_grad():
             std = self.gamma * torch.sqrt(

--- a/agilerl/algorithms/neural_ucb_bandit.py
+++ b/agilerl/algorithms/neural_ucb_bandit.py
@@ -247,11 +247,11 @@ class NeuralUCB(RLAlgorithm[TensorDict]):
             mu_raw[0].backward(retain_graph=True)
             grad_vec = torch.cat(
                 [
-                    w.grad.detach().flatten() / np.sqrt(self.exp_layer.weight.size(0))
+                    w.grad.detach().flatten()
                     for w in self.exp_layer.parameters()
                     if w.requires_grad and w.grad is not None
                 ],
-            )
+            ) / np.sqrt(self.exp_layer.weight.size(0))
             g[:] = grad_vec
         else:
             for k, fx in enumerate(mu):
@@ -260,11 +260,10 @@ class NeuralUCB(RLAlgorithm[TensorDict]):
                 g[k] = torch.cat(
                     [
                         w.grad.detach().flatten()
-                        / np.sqrt(self.exp_layer.weight.size(0))
                         for w in self.exp_layer.parameters()
                         if w.requires_grad and w.grad is not None
                     ],
-                )
+                ) / np.sqrt(self.exp_layer.weight.size(0))
 
         with torch.no_grad():
             action_values = mu + self.gamma * torch.sqrt(

--- a/agilerl/algorithms/td3.py
+++ b/agilerl/algorithms/td3.py
@@ -33,6 +33,7 @@ from agilerl.typing import (
     SupportedObservationSpace,
 )
 from agilerl.utils.algo_utils import (
+    is_train_eval_invariant,
     make_safe_deepcopies,
     multi_dim_clamp,
     share_encoder_parameters,
@@ -343,23 +344,28 @@ class TD3(RLAlgorithm[TensorDict]):
         self.critic_target_1.load_state_dict(self.critic_1.state_dict())
         self.critic_target_2.load_state_dict(self.critic_2.state_dict())
 
+        self._actor_mode_invariant = is_train_eval_invariant(self.actor)
+
         # Optimizers
         self.actor_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.actor,
             lr=self.lr_actor,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         self.critic_1_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.critic_1,
             lr=self.lr_critic,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         self.critic_2_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.critic_2,
             lr=self.lr_critic,
+            optimizer_kwargs=self._adam_kwargs(),
         )
 
         if self.accelerator is not None and wrap:
@@ -439,11 +445,13 @@ class TD3(RLAlgorithm[TensorDict]):
         :rtype: numpy.ndarray[float]
         """
         obs = self.preprocess_observation(obs)
-        self.actor.eval()
+        toggle_mode = not self._actor_mode_invariant
+        if toggle_mode:
+            self.actor.eval()
         with torch.no_grad():
             action: torch.Tensor = self.actor(obs)
-
-        self.actor.train()
+        if toggle_mode:
+            self.actor.train()
 
         # Add noise for exploration
         if training:
@@ -596,12 +604,7 @@ class TD3(RLAlgorithm[TensorDict]):
         :param target: Target network
         :type target: EvolvableModule
         """
-        for eval_param, target_param in zip(
-            net.parameters(), target.parameters(), strict=False
-        ):
-            target_param.data.copy_(
-                self.tau * eval_param.data + (1.0 - self.tau) * target_param.data,
-            )
+        self._soft_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/algorithms/td3.py
+++ b/agilerl/algorithms/td3.py
@@ -33,9 +33,12 @@ from agilerl.typing import (
     SupportedObservationSpace,
 )
 from agilerl.utils.algo_utils import (
+    adam_kwargs,
+    eval_mode,
     is_train_eval_invariant,
     make_safe_deepcopies,
     multi_dim_clamp,
+    polyak_update,
     share_encoder_parameters,
 )
 from agilerl.utils.evolvable_networks import (
@@ -351,21 +354,21 @@ class TD3(RLAlgorithm[TensorDict]):
             optim.Adam,
             networks=self.actor,
             lr=self.lr_actor,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         self.critic_1_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.critic_1,
             lr=self.lr_critic,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         self.critic_2_optimizer = OptimizerWrapper(
             optim.Adam,
             networks=self.critic_2,
             lr=self.lr_critic,
-            optimizer_kwargs=self._adam_kwargs(),
+            optimizer_kwargs=adam_kwargs(self.device, self.accelerator),
         )
 
         if self.accelerator is not None and wrap:
@@ -445,13 +448,9 @@ class TD3(RLAlgorithm[TensorDict]):
         :rtype: numpy.ndarray[float]
         """
         obs = self.preprocess_observation(obs)
-        toggle_mode = not self._actor_mode_invariant
-        if toggle_mode:
-            self.actor.eval()
-        with torch.no_grad():
-            action: torch.Tensor = self.actor(obs)
-        if toggle_mode:
-            self.actor.train()
+        with eval_mode(self.actor, mode_invariant=self._actor_mode_invariant):
+            with torch.no_grad():
+                action: torch.Tensor = self.actor(obs)
 
         # Add noise for exploration
         if training:
@@ -604,7 +603,7 @@ class TD3(RLAlgorithm[TensorDict]):
         :param target: Target network
         :type target: EvolvableModule
         """
-        self._soft_update(net, target, self.tau)
+        polyak_update(net, target, self.tau)
 
     def test(
         self,

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -35,6 +35,7 @@ from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR
 from typing_extensions import TypeVarTuple, Unpack
 
 from agilerl import HAS_LLM_DEPENDENCIES
+from agilerl.modules.custom_components import NoisyLinear
 from agilerl.modules.dummy import DummyEvolvable
 from agilerl.protocols import (
     EvolvableAttributeType,
@@ -76,6 +77,26 @@ else:
     # definition time, so provide a runtime placeholder when the LLM
     # dependencies are not installed.
     PreTrainedModelType = Any
+
+
+# Layers whose forward output differs between train() and eval() mode.
+MODE_SENSITIVE_MODULES = (
+    nn.modules.batchnorm._BatchNorm,
+    nn.modules.instancenorm._InstanceNorm,
+    nn.modules.dropout._DropoutNd,
+    NoisyLinear,
+)
+
+
+def is_train_eval_invariant(module: nn.Module) -> bool:
+    """Whether ``module`` produces identical outputs in train and eval mode.
+
+    :param module: Network to inspect.
+    :type module: torch.nn.Module
+    :return: True if train/eval modes are equivalent.
+    :rtype: bool
+    """
+    return not any(isinstance(m, MODE_SENSITIVE_MODULES) for m in module.modules())
 
 
 def configure_tf32_precision() -> None:

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -6,7 +6,8 @@ import os
 import shutil
 import warnings
 from collections import OrderedDict, defaultdict
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import singledispatch
 from numbers import Number
@@ -25,6 +26,7 @@ import numpy as np
 import numpy.typing as npt
 import torch
 import torch.nn.functional as F
+from accelerate import Accelerator
 from gymnasium import spaces
 from tensordict import TensorDict, from_module
 from tensordict.nn import CudaGraphModule
@@ -97,6 +99,70 @@ def is_train_eval_invariant(module: nn.Module) -> bool:
     :rtype: bool
     """
     return not any(isinstance(m, MODE_SENSITIVE_MODULES) for m in module.modules())
+
+
+@contextmanager
+def eval_mode(*modules: nn.Module, mode_invariant: bool) -> Iterator[None]:
+    """Put ``modules`` in eval mode for the block, restoring train mode afterwards.
+
+    Does nothing when ``mode_invariant``, since the toggle would be a no-op and
+    each call otherwise walks the whole module tree twice.
+
+    :param modules: Networks to switch into eval mode.
+    :type modules: torch.nn.Module
+    :param mode_invariant: Whether train and eval modes are equivalent.
+    :type mode_invariant: bool
+    """
+    if mode_invariant:
+        yield
+        return
+
+    for module in modules:
+        module.eval()
+    try:
+        yield
+    finally:
+        for module in modules:
+            module.train()
+
+
+@torch.no_grad()
+def polyak_update(source: nn.Module, target: nn.Module, tau: float) -> None:
+    """Update ``target <- tau * source + (1 - tau) * target``, fused across parameters.
+
+    :param source: Network whose parameters are copied from.
+    :type source: torch.nn.Module
+    :param target: Target network updated in place.
+    :type target: torch.nn.Module
+    :param tau: Interpolation weight toward ``source``.
+    :type tau: float
+    """
+    torch._foreach_lerp_(list(target.parameters()), list(source.parameters()), tau)
+
+
+def adam_kwargs(
+    device: str | torch.device,
+    accelerator: Accelerator | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Add ``fused=True`` to Adam kwargs when the fused CUDA kernel is usable.
+
+    :param device: Device the optimizer's parameters live on.
+    :type device: str | torch.device
+    :param accelerator: Accelerator owning the step, if any.
+    :type accelerator: accelerate.Accelerator | None
+    :param kwargs: Base optimizer keyword arguments to augment.
+    :return: ``kwargs``, with ``fused=True`` added when applicable.
+    :rtype: dict[str, Any]
+    """
+    if (
+        "fused" not in kwargs
+        and not kwargs.get("capturable")
+        and accelerator is None
+        and "cuda" in str(device)
+    ):
+        kwargs["fused"] = True
+    return kwargs
 
 
 def configure_tf32_precision() -> None:

--- a/agilerl/utils/torch_utils.py
+++ b/agilerl/utils/torch_utils.py
@@ -84,10 +84,11 @@ def parameter_norm(model: nn.Module) -> float:
     :return: L2 norm of all model parameters
     :rtype: float
     """
-    norm = 0.0
-    for param in model.parameters():
-        norm += (param.norm() ** 2).item()
-    return math.sqrt(norm)
+    params: list[torch.Tensor] = list(model.parameters())
+    if not params:
+        return 0.0
+    # One device-to-host sync for the whole model rather than one per parameter.
+    return torch.linalg.vector_norm(torch.stack(torch._foreach_norm(params))).item()
 
 
 def get_transformer_logs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.4"
+version = "2.8.5"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/tests/test_algorithms/test_multi_agent/test_maddpg.py
+++ b/tests/test_algorithms/test_multi_agent/test_maddpg.py
@@ -26,7 +26,7 @@ from agilerl.modules import (
 from agilerl.modules.custom_components import GumbelSoftmax
 from agilerl.networks.actors import DeterministicActor
 from agilerl.networks.q_networks import ContinuousQNetwork
-from agilerl.utils.algo_utils import concatenate_spaces
+from agilerl.utils.algo_utils import concatenate_spaces, is_train_eval_invariant
 from agilerl.utils.evolvable_networks import get_default_encoder_config
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
@@ -993,6 +993,28 @@ class TestMADDPGInit:
 
 
 class TestMADDPGGetAction:
+    # Mode-sensitive actors take the eval()/train() toggle path in get_action.
+    def test_mode_sensitive_actors_restore_train_mode(
+        self, ma_vector_space, ma_discrete_space
+    ):
+        agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+        maddpg = MADDPG(ma_vector_space, ma_discrete_space, agent_ids=agent_ids)
+        for actor in maddpg.actors.values():
+            actor.add_module("dropout", nn.Dropout(0.5))
+        maddpg._actors_mode_invariant = all(
+            is_train_eval_invariant(actor) for actor in maddpg.actors.values()
+        )
+        assert not maddpg._actors_mode_invariant
+
+        state = {
+            agent: np.random.randn(*ma_vector_space[idx].shape)
+            for idx, agent in enumerate(agent_ids)
+        }
+        maddpg.get_action(state)
+
+        assert all(actor.training for actor in maddpg.actors.values())
+        maddpg.clean_up()
+
     @pytest.mark.gpu
     @pytest.mark.parametrize(
         "observation_spaces",

--- a/tests/test_algorithms/test_multi_agent/test_matd3.py
+++ b/tests/test_algorithms/test_multi_agent/test_matd3.py
@@ -19,7 +19,7 @@ from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput, Mod
 from agilerl.modules.custom_components import GumbelSoftmax
 from agilerl.networks.actors import DeterministicActor
 from agilerl.networks.q_networks import ContinuousQNetwork
-from agilerl.utils.algo_utils import concatenate_spaces
+from agilerl.utils.algo_utils import concatenate_spaces, is_train_eval_invariant
 from agilerl.utils.evolvable_networks import get_default_encoder_config
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
@@ -1248,6 +1248,28 @@ class TestMATD3ActionNoise:
 
 
 class TestMATD3GetAction:
+    # Mode-sensitive actors take the eval()/train() toggle path in get_action.
+    def test_mode_sensitive_actors_restore_train_mode(
+        self, ma_vector_space, ma_discrete_space
+    ):
+        agent_ids = ["agent_0", "agent_1", "other_agent_0"]
+        matd3 = MATD3(ma_vector_space, ma_discrete_space, agent_ids=agent_ids)
+        for actor in matd3.actors.values():
+            actor.add_module("dropout", nn.Dropout(0.5))
+        matd3._actors_mode_invariant = all(
+            is_train_eval_invariant(actor) for actor in matd3.actors.values()
+        )
+        assert not matd3._actors_mode_invariant
+
+        state = {
+            agent: np.random.randn(*ma_vector_space[idx].shape)
+            for idx, agent in enumerate(agent_ids)
+        }
+        matd3.get_action(state)
+
+        assert all(actor.training for actor in matd3.actors.values())
+        matd3.clean_up()
+
     @pytest.mark.gpu
     @pytest.mark.parametrize(
         "observation_spaces",

--- a/tests/test_algorithms/test_single_agent/test_cqn.py
+++ b/tests/test_algorithms/test_single_agent/test_cqn.py
@@ -14,6 +14,7 @@ from torch import nn, optim
 
 from agilerl.algorithms.cqn import CQN
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
+from agilerl.utils.algo_utils import is_train_eval_invariant
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_not_equal_state_dict,
@@ -246,6 +247,20 @@ class TestCQNInit:
 
 
 class TestCQNGetAction:
+    # A mode-sensitive actor takes the eval()/train() toggle path in get_action.
+    def test_mode_sensitive_actor_restores_train_mode(self, vector_space):
+        action_space = spaces.Discrete(2)
+        cqn = CQN(vector_space, action_space)
+        cqn.actor.add_module("dropout", nn.Dropout(0.5))
+        cqn._actor_mode_invariant = is_train_eval_invariant(cqn.actor)
+        assert not cqn._actor_mode_invariant
+
+        action = cqn.get_action(np.array([1, 2, 3, 4]), epsilon=0.0)[0]
+
+        assert action >= 0
+        assert action < action_space.n
+        assert cqn.actor.training
+
     # Returns the expected action when given a state observation and epsilon=0 or 1.
     def test_epsilon_greedy_returns_valid_action(self, vector_space):
         action_space = spaces.Discrete(2)

--- a/tests/test_algorithms/test_single_agent/test_ddpg.py
+++ b/tests/test_algorithms/test_single_agent/test_ddpg.py
@@ -15,6 +15,7 @@ from agilerl.algorithms.ddpg import DDPG
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.networks.actors import DeterministicActor
 from agilerl.networks.q_networks import ContinuousQNetwork
+from agilerl.utils.algo_utils import is_train_eval_invariant
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_not_equal_state_dict,
@@ -330,6 +331,19 @@ class TestDDPGInit:
 
 
 class TestDDPGGetAction:
+    # A mode-sensitive actor takes the eval()/train() toggle path in get_action.
+    def test_mode_sensitive_actor_restores_train_mode(self, vector_space):
+        action_space = spaces.Box(low=-1, high=1, shape=(2,))
+        ddpg = DDPG(vector_space, action_space)
+        ddpg.actor.add_module("dropout", nn.Dropout(0.5))
+        ddpg._actor_mode_invariant = is_train_eval_invariant(ddpg.actor)
+        assert not ddpg._actor_mode_invariant
+
+        action = ddpg.get_action(get_sample_from_space(vector_space), training=False)[0]
+
+        assert len(action) == action_space.shape[0]
+        assert ddpg.actor.training
+
     @pytest.mark.parametrize(
         "observation_space",
         [

--- a/tests/test_algorithms/test_single_agent/test_dqn.py
+++ b/tests/test_algorithms/test_single_agent/test_dqn.py
@@ -16,6 +16,7 @@ from torch import nn, optim
 from agilerl.algorithms.dqn import DQN
 from agilerl.components.data import Transition
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
+from agilerl.utils.algo_utils import is_train_eval_invariant
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_state_dicts_equal,
@@ -264,6 +265,21 @@ class TestDQNInit:
 
 
 class TestDQNGetAction:
+    # A mode-sensitive actor takes the eval()/train() toggle path in get_action.
+    def test_mode_sensitive_actor_restores_train_mode(
+        self, vector_space, discrete_space
+    ):
+        dqn = DQN(vector_space, discrete_space)
+        dqn.actor.add_module("dropout", nn.Dropout(0.5))
+        dqn._actor_mode_invariant = is_train_eval_invariant(dqn.actor)
+        assert not dqn._actor_mode_invariant
+
+        action = dqn.get_action(get_sample_from_space(vector_space), epsilon=0.0)[0]
+
+        assert action >= 0
+        assert action < discrete_space.n
+        assert dqn.actor.training
+
     @pytest.mark.parametrize(
         "observation_space",
         [

--- a/tests/test_algorithms/test_single_agent/test_ilql.py
+++ b/tests/test_algorithms/test_single_agent/test_ilql.py
@@ -14,13 +14,13 @@ from agilerl.algorithms.ilql import (
     TopAdvantageNGrams,
     interact_environment,
     map_pytree,
-    parameter_norm,
     to,
     to_decorator,
 )
 from agilerl.data.language_environment import Language_Observation
 from agilerl.data.rl_data import ConstantTokenReward, DataPoint, List_RL_Dataset
 from agilerl.data.torch_datasets import GeneralDataset
+from agilerl.utils.torch_utils import parameter_norm
 from tests.helper_functions import assert_state_dicts_equal
 from tests.test_data import WordleTokenizer
 

--- a/tests/test_algorithms/test_single_agent/test_td3.py
+++ b/tests/test_algorithms/test_single_agent/test_td3.py
@@ -15,6 +15,7 @@ from agilerl.algorithms.td3 import TD3
 from agilerl.modules import EvolvableCNN, EvolvableMLP, EvolvableMultiInput
 from agilerl.networks.actors import DeterministicActor
 from agilerl.networks.q_networks import ContinuousQNetwork
+from agilerl.utils.algo_utils import is_train_eval_invariant
 from agilerl.wrappers.make_evolvable import MakeEvolvable
 from tests.helper_functions import (
     assert_not_equal_state_dict,
@@ -452,6 +453,19 @@ class TestTD3Init:
 
 
 class TestTD3GetAction:
+    # A mode-sensitive actor takes the eval()/train() toggle path in get_action.
+    def test_mode_sensitive_actor_restores_train_mode(self, vector_space):
+        action_space = spaces.Box(low=-1, high=1, shape=(2,))
+        td3 = TD3(vector_space, action_space)
+        td3.actor.add_module("dropout", nn.Dropout(0.5))
+        td3._actor_mode_invariant = is_train_eval_invariant(td3.actor)
+        assert not td3._actor_mode_invariant
+
+        action = td3.get_action(get_sample_from_space(vector_space), training=False)[0]
+
+        assert len(action) == action_space.shape[0]
+        assert td3.actor.training
+
     @pytest.mark.parametrize(
         "observation_space",
         ["vector_space", "image_space", "dict_space"],

--- a/tests/test_utils/test_torch_utils.py
+++ b/tests/test_utils/test_torch_utils.py
@@ -86,7 +86,7 @@ def test_parameter_norm_multiple_parameters():
     for param in model.parameters():
         expected_norm += (param.norm() ** 2).item()
     expected_norm = math.sqrt(expected_norm)
-    assert parameter_norm(model) == expected_norm
+    assert parameter_norm(model) == pytest.approx(expected_norm)
 
 
 # The value of "attention_entropy" is a tuple containing the model's attention entropy and the total number of non-masked tokens.

--- a/tutorials/pettingzoo/dqn_curriculum.py
+++ b/tutorials/pettingzoo/dqn_curriculum.py
@@ -6,7 +6,6 @@
 Author: Nick (https://github.com/nicku-a)
 """
 
-import copy
 import os
 import random
 from collections import deque
@@ -19,12 +18,11 @@ import wandb
 import yaml
 from pettingzoo import ParallelEnv
 from pettingzoo.classic import connect_four_v3
-from tqdm import tqdm, trange
+from tensordict import TensorDict
+from tqdm import trange
 
 from agilerl.algorithms import DQN
-from agilerl.algorithms.core import OptimizerWrapper
 from agilerl.algorithms.core.registry import HyperparameterConfig, RLParameter
-from agilerl.components.data import Transition
 from agilerl.components.replay_buffer import ReplayBuffer
 from agilerl.hpo.mutation import Mutations
 from agilerl.hpo.tournament import TournamentSelection
@@ -42,183 +40,6 @@ class CurriculumEnv:
     def __init__(self, env: ParallelEnv, lesson: dict):
         self.env = env
         self.lesson = lesson
-
-    def fill_replay_buffer(
-        self,
-        memory: ReplayBuffer,
-        opponent: "Opponent",
-    ) -> ReplayBuffer:
-        """Fill the replay buffer with experiences collected by taking random actions in the environment.
-
-        :param memory: Experience replay buffer
-        :type memory: AgileRL experience replay buffer
-        :param opponent: Opponent to train against
-        :type opponent: Opponent
-        :return: Filled replay buffer
-        :rtype: ReplayBuffer
-        """
-        print("Filling replay buffer ...")
-
-        pbar = tqdm(total=memory.max_size)
-        while len(memory) < memory.max_size:
-            # Randomly decide whether random player will go first or second
-            opponent_first = random.random() > 0.5
-
-            mem_full = len(memory)
-            self.reset()  # Reset environment at start of episode
-            observation, reward, done, truncation, _ = self.last()
-
-            (
-                p1_state,
-                p1_state_flipped,
-                p1_action,
-                p1_next_state,
-                p1_next_state_flipped,
-            ) = (None, None, None, None, None)
-            done, truncation = False, False
-
-            while not (done or truncation):
-                # Player 0's turn
-                p0_action_mask = observation["action_mask"]
-                p0_state, p0_state_flipped = transform_and_flip(observation, player=0)
-                if opponent_first:
-                    p0_action = self.env.action_space("player_0").sample(p0_action_mask)
-                elif self.lesson["warm_up_opponent"] == "random":
-                    p0_action = opponent.get_action(
-                        p0_action_mask,
-                        p1_action,
-                        self.lesson["block_vert_coef"],
-                    )
-                else:
-                    p0_action = opponent.get_action(player=0)
-                self.step(p0_action)  # Act in environment
-                observation, _, done, truncation, _ = self.last()
-                p0_next_state, p0_next_state_flipped = transform_and_flip(
-                    observation,
-                    player=0,
-                )
-
-                if done or truncation:
-                    reward = self.reward(done=True, player=0)
-                    transition = Transition(
-                        obs=np.concatenate(
-                            (p0_state, p1_state, p0_state_flipped, p1_state_flipped),
-                        ),
-                        action=np.array(
-                            [p0_action, p1_action, 6 - p0_action, 6 - p1_action],
-                        ),
-                        reward=np.array(
-                            [
-                                reward,
-                                self.lesson["rewards"]["lose"],
-                                reward,
-                                self.lesson["rewards"]["lose"],
-                            ],
-                        ),
-                        next_obs=np.concatenate(
-                            (
-                                p0_next_state,
-                                p1_next_state,
-                                p0_next_state_flipped,
-                                p1_next_state_flipped,
-                            ),
-                        ),
-                        done=np.array([done, done, done, done]),
-                        batch_size=[4],
-                    )
-                    memory.add(transition.to_tensordict())
-                else:  # Play continues
-                    if p1_state is not None:
-                        reward = self.reward(done=False, player=1)
-                        transition = Transition(
-                            obs=np.concatenate((p1_state, p1_state_flipped)),
-                            action=np.array([p1_action, 6 - p1_action]),
-                            reward=np.array([reward, reward]),
-                            next_obs=np.concatenate(
-                                (p1_next_state, p1_next_state_flipped),
-                            ),
-                            done=np.array([done, done]),
-                            batch_size=[2],
-                        )
-                        memory.add(transition.to_tensordict())
-
-                    # Player 1's turn
-                    p1_action_mask = observation["action_mask"]
-                    p1_state, p1_state_flipped = transform_and_flip(
-                        observation,
-                        player=1,
-                    )
-                    if not opponent_first:
-                        p1_action = self.env.action_space("player_1").sample(
-                            p1_action_mask,
-                        )
-                    elif self.lesson["warm_up_opponent"] == "random":
-                        p1_action = opponent.get_action(
-                            p1_action_mask,
-                            p0_action,
-                            self.lesson["block_vert_coef"],
-                        )
-                    else:
-                        p1_action = opponent.get_action(player=1)
-                    self.step(p1_action)  # Act in environment
-                    observation, _, done, truncation, _ = self.last()
-                    p1_next_state, p1_next_state_flipped = transform_and_flip(
-                        observation,
-                        player=1,
-                    )
-
-                    if done or truncation:
-                        reward = self.reward(done=True, player=1)
-                        transition = Transition(
-                            obs=np.concatenate(
-                                (
-                                    p0_state,
-                                    p1_state,
-                                    p0_state_flipped,
-                                    p1_state_flipped,
-                                ),
-                            ),
-                            action=np.array(
-                                [p0_action, p1_action, 6 - p0_action, 6 - p1_action],
-                            ),
-                            reward=np.array(
-                                [
-                                    self.lesson["rewards"]["lose"],
-                                    reward,
-                                    self.lesson["rewards"]["lose"],
-                                    reward,
-                                ],
-                            ),
-                            next_obs=np.concatenate(
-                                (
-                                    p0_next_state,
-                                    p1_next_state,
-                                    p0_next_state_flipped,
-                                    p1_next_state_flipped,
-                                ),
-                            ),
-                            done=np.array([done, done, done, done]),
-                            batch_size=[4],
-                        )
-                        memory.add(transition.to_tensordict())
-                    else:  # Play continues
-                        reward = self.reward(done=False, player=0)
-                        transition = Transition(
-                            obs=np.concatenate((p0_state, p0_state_flipped)),
-                            action=np.array([p0_action, 6 - p0_action]),
-                            reward=np.array([reward, reward]),
-                            next_obs=np.concatenate(
-                                (p0_next_state, p0_next_state_flipped),
-                            ),
-                            done=np.array([done, done]),
-                            batch_size=[2],
-                        )
-                        memory.add(transition.to_tensordict())
-
-            pbar.update(len(memory) - mem_full)
-        pbar.close()
-        print("Replay buffer warmed up.")
-        return memory
 
     def check_winnable(self, lst: list[int], piece: int) -> bool:
         """Checks if four pieces in a row represent a winnable opportunity, e.g. [1, 1, 1, 0] or [2, 0, 2, 2].
@@ -537,187 +358,282 @@ class Opponent:
         return (True, reward, ended) + ((lengths,) if return_length else ())
 
 
-def transform_and_flip(observation, player):
-    """Transforms and flips observation for input to agent's neural network.
+def agent_state(observation: dict) -> np.ndarray:
+    """Player-perspective CHW float state from a Connect-Four observation.
 
-    :param observation: Observation to preprocess
-    :type observation: dict[str, np.ndarray]
-    :param player: Player, 0 or 1
-    :type player: int
+    PettingZoo returns the observation from the *current* player's point of view,
+    so a plain channel-move is enough for whoever is to move (no plane swap).
+
+    :param observation: Raw PettingZoo observation dict.
+    :type observation: dict
+    :return: (channels, height, width) float32 array.
+    :rtype: numpy.ndarray
     """
-    state = observation["observation"]
-    # Pre-process dimensions for PyTorch (N, C, H, W)
-    state = np.moveaxis(state, -1, -3)
-    if player == 1:
-        # Swap pieces so that the agent always sees the board from the same perspective
-        state[[0, 1], :, :] = state[[1, 0], :, :]
-    state_flipped = np.expand_dims(np.flip(state, 2), 0)
-    state = np.expand_dims(state, 0)
-    return state, state_flipped
+    return np.moveaxis(observation["observation"], -1, -3).astype(np.float32)
+
+
+class ConnectFourVecEnv:
+    """Vectorized self-play Connect Four as a single-agent MDP.
+
+    ``num_envs`` games are stepped in lockstep with the opponent embedded in
+    :meth:`step`, so one batched ``get_action`` drives them all. Buffers are
+    preallocated and written in place, and terminated games auto-reset. A fixed
+    ``num_envs`` keeps the agent's batch shapes static for CUDA graph capture.
+
+    :param num_envs: Number of parallel games.
+    :type num_envs: int
+    :param lesson: Curriculum lesson settings (opponent, rewards, ...).
+    :type lesson: dict
+    :param opponent_policy: Frozen agent used as the opponent for self-play
+        (``lesson['opponent'] == 'self'``); ``None`` for rule-based opponents.
+    :type opponent_policy: DQN | None
+    """
+
+    def __init__(self, num_envs: int, lesson: dict, opponent_policy=None):
+        self.num_envs = num_envs
+        self.lesson = lesson
+        self.opponent_policy = opponent_policy
+        raw = connect_four_v3.env().observation_space("player_0")["observation"]
+        self.single_observation_space = gym.spaces.Box(
+            low=raw.low.transpose(2, 0, 1),
+            high=raw.high.transpose(2, 0, 1),
+            dtype=np.float32,
+        )
+        self.single_action_space = connect_four_v3.env().action_space("player_0")
+        self.observations = np.zeros(
+            (num_envs, *self.single_observation_space.shape), dtype=np.float32
+        )
+        self.masks = np.ones((num_envs, 7), dtype=np.int8)
+        self.rewards = np.zeros(num_envs, dtype=np.float32)
+        self.terminals = np.zeros(num_envs, dtype=bool)
+        self.games = [
+            CurriculumEnv(connect_four_v3.env(), lesson) for _ in range(num_envs)
+        ]
+        self.rule_opponents = (
+            [Opponent(g, difficulty=lesson["opponent"]) for g in self.games]
+            if lesson["opponent"] != "self"
+            else None
+        )
+
+    def transition(
+        self, prev_observations: np.ndarray, actions: np.ndarray
+    ) -> TensorDict:
+        """Build one batched replay transition from the pre-step obs and current buffers."""
+        n = self.num_envs
+        return TensorDict(
+            {
+                "obs": torch.from_numpy(prev_observations.copy()),
+                "action": torch.from_numpy(np.asarray(actions, dtype=np.int64)).reshape(
+                    n, 1
+                ),
+                "reward": torch.from_numpy(self.rewards.copy()).reshape(n, 1),
+                "next_obs": torch.from_numpy(self.observations.copy()),
+                "done": torch.from_numpy(self.terminals.astype(np.float32)).reshape(
+                    n, 1
+                ),
+            },
+            batch_size=[n],
+        )
+
+    def _write_obs(self, i: int) -> None:
+        obs, _, _, _, _ = self.games[i].last()
+        self.observations[i] = agent_state(obs)
+        self.masks[i] = obs["action_mask"]
+
+    def _reset_game(self, i: int) -> None:
+        self.games[i].reset()
+        self._write_obs(i)
+
+    def reset(self, seed: int | None = None) -> None:
+        """Reset every game and fill the observation/mask buffers in place."""
+        for i in range(self.num_envs):
+            self._reset_game(i)
+        self.terminals[:] = False
+
+    def _opponent_actions(self, pending: list[int]) -> list[int]:
+        """Opponent (player_1) moves for the games in ``pending``."""
+        if not pending:
+            return []
+        if self.opponent_policy is not None:
+            # self-play: one batched greedy forward through the frozen opponent net
+            obs = np.stack([agent_state(self.games[i].last()[0]) for i in pending])
+            masks = np.stack([self.games[i].last()[0]["action_mask"] for i in pending])
+            return list(
+                self.opponent_policy.get_action(obs, epsilon=0.0, action_mask=masks)
+            )
+        # 'random' takes the action mask; 'weak'/'strong' introspect the board.
+        if self.lesson["opponent"] == "random":
+            block = self.lesson.get("block_vert_coef", 1)
+            return [
+                self.rule_opponents[i].get_action(
+                    self.games[i].last()[0]["action_mask"], None, block
+                )
+                for i in pending
+            ]
+        return [self.rule_opponents[i].get_action(player=1) for i in pending]
+
+    def step(self, actions: np.ndarray) -> None:
+        """Apply agent actions, play the opponent's reply, write buffers, auto-reset."""
+        pending = []
+        for i, g in enumerate(self.games):
+            g.step(int(actions[i]))
+            _, _, done, trunc, _ = g.last()
+            if done or trunc:
+                self.rewards[i] = g.reward(done=True, player=0)
+                self.terminals[i] = True
+                self._reset_game(i)
+            else:
+                pending.append(i)
+        opp_actions = self._opponent_actions(pending)
+        for j, i in enumerate(pending):
+            g = self.games[i]
+            g.step(int(opp_actions[j]))
+            _, _, done, trunc, _ = g.last()
+            if done or trunc:
+                self.rewards[i] = self.lesson["rewards"]["lose"]
+                self.terminals[i] = True
+                self._reset_game(i)
+            else:
+                self.rewards[i] = g.reward(done=False, player=0)
+                self.terminals[i] = False
+                self._write_obs(i)
+
+
+@torch.no_grad()
+def evaluate(agent, lesson, num_envs: int, n_games: int = 192) -> float:
+    """Greedy win-rate vs the eval opponent, played on ``num_envs`` parallel games.
+
+    Uses the same ``num_envs`` as training so the CUDA-graph-captured
+    ``get_action`` always sees the same static batch shape.
+    """
+    eval_lesson = dict(lesson, opponent=lesson["eval_opponent"])
+    venv = ConnectFourVecEnv(num_envs, eval_lesson)
+    venv.reset()
+    wins = done = 0
+    while done < n_games:
+        actions = agent.get_action(
+            venv.observations, epsilon=0.0, action_mask=venv.masks
+        )
+        venv.step(np.asarray(actions))
+        for i in range(num_envs):
+            if venv.terminals[i]:
+                wins += venv.rewards[i] >= lesson["rewards"]["win"] * 0.9
+                done += 1
+    return wins / max(done, 1)
 
 
 if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print("===== AgileRL Curriculum Learning Demo =====")
+    print("===== AgileRL Curriculum Learning Demo (vectorized + CUDA graphs) =====")
+
+    # Fixed so the agent's batch shapes stay static for CUDA graph capture.
+    NUM_ENVS = 32
+    # Replays a step's kernel launches as one call, removing the CPU dispatch
+    # overhead that dominates small networks. Needs static shapes.
+    USE_CUDAGRAPHS = device.type == "cuda"
 
     for lesson_number in range(1, 5):
-        # Load lesson for curriculum
         with open(f"./curriculums/connect_four/lesson{lesson_number}.yaml") as file:
             LESSON = yaml.safe_load(file)
 
-        # Network configuration
         net_config = {
             "encoder_config": {
                 "channel_size": [128],
                 "kernel_size": [4],
                 "stride_size": [1],
             },
-            "head_config": {
-                "hidden_size": [64, 64],
-            },
+            "head_config": {"hidden_size": [64, 64]},
         }
-
-        # Algorithm hyperparameters
         init_hp = {
             "double": True,
-            "batch_size": 256,
+            "batch_size": 256,  # fixed (not mutated) so the CUDA graph stays valid
             "lr": 1e-4,
             "gamma": 0.99,
             "learn_step": 1,
             "tau": 0.01,
         }
-
         population_size = 6
         memory_size = 10000
 
-        # Define the connect four environment
-        env = connect_four_v3.env()
-        env.reset()
+        probe = ConnectFourVecEnv(NUM_ENVS, LESSON)
+        observation_space = probe.single_observation_space
+        action_space = probe.single_action_space
 
-        # Configure the algo input arguments
-        observation_spaces = [env.observation_space(agent) for agent in env.agents]
-        action_spaces = [env.action_space(agent) for agent in env.agents]
-
-        # Warp the environment in the curriculum learning wrapper
-        env = CurriculumEnv(env, LESSON)
-
-        # Pre-process dimensions for PyTorch layers
-        # We only need to worry about the state dim of a single agent
-        # Transpose observation space from (6, 7, 2) HWC to (2, 6, 7) CHW
-        raw_space = observation_spaces[0]["observation"]
-        observation_space = gym.spaces.Box(
-            low=raw_space.low.transpose(2, 0, 1),
-            high=raw_space.high.transpose(2, 0, 1),
-            dtype=raw_space.dtype,
-        )
-
-        # Mutation config for RL hyperparameters
+        # batch_size is not mutated: it would invalidate the captured CUDA graph.
         hp_config = HyperparameterConfig(
             lr=RLParameter(min=1e-4, max=1e-2),
-            batch_size=RLParameter(min=8, max=64, dtype=int),
             learn_step=RLParameter(
-                min=1,
-                max=120,
-                dtype=int,
-                grow_factor=1.5,
-                shrink_factor=0.75,
+                min=1, max=120, dtype=int, grow_factor=1.5, shrink_factor=0.75
             ),
         )
 
-        # Create a population ready for evolutionary hyper-parameter optimisation
         pop = DQN.population(
             size=population_size,
             observation_space=observation_space,
-            action_space=action_spaces[0],
+            action_space=action_space,
             net_config=net_config,
             hp_config=hp_config,
             device=device,
+            cudagraphs=USE_CUDAGRAPHS,
             **init_hp,
         )
 
-        # Configure the replay buffer
-        memory = ReplayBuffer(
-            max_size=memory_size,
-            device=device,
-        )
-
-        # Instantiate a tournament selection object (used for HPO)
+        memory = ReplayBuffer(max_size=memory_size, device=device)
         tournament = TournamentSelection(
-            tournament_size=2,  # Tournament selection size
-            elitism=True,  # Elitism in tournament selection
-            population_size=population_size,  # Population size
+            tournament_size=2, elitism=True, population_size=population_size
         )
-
-        # Instantiate a mutations object (used for HPO)
         mutations = Mutations(
-            no_mutation=0.2,  # Probability of no mutation
-            architecture=0,  # Probability of architecture mutation
-            new_layer_prob=0.2,  # Probability of new layer mutation
-            parameters=0.2,  # Probability of parameter mutation
-            activation=0,  # Probability of activation function mutation
-            rl_hp=0.2,  # Probability of RL hyperparameter mutation
-            mutation_sd=0.1,  # Mutation strength
+            no_mutation=0.2,
+            architecture=0,
+            new_layer_prob=0.2,
+            parameters=0.2,
+            activation=0,
+            rl_hp=0.2,
+            mutation_sd=0.1,
             rand_seed=1,
             device=device,
         )
 
-        # Define training loop parameters
-        episodes_per_epoch = 10
-        max_episodes = LESSON["max_train_episodes"]  # Total episodes
-        max_steps = 500  # Maximum steps to take in each episode
-        evo_epochs = 20  # Evolution frequency
-        evo_loop = 50  # Number of evaluation episodes
-        elite = pop[0]  # Assign a placeholder "elite" agent
-        epsilon = 1.0  # Starting epsilon value
-        eps_end = 0.1  # Final epsilon value
-        eps_decay = 0.9998  # Epsilon decays
-        opp_update_counter = 0
+        # Training-loop parameters
+        max_episodes = LESSON["max_train_episodes"]
+        evo_epochs = 5  # evolve every N vectorized rollout blocks
+        block_steps = 100  # batched steps per agent per block
+        epsilon, eps_end, eps_decay = 1.0, 0.1, 0.9995
 
         if LESSON["pretrained_path"] is not None:
             for agent in pop:
-                # Load pretrained checkpoint
                 agent.load_checkpoint(LESSON["pretrained_path"])
-                # Reinit optimizer for new task
-                agent.lr = init_hp["lr"]
-                agent.optimizer = OptimizerWrapper(
-                    torch.optim.Adam,
-                    networks=agent.actor,
-                    lr=agent.lr,
-                    network_names=agent.optimizer.network_names,
-                    lr_name=agent.optimizer.lr_name,
-                    optimizer_kwargs={"capturable": agent.capturable},
-                )
 
+        opponent_pool = None
         if LESSON["opponent"] == "self":
-            # Create initial pool of opponents
             opponent_pool = deque(maxlen=LESSON["opponent_pool_size"])
             for _ in range(LESSON["opponent_pool_size"]):
-                opp = copy.deepcopy(pop[0])
-                opp.actor.load_state_dict(pop[0].actor.state_dict())
-                opp.actor.eval()
-                opponent_pool.append(opp)
+                opponent_pool.append(pop[0].clone())
 
-        # Perform buffer and agent warmups if desired
+        # Buffer + agent warm-up (vectorized random rollout)
         if LESSON["buffer_warm_up"]:
-            warm_up_opponent = Opponent(env, difficulty=LESSON["warm_up_opponent"])
-
-            # Fill replay buffer with transitions
-            memory = env.fill_replay_buffer(memory, warm_up_opponent)
+            warm_lesson = dict(LESSON, opponent=LESSON["warm_up_opponent"])
+            warm_env = ConnectFourVecEnv(NUM_ENVS, warm_lesson)
+            warm_env.reset()
+            print("Filling replay buffer ...")
+            while len(memory) < memory.max_size:
+                acts = np.array(
+                    [
+                        random.choices(range(7), warm_env.masks[i])[0]
+                        for i in range(NUM_ENVS)
+                    ]
+                )
+                prev = warm_env.observations.copy()
+                warm_env.step(acts)
+                memory.add(warm_env.transition(prev, acts))
             if LESSON["agent_warm_up"] > 0:
                 print("Warming up agents ...")
-                agent = pop[0]
-                # Train on randomly collected samples
-                for _ in trange(LESSON["agent_warm_up"]):
-                    experiences = memory.sample(agent.batch_size)
-                    agent.learn(experiences)
-
-                pop = [agent.clone() for _ in pop]
-                elite = agent
-                print("Agent population warmed up.")
+                for agent in pop:
+                    for _ in range(LESSON["agent_warm_up"]):
+                        agent.learn(memory.sample(agent.batch_size))
 
         if max_episodes > 0:
             wandb.init(
-                # set the wandb project where this run will be logged
                 project="AgileRL",
                 name="{}-EvoHPO-{}-{}Opposition-CNN-{}".format(
                     "connect_four_v3",
@@ -733,364 +649,51 @@ if __name__ == "__main__":
                 },
             )
 
+        elite = pop[0]
         total_steps = 0
-        total_episodes = 0
-        pbar = trange(int(max_episodes / episodes_per_epoch))
+        # Each step collects NUM_ENVS transitions.
+        n_blocks = 0 if max_episodes == 0 else 25
 
-        # Training loop
-        for idx_epi in pbar:
-            turns_per_episode = []
-            for agent in pop:  # Loop through population
-                for _ in range(episodes_per_epoch):
-                    env.reset()  # Reset environment at start of episode
-                    observation, cumulative_reward, done, truncation, _ = env.last()
-
-                    (
-                        p1_state,
-                        p1_state_flipped,
-                        p1_action,
-                        p1_next_state,
-                        p1_next_state_flipped,
-                    ) = (None, None, None, None, None)
-
-                    if LESSON["opponent"] == "self":
-                        # Randomly choose opponent from opponent pool if using self-play
-                        opponent = random.choice(opponent_pool)
-                    else:
-                        # Create opponent of desired difficulty
-                        opponent = Opponent(env, difficulty=LESSON["opponent"])
-
-                    # Randomly decide whether agent will go first or second
-                    opponent_first = random.random() > 0.5
-
-                    score = 0
-                    turns = 0  # Number of turns counter
-                    for idx_step in range(max_steps):
-                        # Player 0"s turn
-                        p0_action_mask = observation["action_mask"]
-                        p0_state, p0_state_flipped = transform_and_flip(
-                            observation,
-                            player=0,
-                        )
-
-                        if opponent_first:
-                            if LESSON["opponent"] == "self":
-                                p0_action = opponent.get_action(
-                                    p0_state,
-                                    0,
-                                    p0_action_mask,
-                                )[0]
-                            elif LESSON["opponent"] == "random":
-                                p0_action = opponent.get_action(
-                                    p0_action_mask,
-                                    p1_action,
-                                    LESSON["block_vert_coef"],
-                                )
-                            else:
-                                p0_action = opponent.get_action(player=0)
-                        else:
-                            p0_action = agent.get_action(
-                                p0_state,
-                                epsilon,
-                                p0_action_mask,
-                            )[0]  # Get next action from agent
-                        env.step(p0_action)  # Act in environment
-                        observation, cumulative_reward, done, truncation, _ = env.last()
-                        p0_next_state, p0_next_state_flipped = transform_and_flip(
-                            observation,
-                            player=0,
-                        )
-                        if not opponent_first:
-                            score = cumulative_reward
-                        turns += 1
-
-                        # Check if game is over (Player 0 win)
-                        if done or truncation:
-                            reward = env.reward(done=True, player=0)
-                            transition = Transition(
-                                obs=np.concatenate(
-                                    (
-                                        p0_state,
-                                        p1_state,
-                                        p0_state_flipped,
-                                        p1_state_flipped,
-                                    ),
-                                ),
-                                action=np.array(
-                                    [
-                                        p0_action,
-                                        p1_action,
-                                        6 - p0_action,
-                                        6 - p1_action,
-                                    ],
-                                ),
-                                reward=np.array(
-                                    [
-                                        reward,
-                                        LESSON["rewards"]["lose"],
-                                        reward,
-                                        LESSON["rewards"]["lose"],
-                                    ],
-                                ),
-                                next_obs=np.concatenate(
-                                    (
-                                        p0_next_state,
-                                        p1_next_state,
-                                        p0_next_state_flipped,
-                                        p1_next_state_flipped,
-                                    ),
-                                ),
-                                done=np.array([done, done, done, done]),
-                                batch_size=[4],
-                            )
-                            memory.add(transition.to_tensordict())
-                        else:  # Play continues
-                            if p1_state is not None:
-                                reward = env.reward(done=False, player=1)
-                                transition = Transition(
-                                    obs=np.concatenate((p1_state, p1_state_flipped)),
-                                    action=np.array([p1_action, 6 - p1_action]),
-                                    reward=np.array([reward, reward]),
-                                    next_obs=np.concatenate(
-                                        (p1_next_state, p1_next_state_flipped),
-                                    ),
-                                    done=np.array([done, done]),
-                                    batch_size=[2],
-                                )
-                                memory.add(transition.to_tensordict())
-
-                            # Player 1"s turn
-                            p1_action_mask = observation["action_mask"]
-                            p1_state, p1_state_flipped = transform_and_flip(
-                                observation,
-                                player=1,
-                            )
-
-                            if not opponent_first:
-                                if LESSON["opponent"] == "self":
-                                    p1_action = opponent.get_action(
-                                        p1_state,
-                                        0,
-                                        p1_action_mask,
-                                    )[0]
-                                elif LESSON["opponent"] == "random":
-                                    p1_action = opponent.get_action(
-                                        p1_action_mask,
-                                        p0_action,
-                                        LESSON["block_vert_coef"],
-                                    )
-                                else:
-                                    p1_action = opponent.get_action(player=1)
-                            else:
-                                p1_action = agent.get_action(
-                                    p1_state,
-                                    epsilon,
-                                    p1_action_mask,
-                                )[0]  # Get next action from agent
-                            env.step(p1_action)  # Act in environment
-                            observation, cumulative_reward, done, truncation, _ = (
-                                env.last()
-                            )
-                            p1_next_state, p1_next_state_flipped = transform_and_flip(
-                                observation,
-                                player=1,
-                            )
-
-                            if opponent_first:
-                                score = cumulative_reward
-                            turns += 1
-
-                            # Check if game is over (Player 1 win)
-                            if done or truncation:
-                                reward = env.reward(done=True, player=1)
-                                transition = Transition(
-                                    obs=np.concatenate(
-                                        (
-                                            p0_state,
-                                            p1_state,
-                                            p0_state_flipped,
-                                            p1_state_flipped,
-                                        ),
-                                    ),
-                                    action=np.array(
-                                        [
-                                            p0_action,
-                                            p1_action,
-                                            6 - p0_action,
-                                            6 - p1_action,
-                                        ],
-                                    ),
-                                    reward=np.array(
-                                        [
-                                            reward,
-                                            LESSON["rewards"]["lose"],
-                                            reward,
-                                            LESSON["rewards"]["lose"],
-                                        ],
-                                    ),
-                                    next_obs=np.concatenate(
-                                        (
-                                            p0_next_state,
-                                            p1_next_state,
-                                            p0_next_state_flipped,
-                                            p1_next_state_flipped,
-                                        ),
-                                    ),
-                                    done=np.array([done, done, done, done]),
-                                    batch_size=[4],
-                                )
-                                memory.add(transition.to_tensordict())
-                            else:  # Play continues
-                                reward = env.reward(done=False, player=0)
-                                transition = Transition(
-                                    obs=np.concatenate((p0_state, p0_state_flipped)),
-                                    action=np.array([p0_action, 6 - p0_action]),
-                                    reward=np.array([reward, reward]),
-                                    next_obs=np.concatenate(
-                                        (p0_next_state, p0_next_state_flipped),
-                                    ),
-                                    done=np.array([done, done]),
-                                    batch_size=[2],
-                                )
-                                memory.add(transition.to_tensordict())
-
-                        # Learn according to learning frequency
-                        if (memory.counter % agent.learn_step == 0) and (
-                            len(memory) >= agent.batch_size
-                        ):
-                            # Sample replay buffer
-                            # Learn according to agent"s RL algorithm
-                            experiences = memory.sample(agent.batch_size)
-                            agent.learn(experiences)
-
-                        # Stop episode if any agents have terminated
-                        if done or truncation:
-                            break
-
-                    total_steps += idx_step + 1
-                    total_episodes += 1
-                    turns_per_episode.append(turns)
-                    # Save the total episode reward
-                    agent.scores.append(score)
-
+        pbar = trange(n_blocks)
+        for block in pbar:
+            for agent in pop:
+                opp = (
+                    random.choice(opponent_pool) if opponent_pool is not None else None
+                )
+                venv = ConnectFourVecEnv(NUM_ENVS, LESSON, opponent_policy=opp)
+                venv.reset()
+                for agent_step in range(block_steps):
+                    prev = venv.observations.copy()
+                    actions = agent.get_action(venv.observations, epsilon, venv.masks)
+                    venv.step(np.asarray(actions))
+                    memory.add(venv.transition(prev, np.asarray(actions)))
                     if (
-                        LESSON["opponent"] == "self"
-                        and (total_episodes % LESSON["opponent_upgrade"] == 0)
-                        and ((idx_epi + 1) > evo_epochs)
+                        len(memory) >= agent.batch_size
+                        and agent_step % agent.learn_step == 0
                     ):
-                        elite_opp, _, _ = tournament._elitism(pop)
-                        elite_opp.actor.eval()
-                        opponent_pool.append(elite_opp)
-                        opp_update_counter += 1
-
-                # Update epsilon for exploration
+                        agent.learn(memory.sample(agent.batch_size))
+                    total_steps += NUM_ENVS
                 epsilon = max(eps_end, epsilon * eps_decay)
 
-            mean_turns = np.mean(turns_per_episode)
+            # Self-play: refresh the opponent pool with the current elite
+            if opponent_pool is not None and (block + 1) % evo_epochs == 0:
+                elite_opp, _, _ = tournament._elitism(pop)
+                opponent_pool.append(elite_opp.clone())
 
-            # Now evolve population if necessary
-            if (idx_epi + 1) % evo_epochs == 0:
-                # Evaluate population vs random actions
-                fitnesses = []
-                eval_turns = 0  # Eval turns counter
-                for agent in pop:
-                    with torch.no_grad():
-                        rewards = []
-                        for _ in range(evo_loop):
-                            env.reset()  # Reset environment at start of episode
-                            observation, cumulative_reward, done, truncation, _ = (
-                                env.last()
-                            )
-
-                            player = -1  # Tracker for which player"s turn it is
-
-                            # Create opponent of desired difficulty
-                            opponent = Opponent(env, difficulty=LESSON["eval_opponent"])
-
-                            # Randomly decide whether agent will go first or second
-                            opponent_first = not random.random() > 0.5
-
-                            score = 0
-
-                            for _ in range(max_steps):
-                                action_mask = observation["action_mask"]
-                                if player < 0:
-                                    if opponent_first:
-                                        if LESSON["eval_opponent"] == "random":
-                                            action = opponent.get_action(action_mask)
-                                        else:
-                                            action = opponent.get_action(player=0)
-                                    else:
-                                        state = np.moveaxis(
-                                            observation["observation"],
-                                            [-1],
-                                            [-3],
-                                        )
-                                        state = np.expand_dims(state, 0)
-                                        action = agent.get_action(
-                                            state,
-                                            0,
-                                            action_mask,
-                                        )[0]  # Get next action from agent
-                                if player > 0:
-                                    if not opponent_first:
-                                        if LESSON["eval_opponent"] == "random":
-                                            action = opponent.get_action(action_mask)
-                                        else:
-                                            action = opponent.get_action(player=1)
-                                    else:
-                                        state = np.moveaxis(
-                                            observation["observation"],
-                                            [-1],
-                                            [-3],
-                                        )
-                                        state[[0, 1], :, :] = state[[1, 0], :, :]
-                                        state = np.expand_dims(state, 0)
-                                        action = agent.get_action(
-                                            state,
-                                            0,
-                                            action_mask,
-                                        )[0]  # Get next action from agent
-
-                                env.step(action)  # Act in environment
-                                observation, cumulative_reward, done, truncation, _ = (
-                                    env.last()
-                                )
-
-                                if (player > 0 and opponent_first) or (
-                                    player < 0 and not opponent_first
-                                ):
-                                    score = cumulative_reward
-
-                                eval_turns += 1
-
-                                if done or truncation:
-                                    break
-
-                                player *= -1
-
-                            rewards.append(score)
-                    mean_fit = np.mean(rewards)
-                    agent.fitness.append(mean_fit)
-                    fitnesses.append(mean_fit)
-
-                eval_turns = eval_turns / len(pop) / evo_loop
-
-                pbar.set_postfix_str(
-                    f"Train Mean Score: {np.mean(agent.scores[-episodes_per_epoch:])} "
-                    f"Train Mean Turns: {mean_turns} "
-                    f"Eval Mean Fitness: {np.mean(fitnesses)} "
-                    f"Eval Best Fitness: {np.max(fitnesses)} "
-                    f"Eval Mean Turns: {eval_turns} "
-                    f"Total Steps: {total_steps}",
-                )
-                pbar.update(0)
-
-                # Tournament selection and population mutation
+            if (block + 1) % evo_epochs == 0:
+                fitnesses = [evaluate(agent, LESSON, NUM_ENVS) for agent in pop]
+                for agent, fit in zip(pop, fitnesses):
+                    agent.metrics.add_fitness(fit)
                 elite, pop = tournament.select(pop)
                 pop = mutations.mutation(pop)
+                pbar.set_postfix_str(
+                    f"Lesson {lesson_number}  Eval win-rate (best): {max(fitnesses):.2f}  "
+                    f"Total steps: {total_steps}"
+                )
 
-        # Save the trained agent
+        if max_episodes > 0:
+            wandb.finish()
+
         save_path = LESSON["save_path"]
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         elite.save_checkpoint(save_path)

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.4"
+version = "2.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -408,14 +408,14 @@ name = "anthropic"
 version = "0.104.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "distro", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "docstring-parser", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jiter", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "sniffio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/c7/7a655b948916f777354648ce979f68b94d5b8dbdb5f61fed1f37fad9378c/anthropic-0.104.1.tar.gz", hash = "sha256:17362b6c45f527afcc9b0fdf62011ffd359726ab2ebcb1978ea0cc41bd8d8d40", size = 850081, upload-time = "2026-05-22T15:36:57.432Z" }
 wheels = [
@@ -447,7 +447,7 @@ name = "apache-tvm-ffi"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/60/1e787a0b5ebf318483235be2a689ee367173983067e441b8379564f667c0/apache_tvm_ffi-0.1.9.tar.gz", hash = "sha256:d2d402587e8906de0a07f4746aa78f3d452c7efe3625d4bb39ac2ad693bce530", size = 2513731, upload-time = "2026-02-27T19:28:06.602Z" }
 wheels = [
@@ -568,11 +568,11 @@ name = "bitsandbytes"
 version = "0.49.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "packaging", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "packaging" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/71/acff7af06c818664aa87ff73e17a52c7788ad746b72aea09d3cb8e424348/bitsandbytes-0.49.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:2fc0830c5f7169be36e60e11f2be067c8f812dfcb829801a8703735842450750", size = 31442815, upload-time = "2026-02-16T21:26:06.783Z" },
@@ -584,7 +584,7 @@ name = "blake3"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/aa/abcd75e9600987a0bc6cfe9b6b2ff3f0e2cb08c170addc6e76035b5c4cb3/blake3-1.0.8.tar.gz", hash = "sha256:513cc7f0f5a7c035812604c2c852a0c1468311345573de647e310aca4ab165ba", size = 117308, upload-time = "2025-10-14T06:47:48.83Z" }
 wheels = [
@@ -902,10 +902,10 @@ name = "compressed-tensors"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "loguru", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "transformers", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "loguru" },
+    { name = "pydantic" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/9e/d7f18bd9a0354088abc11a0c1f2c7698f7c49e5a709faedf6a46e388f693/compressed_tensors-0.17.0.tar.gz", hash = "sha256:15c20d06bdbcf35b51fc99fd125e7b9be1e1855567c33b7a46dfac26ad6fb126", size = 257091, upload-time = "2026-06-03T16:49:17.208Z" }
 wheels = [
@@ -922,7 +922,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1003,8 +1003,8 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'darwin') or (python_full_version >= '3.11' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1198,7 +1198,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
@@ -1224,8 +1224,8 @@ name = "cuda-python"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-bindings" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/da/b4dbe129f941afe1c24a09ba53521b78875626763d96414798a74763282f/cuda_python-13.2.0-py3-none-any.whl", hash = "sha256:2f092b0ec13a860115fa595411889ee939ad203450ea4f91e9461b174ea7b084", size = 8145, upload-time = "2026-03-11T13:55:19.143Z" },
@@ -1236,7 +1236,7 @@ name = "cuda-tile"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/c8/1687a83d0739151ca410a5716b5f1dfb6f8feb6381c7c695d72264f17e1c/cuda_tile-1.3.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:c55616c648f06f84808648a521c67f2d7c790574d6b53ddf8c3bfbc995d36d45", size = 245438, upload-time = "2026-04-20T15:51:18.862Z" },
@@ -1251,9 +1251,9 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "nvidia-cuda-nvcc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cuda-tileiras", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvvm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-cuda-tileiras" },
+    { name = "nvidia-nvvm" },
 ]
 
 [[package]]
@@ -1266,37 +1266,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1341,19 +1341,19 @@ name = "deepspeed"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "einops", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "hjson", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "msgpack", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "ninja", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "packaging", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "psutil", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "py-cpuinfo", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tqdm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "einops" },
+    { name = "hjson" },
+    { name = "msgpack" },
+    { name = "ninja" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+    { name = "pydantic" },
+    { name = "torch" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/cc/1bd9a0f1545fa57a45f98597a78ef6b39ae1fac1afb3e14c70cb8b02455e/deepspeed-0.19.2.tar.gz", hash = "sha256:7e854b6ebe3d2bfa239f82958372927631c74e5324c7f08f17ce7ff5f6b06969", size = 1756950, upload-time = "2026-06-16T20:53:22.919Z" }
 
@@ -1374,8 +1374,8 @@ name = "depyf"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "astor", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "dill", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "astor" },
+    { name = "dill" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/35/83fb0178212279aa0af031031905804c6de5618435d229f41ed21bb9ad2c/depyf-0.20.0.tar.gz", hash = "sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98", size = 6168761, upload-time = "2025-10-13T12:33:38.589Z" }
 wheels = [
@@ -1494,8 +1494,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "idna", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "dnspython" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -1507,7 +1507,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1537,11 +1537,11 @@ name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-inspection", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
@@ -1550,15 +1550,15 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "fastar", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jinja2", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic-extra-types", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic-settings", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "python-multipart", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "email-validator" },
+    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
@@ -1566,10 +1566,10 @@ name = "fastapi-cli"
 version = "0.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tomli", marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "typer", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "rich-toolkit" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
 wheels = [
@@ -1578,8 +1578,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "fastapi-cloud-cli" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
@@ -1587,15 +1587,15 @@ name = "fastapi-cloud-cli"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "detect-installer", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "fastar", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", extra = ["email"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "rich-toolkit", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "rignore", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "sentry-sdk", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typer", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "uvicorn", extra = ["standard"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "detect-installer" },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "rich-toolkit" },
+    { name = "rignore" },
+    { name = "sentry-sdk" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/1d/57221a834b0f62dfa510c2b3db6e9b682cfbc280cef41919a8811ce1ff89/fastapi_cloud_cli-0.18.0.tar.gz", hash = "sha256:95f7a79200e3a90a005e068a4d8ede49d4b04accb095ccd4fd47da998fc28c74", size = 53320, upload-time = "2026-05-22T09:53:54.462Z" }
 wheels = [
@@ -1710,7 +1710,7 @@ name = "fastsafetensors"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typer", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/33/c97b2bcbe06e0f011eedee0f41d4060f6344901a53c2703acc3dd7429713/fastsafetensors-0.3.2.tar.gz", hash = "sha256:9e358fce238684613a5c3ebb7800c52c5b3270c0bb5e4ed2191ee8f3d0431de1", size = 70409, upload-time = "2026-05-22T05:39:34.787Z" }
 wheels = [
@@ -1746,22 +1746,22 @@ name = "flashinfer-python"
 version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "click", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "cuda-tile", extra = ["tileiras"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "einops", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "ninja", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cudnn-frontend", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cutlass-dsl", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-ml-py", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "packaging", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tabulate", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tqdm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "apache-tvm-ffi" },
+    { name = "click" },
+    { name = "cuda-tile", extra = ["tileiras"] },
+    { name = "einops" },
+    { name = "ninja" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "nvidia-ml-py" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "torch" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/d0/114a64319f5a804def2f307d5ed8f95e6d94a2acdacac4ed5f57525cbf46/flashinfer_python-0.6.12.tar.gz", hash = "sha256:bed67f9c46d81dd22611dfef2787998fc412b2fe2648d9e7d336861dda912694", size = 9453326, upload-time = "2026-05-29T23:45:16.466Z" }
 wheels = [
@@ -2055,7 +2055,7 @@ name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
 wheels = [
@@ -2108,9 +2108,9 @@ wheels = [
 
 [package.optional-dependencies]
 box2d = [
-    { name = "box2d", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
-    { name = "pygame-ce", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
-    { name = "swig", marker = "python_full_version < '3.11' or sys_platform != 'win32'" },
+    { name = "box2d" },
+    { name = "pygame-ce" },
+    { name = "swig" },
 ]
 
 [[package]]
@@ -2298,18 +2298,18 @@ name = "humming-kernels"
 version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jinja2", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-ml-py", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pyelftools", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "safetensors", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tabulate", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tqdm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "triton", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-bindings" },
+    { name = "jinja2" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "nvidia-ml-py" },
+    { name = "pyelftools" },
+    { name = "safetensors" },
+    { name = "tabulate" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "triton" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/5a/fbf574dcd83e9fea6aa3fa96b37bbdec40b8672407b1ed9679efa31fff1d/humming_kernels-0.1.6.tar.gz", hash = "sha256:882b9f382a010165a7cf8eecbad943bfe8d6b17566328fb57611c9a34bdccc9a", size = 214408, upload-time = "2026-06-20T04:04:43.221Z" }
 wheels = [
@@ -2318,10 +2318,10 @@ wheels = [
 
 [package.optional-dependencies]
 cu13 = [
-    { name = "nvidia-cuda-cccl", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cuda-nvcc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cuda-cccl" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-runtime" },
 ]
 
 [[package]]
@@ -2446,11 +2446,11 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -2476,12 +2476,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'darwin') or (python_full_version >= '3.11' and sys_platform == 'darwin')" },
-    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jaxlib", version = "0.10.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
+    { name = "opt-einsum" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/49/b082387119c4a6bc7596296bbdc6bce034628cdd2845ebb27304cbca3624/jax-0.10.1.tar.gz", hash = "sha256:11672410faf8752429eb9a131de203dc488a2a3a012d509baa2b39878008810d", size = 2718178, upload-time = "2026-05-20T14:54:09.441Z" }
 wheels = [
@@ -2498,9 +2498,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -2542,10 +2542,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'darwin') or (python_full_version >= '3.11' and sys_platform == 'darwin')" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/e9/43253041a0b28f64a99dfa8a6823de415b1b9723dc8eb8718945bb957b1c/jaxlib-0.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff0c82cb958d180d26687459962e262b6e1c90f239903c8253cc190067124db4", size = 60802893, upload-time = "2026-05-20T14:52:36.047Z" },
@@ -2641,10 +2641,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jsonschema-specifications", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "referencing", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "rpds-py", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -2656,7 +2656,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -2796,8 +2796,8 @@ name = "liger-kernel"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "triton", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "torch" },
+    { name = "triton" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/6b/5d4b965e411d35fb1f533d4b2a2a9a1e99f4bf3fc751ab22b989159c2a18/liger_kernel-0.8.1.tar.gz", hash = "sha256:ae708a8079d2283070128e38497aa2976294d822e21a0f21ea86e63c67334a8b", size = 4157449, upload-time = "2026-07-23T00:01:37.77Z" }
 wheels = [
@@ -2835,10 +2835,10 @@ name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "interegular", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "packaging", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pyyaml", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "interegular" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d5/41cd417ba7dfdbbcfe46cebf81fb3dfd7c591b89897560ad05bb410a465d/lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da", size = 40258, upload-time = "2025-08-24T19:37:47.527Z" }
 wheels = [
@@ -2850,7 +2850,7 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_version < '0'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -2999,19 +2999,19 @@ name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx-sse", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jsonschema", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic-settings", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pyjwt", extra = ["crypto"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "python-multipart", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "sse-starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-inspection", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "uvicorn", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
@@ -3023,7 +3023,7 @@ name = "mdit-py-plugins"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
@@ -3073,16 +3073,16 @@ name = "mistral-common"
 version = "1.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pillow", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tiktoken", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jsonschema" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/03/3c5d4c9430da406f8444f9a7b058a6aa89c525fb068a57fe2ab8b04a6d08/mistral_common-1.11.3.tar.gz", hash = "sha256:6437e128fc8a307318440839ca14ddf2e8060056b062233ec0db10352651374c", size = 6360629, upload-time = "2026-06-04T09:01:11.131Z" }
 wheels = [
@@ -3091,7 +3091,7 @@ wheels = [
 
 [package.optional-dependencies]
 image = [
-    { name = "opencv-python-headless", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "opencv-python-headless" },
 ]
 
 [[package]]
@@ -3136,13 +3136,13 @@ name = "model-hosting-container-standards"
 version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jmespath", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "setuptools", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "supervisor", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jmespath" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "starlette" },
+    { name = "supervisor" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/5a/d669bdeb5ba96db42c6ef010835a25119b05f8c35ee5f1c3f715626625fe/model_hosting_container_standards-0.1.15.tar.gz", hash = "sha256:ae8dd74d3250545c14f0a7068186c7b0f0ab6563d31e7137f556b6b660c8a6a9", size = 93994, upload-time = "2026-05-05T18:22:29.357Z" }
 wheels = [
@@ -3363,12 +3363,12 @@ name = "myst-parser"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "markdown-it-py", marker = "python_full_version >= '3.11'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", marker = "python_full_version >= '3.11'" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
@@ -3457,10 +3457,10 @@ name = "numba"
 version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "llvmlite" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131, upload-time = "2026-04-01T03:52:01.946Z" }
 wheels = [
@@ -3695,9 +3695,9 @@ name = "nvidia-cuda-nvcc"
 version = "13.2.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvvm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-nvvm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/df/faf551572ae1359290afa5cb05d2c4b7e6674b07b8283b20eab4dbad15f6/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dfc76950c775cd00ce588f15192f08c9b858c0dcfa7da685acf39a3d0d8f588b", size = 38713559, upload-time = "2026-04-13T09:42:17.478Z" },
@@ -3727,8 +3727,8 @@ name = "nvidia-cuda-tileiras"
 version = "13.2.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvcc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvvm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-nvvm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/04/eb26cc1d67c653f5dbe8c13fd6da9c1e844b097147051b5052ac5e6d4047/nvidia_cuda_tileiras-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:658299efca52a20496b425efb0b19cb1ea7d57406a18d3f5024d4df92d5b54c1", size = 36418791, upload-time = "2026-04-13T09:48:30.107Z" },
@@ -3740,7 +3740,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3767,7 +3767,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3797,9 +3797,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3811,7 +3811,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3832,7 +3832,7 @@ name = "nvidia-cutlass-dsl"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cutlass-dsl-libs-base" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/15/575d7df4fe2f3406f1cfc68be72aeff2834f8a696daf1cd5bee8017e4507/nvidia_cutlass_dsl-4.5.2-py3-none-any.whl", hash = "sha256:68ed1b63ca74aae87955012da9dfd7fdaae471329d0028b229b841c7192ccf52", size = 10179, upload-time = "2026-05-25T03:38:56.364Z" },
@@ -3840,7 +3840,7 @@ wheels = [
 
 [package.optional-dependencies]
 cu13 = [
-    { name = "nvidia-cutlass-dsl-libs-cu13", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cutlass-dsl-libs-cu13" },
 ]
 
 [[package]]
@@ -3848,11 +3848,11 @@ name = "nvidia-cutlass-dsl-libs-base"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-python", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-python" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/3e/2cca8745885aaba0d835a8be29e516e56930791c01f0806da95d3017a495/nvidia_cutlass_dsl_libs_base-4.5.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b62807bc5ea13bbdef648212893fac407ed943f940cece56b880d44af243e075", size = 75635922, upload-time = "2026-05-25T03:46:33.526Z" },
@@ -3870,12 +3870,12 @@ name = "nvidia-cutlass-dsl-libs-cu13"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-python", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-python" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "nvidia-cutlass-dsl-libs-base" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/96/1519dc5fb936b2e8d519710a1134ecfd162dfbdb014f15ea4534f52ca221/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:696c65ca03995713b6719bc59b7df06f8ec1d263d7eb6ac77aa011201e142bd5", size = 79086862, upload-time = "2026-05-25T03:39:21.998Z" },
@@ -3960,14 +3960,14 @@ name = "openai"
 version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "distro", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "httpx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jiter", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "sniffio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tqdm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
 wheels = [
@@ -3979,7 +3979,7 @@ name = "openai-harmony"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
@@ -3999,9 +3999,9 @@ name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
@@ -4015,7 +4015,7 @@ name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
@@ -4027,8 +4027,8 @@ name = "opentelemetry-exporter-otlp"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/94/8637919a5d01f81dacf510234bc0110b944f4687a6e96b0a02adf2f6bdce/opentelemetry_exporter_otlp-1.42.1.tar.gz", hash = "sha256:2d9ebaed714377a67d224d46795ddcc11d2c877fa5de35fda70b6f3b010729a9", size = 6086, upload-time = "2026-05-21T16:32:51.963Z" }
 wheels = [
@@ -4040,7 +4040,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "opentelemetry-proto" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
 wheels = [
@@ -4052,13 +4052,13 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "grpcio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-api", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-proto", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-sdk", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
 wheels = [
@@ -4070,13 +4070,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-api", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-proto", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-sdk", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
 wheels = [
@@ -4088,7 +4088,7 @@ name = "opentelemetry-proto"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
 wheels = [
@@ -4100,9 +4100,9 @@ name = "opentelemetry-sdk"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-semantic-conventions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
 wheels = [
@@ -4114,8 +4114,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
 wheels = [
@@ -4127,8 +4127,8 @@ name = "opentelemetry-semantic-conventions-ai"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-sdk", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-semantic-conventions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/02/10aeacc37a38a3a8fa16ff67bec1ae3bf882539f6f9efb0f70acf802ca2d/opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c", size = 26533, upload-time = "2026-03-26T14:20:38.73Z" }
 wheels = [
@@ -4245,10 +4245,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4307,10 +4307,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'darwin') or (python_full_version >= '3.11' and sys_platform == 'darwin')" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -4494,8 +4494,8 @@ name = "prometheus-fastapi-instrumentator"
 version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prometheus-client", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "prometheus-client" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/f4/cdcebf7094b03b99fba71ac8f56bd6f227973642662f49d272332d8419b3/prometheus_fastapi_instrumentator-8.1.0.tar.gz", hash = "sha256:b77f3043665e8d28e2bbd21017506195a43d9adf1d402d01bf95b494b7e560e1", size = 20492, upload-time = "2026-07-26T11:12:44.202Z" }
 wheels = [
@@ -4844,7 +4844,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -4938,8 +4938,8 @@ name = "pydantic-extra-types"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
@@ -4948,7 +4948,7 @@ wheels = [
 
 [package.optional-dependencies]
 pycountry = [
-    { name = "pycountry", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pycountry" },
 ]
 
 [[package]]
@@ -4956,9 +4956,9 @@ name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "python-dotenv", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-inspection", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
@@ -5052,7 +5052,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
@@ -5061,7 +5061,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -5321,7 +5321,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(python_full_version < '3.11' and implementation_name == 'pypy' and sys_platform == 'win32') or (implementation_name == 'pypy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -5362,11 +5362,11 @@ name = "quack-kernels"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "einops", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cutlass-dsl", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch-c-dlpack-ext", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "apache-tvm-ffi" },
+    { name = "einops" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "torch" },
+    { name = "torch-c-dlpack-ext" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/58/58b82e91b236539f424ff5681e7095b1f2860ddfb7778fe0be14d8fb58de/quack_kernels-0.4.1.tar.gz", hash = "sha256:9d7d6ba412bc0c8a9b1331c52a73db76280adb9dc2f2750df4851ddabef1466b", size = 274766, upload-time = "2026-04-30T14:37:55.65Z" }
 wheels = [
@@ -5390,9 +5390,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "rpds-py", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -5533,9 +5533,9 @@ name = "rich-toolkit"
 version = "0.19.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "rich", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/02/32217f3657ae91a0ea7cf1d74ade78f44352f830d00c468f753ddb3d4980/rich_toolkit-0.19.10.tar.gz", hash = "sha256:dc2e8c515ef9fbb4894e62bd41a2d2960dd7c2f505b5084894604d5ccfee3f09", size = 198167, upload-time = "2026-05-21T10:11:42.397Z" }
 wheels = [
@@ -5730,7 +5730,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -5800,8 +5800,8 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and sys_platform != 'darwin') or (python_full_version >= '3.11' and sys_platform == 'darwin')" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' or sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -6010,12 +6010,12 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", marker = "python_full_version < '3.11'" },
-    { name = "starlette", marker = "python_full_version < '3.11'" },
-    { name = "uvicorn", marker = "python_full_version < '3.11'" },
-    { name = "watchfiles", marker = "python_full_version < '3.11'" },
-    { name = "websockets", marker = "python_full_version < '3.11'" },
+    { name = "colorama" },
+    { name = "sphinx" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/2c/155e1de2c1ba96a72e5dba152c509a8b41e047ee5c2def9e9f0d812f8be7/sphinx_autobuild-2024.10.3.tar.gz", hash = "sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1", size = 14023, upload-time = "2024-10-02T23:15:30.172Z" }
 wheels = [
@@ -6041,12 +6041,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", marker = "python_full_version >= '3.11'" },
-    { name = "starlette", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", marker = "python_full_version >= '3.11'" },
+    { name = "colorama" },
+    { name = "sphinx" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
@@ -6099,7 +6099,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "sphinx", marker = "python_full_version < '3.11'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -6125,7 +6125,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "sphinx", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
@@ -6142,9 +6142,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", marker = "python_full_version < '3.11'" },
+    { name = "docutils" },
+    { name = "requests" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/8a/e3b943c59927280c9c5bfb94064845a57f36bc2e021435adbfb7d3ecca1f/sphinx_github_changelog-1.7.2.tar.gz", hash = "sha256:79f11f30ec5b1ae52a1742a6dc702644203b164732a1af4b049ebe522ff484e4", size = 78662, upload-time = "2026-03-23T21:49:45.238Z" }
 wheels = [
@@ -6170,10 +6170,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.11'" },
-    { name = "httpx", marker = "python_full_version >= '3.11'" },
-    { name = "myst-parser", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", marker = "python_full_version >= '3.11'" },
+    { name = "docutils" },
+    { name = "httpx" },
+    { name = "myst-parser" },
+    { name = "sphinx" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/cd/cae0c1a25a8f9f40d95c4816a66f88e964c5a68efee8f58d3678bd535f10/sphinx_github_changelog-2.2.0.tar.gz", hash = "sha256:ffbb65206c8be8e84f39b4de7a44e98e92312fe38b363e7f016277443d493700", size = 71178, upload-time = "2026-05-24T00:30:42.655Z" }
 wheels = [
@@ -6216,12 +6216,12 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.11'" },
-    { name = "docutils", marker = "python_full_version < '3.11'" },
-    { name = "idna", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", marker = "python_full_version < '3.11'" },
-    { name = "urllib3", marker = "python_full_version < '3.11'" },
+    { name = "certifi" },
+    { name = "docutils" },
+    { name = "idna" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/fe/ac4e24f35b5148b31ac717ae7dcc7a2f7ec56eb729e22c7252ed8ad2d9a5/sphinx_prompt-1.9.0.tar.gz", hash = "sha256:471b3c6d466dce780a9b167d9541865fd4e9a80ed46e31b06a52a0529ae995a1", size = 5340, upload-time = "2024-08-07T15:46:51.428Z" }
 wheels = [
@@ -6247,14 +6247,14 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.11'" },
-    { name = "docutils", marker = "python_full_version >= '3.11'" },
-    { name = "idna", marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", marker = "python_full_version >= '3.11'" },
-    { name = "urllib3", marker = "python_full_version >= '3.11'" },
+    { name = "certifi" },
+    { name = "docutils" },
+    { name = "idna" },
+    { name = "jinja2" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "sphinx" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/a3/91293c0e0f0b76d0697ba7a41541929ca3f5457671d008bd84a9bde17e21/sphinx_prompt-1.10.2.tar.gz", hash = "sha256:47b592ba75caebd044b0eddf7a5a1b6e0aef6df587b034377cd101a999b686ba", size = 5566, upload-time = "2025-11-28T09:23:18.057Z" }
 wheels = [
@@ -6376,8 +6376,8 @@ name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "anyio" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
 wheels = [
@@ -6527,8 +6527,8 @@ name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "regex" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
 wheels = [
@@ -6559,18 +6559,18 @@ name = "tilelang"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "cloudpickle", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "ml-dtypes", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "psutil", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch-c-dlpack-ext", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tqdm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "z3-solver", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "apache-tvm-ffi" },
+    { name = "cloudpickle" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "psutil" },
+    { name = "torch" },
+    { name = "torch-c-dlpack-ext" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "z3-solver" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/70/5051f65821baa30a3d61fc48f8ba10c776490315e8c90f82559b92089756/tilelang-0.1.9.tar.gz", hash = "sha256:287f727c913bb648fcf6c1968809ba3390e55eeed257a5c6bb9a80bc05966af4", size = 93395292, upload-time = "2026-04-22T09:19:11.988Z" }
 wheels = [
@@ -6647,10 +6647,10 @@ name = "tokenspeed-mla"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cutlass-dsl", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tokenspeed-triton", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "apache-tvm-ffi" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "tokenspeed-triton" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/20/4110d624d81d63f0bee2f19dba7ea0e1d8a31ea50147e6c1db82223c88a4/tokenspeed_mla-0.1.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:592590f36d85e624ecdc5e357ff35e29e761e6d879900dce8b67a6785c8ce75c", size = 743769, upload-time = "2026-05-13T03:30:54.486Z" },
@@ -6755,7 +6755,7 @@ name = "torch-c-dlpack-ext"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "torch" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
 wheels = [
@@ -6791,11 +6791,11 @@ name = "torchvision"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pillow", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pillow" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/74/11fee109841e80ad14e5ca2d80bff6b10eb11b7838ff06f35bfeaa9f7251/torchvision-0.26.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2adfbe438473236191ff077a4a9a0c767436879c89628aa97137e959b0c11a94", size = 7766423, upload-time = "2026-03-23T18:12:56.049Z" },
@@ -6931,13 +6931,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "httptools", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "python-dotenv", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pyyaml", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "watchfiles", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "websockets", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "colorama", marker = "python_version < '0'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [[package]]
@@ -6985,80 +6985,80 @@ name = "vllm"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "anthropic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "apache-tvm-ffi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "blake3", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "cachetools", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "cbor2", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "cloudpickle", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "compressed-tensors", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "depyf", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "diskcache", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "einops", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "fastapi", extra = ["standard"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "fastsafetensors", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "filelock", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "flashinfer-cubin", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "flashinfer-python", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "humming-kernels", extra = ["cu13"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "ijson", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jsonschema", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "lark", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "llguidance", marker = "(python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 'ppc64le' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "lm-format-enforcer", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "mcp", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "mistral-common", extra = ["image"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "model-hosting-container-standards", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "msgspec", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "ninja", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numba", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cudnn-frontend", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cutlass-dsl", extra = ["cu13"], marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "openai", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "openai-harmony", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opencv-python-headless", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-api", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-exporter-otlp", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-sdk", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "outlines-core", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "partial-json-parser", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pillow", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "prometheus-client", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "prometheus-fastapi-instrumentator", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "protobuf", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "psutil", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "py-cpuinfo", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pybase64", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "python-json-logger", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pyyaml", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "pyzmq", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "quack-kernels", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "regex", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "requests", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "safetensors", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "sentencepiece", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "setproctitle", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "six", marker = "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "starlette", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tiktoken", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tilelang", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tokenizers", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tokenspeed-mla", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torchaudio", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torchvision", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "tqdm", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "transformers", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "watchfiles", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "xgrammar", marker = "(python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 'ppc64le' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 's390x' and sys_platform == 'win32') or (python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'arm64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'ppc64le' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 's390x' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32') or (platform_machine == 'x86_64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "aiohttp" },
+    { name = "anthropic" },
+    { name = "apache-tvm-ffi" },
+    { name = "blake3" },
+    { name = "cachetools" },
+    { name = "cbor2" },
+    { name = "cloudpickle" },
+    { name = "compressed-tensors" },
+    { name = "depyf" },
+    { name = "diskcache" },
+    { name = "einops" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "fastsafetensors" },
+    { name = "filelock" },
+    { name = "flashinfer-cubin" },
+    { name = "flashinfer-python" },
+    { name = "humming-kernels", extra = ["cu13"] },
+    { name = "ijson" },
+    { name = "jsonschema" },
+    { name = "lark" },
+    { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 'x86_64'" },
+    { name = "lm-format-enforcer" },
+    { name = "mcp" },
+    { name = "mistral-common", extra = ["image"] },
+    { name = "model-hosting-container-standards" },
+    { name = "msgspec" },
+    { name = "ninja" },
+    { name = "numba" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-cutlass-dsl", extra = ["cu13"] },
+    { name = "openai" },
+    { name = "openai-harmony" },
+    { name = "opencv-python-headless" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+    { name = "outlines-core" },
+    { name = "partial-json-parser" },
+    { name = "pillow" },
+    { name = "prometheus-client" },
+    { name = "prometheus-fastapi-instrumentator" },
+    { name = "protobuf" },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+    { name = "pybase64" },
+    { name = "pydantic" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "pyzmq" },
+    { name = "quack-kernels" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "sentencepiece" },
+    { name = "setproctitle" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "six", marker = "python_full_version >= '3.12'" },
+    { name = "starlette" },
+    { name = "tiktoken" },
+    { name = "tilelang" },
+    { name = "tokenizers" },
+    { name = "tokenspeed-mla" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/17/ea541f9ffb31d438ed6a5a8e1f7b9805410664abf97e326f28416147a5da/vllm-0.24.0.tar.gz", hash = "sha256:0862453adc1f3339f1a0c9dca1179c34d6ed6e118f87b6e5bddd120af614ac66", size = 37236989, upload-time = "2026-06-30T01:18:35.996Z" }
 wheels = [
@@ -7239,15 +7239,15 @@ name = "xgrammar"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'emscripten'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pydantic", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "transformers", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "apache-tvm-ffi" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pydantic" },
+    { name = "torch" },
+    { name = "transformers" },
+    { name = "triton", marker = "platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/ea/6394caddd078d33772070eefaaf77cb0a826a3047b908b688dece7d040b5/xgrammar-0.2.1.tar.gz", hash = "sha256:4c48c251b75d211e9ffa7f4f4ac8b5b0164f89fd5f0d1883ad7ff4554922030d", size = 2427065, upload-time = "2026-05-17T21:39:26.576Z" }
 wheels = [


### PR DESCRIPTION
Fixes #340

## Problem

The Connect Four curriculum tutorial took **~12.75h** to finish lesson 2 on an L4. Profiling showed it was not compute-bound: a batch-256 `learn()` ran **~150 tiny CUDA kernels with the GPU idle ~74%**, and single-sample action selection wasted essentially all of the GPU's throughput (action selection costs the same wall time at batch 1 as at batch 256).

## Solution

**Shared across algorithms**
- `EvolvableAlgorithm._soft_update` — fuses the per-parameter Polyak loop into one `torch._foreach_lerp_`. Replaces the loop that was copy-pasted across 7 algorithms.
- `EvolvableAlgorithm._adam_kwargs` — enables the fused CUDA Adam kernel where safe (CUDA, no accelerate, not graph-captured). Wired into all 13 Adam constructions.
- `algo_utils.is_train_eval_invariant` — lets algorithms skip the per-action `eval()`/`train()` toggle, which otherwise walks the module tree twice on every action. `NoisyLinear` counts as mode-sensitive.

**DQN** additionally runs one online forward over `cat(obs, next_obs)` for double Q-learning instead of two, and keeps epsilon a Python float outside graph capture.

**Audit of the same pattern elsewhere** — ILQL `soft_update`/`hard_update` (transformer-sized, biggest win), `parameter_norm` (was one device-to-host sync *per tensor*), and the bandits' per-block scalar division.

**Tutorial** now plays `NUM_ENVS` self-play games in lockstep with the opponent embedded in the env step, so one batched `get_action` and one batched replay add drive every game, with `cudagraphs=True` capturing the train/eval kernels.

## Evidence

Measured on an L4, projected lesson-2 wall time at an identical gradient-step budget (min-of-3):

| Config | Projected | Speedup |
|---|---|---|
| Baseline | 12.75 h | — |
| + fused algorithm changes | 10.09 h | 1.26× |
| + vectorized rollout | 7.03 h | 1.81× |
| + CUDA graphs | **2.48 h** | **5.1×** |

Component micro-benchmarks: `soft_update` 750→66 µs (11.3×), `learn` 3059→529 µs with graphs (5.8×), `get_action` 979→380 µs (2.6×), batched H2D transfer 973→36 µs (27×).

Correctness: fused DQN update is identical to the previous path over 20 steps (loss 1.2e-7, params 3.1e-6); fused `soft_update`/`hard_update`/bandit changes verified identical. **491 algorithm tests pass** post-rebase, plus 1,883 across `test_utils` + single-agent + multi-agent. The tutorial still learns — win rate vs the weak opponent reaches **0.99**.

Follow-ups (making `cudagraphs` first-class, HPO graph invalidation, `learn_step` semantics) are tracked separately.