### PR TITLE
Stop paying for PEFT's fp32 LoRA input cast under autocast

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -145,10 +145,10 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
         prepare_model_for_kbit_training,
         set_peft_model_state_dict,
     )
-    from peft.tuners.tuners_utils import BaseTunerLayer
     from safetensors.torch import load_file
 
     from agilerl.algorithms.core.llm_ops.fused_lora import (
+        get_cached_lora_layers,
         patch_lora_for_fused_forward,
         set_fused_adapter_routing,
         unset_fused_adapter_routing,
@@ -4462,7 +4462,7 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
             yield
             return
 
-        layers = [m for m in self.actor.modules() if isinstance(m, BaseTunerLayer)]
+        layers = get_cached_lora_layers(self.actor)
         previous = [layer.cast_input_dtype_enabled for layer in layers]
         for layer in layers:
             layer.cast_input_dtype_enabled = False

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -145,6 +145,7 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
         prepare_model_for_kbit_training,
         set_peft_model_state_dict,
     )
+    from peft.tuners.tuners_utils import BaseTunerLayer
     from safetensors.torch import load_file
 
     from agilerl.algorithms.core.llm_ops.fused_lora import (
@@ -4446,10 +4447,30 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
         else:
             device_type = torch.device(self.device).type
             if device_type == "cuda" and torch.cuda.is_bf16_supported():
-                with torch.amp.autocast(device_type, dtype=torch.bfloat16):
+                with (
+                    torch.amp.autocast(device_type, dtype=torch.bfloat16),
+                    self._lora_input_cast_ctx(),
+                ):
                     yield
             else:
                 yield
+
+    @contextmanager
+    def _lora_input_cast_ctx(self) -> Generator[None, None, None]:
+        """Skip PEFT's fp32 cast of every LoRA input while autocast is active."""
+        if self.actor is None:
+            yield
+            return
+
+        layers = [m for m in self.actor.modules() if isinstance(m, BaseTunerLayer)]
+        previous = [layer.cast_input_dtype_enabled for layer in layers]
+        for layer in layers:
+            layer.cast_input_dtype_enabled = False
+        try:
+            yield
+        finally:
+            for layer, was_enabled in zip(layers, previous, strict=True):
+                layer.cast_input_dtype_enabled = was_enabled
 
     @contextmanager
     def _activation_offload_ctx(self) -> Generator[None, None, None]:

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -125,7 +125,7 @@ def _store_layer_cache(model: nn.Module, layers: list[LoraLayer]) -> None:
     _LORA_LAYER_CACHE[model] = layers
 
 
-def _get_cached_lora_layers(model: nn.Module) -> list[LoraLayer]:
+def get_cached_lora_layers(model: nn.Module) -> list[LoraLayer]:
     """All ``LoraLayer`` modules under *model*, cached after the first traversal.
 
     :param model: A ``PeftModel`` or any module containing ``LoraLayer`` s.
@@ -210,7 +210,7 @@ def unpatch_lora_for_fused_forward(model: nn.Module) -> None:
 
     :param model: The model to release from fused-routing control.
     """
-    for module in _get_cached_lora_layers(model):
+    for module in get_cached_lora_layers(model):
         if _is_routed_layer(module):
             # Drop the monkeypatched instance forward, restoring the class one.
             module.__dict__.pop("forward", None)
@@ -233,7 +233,7 @@ def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
     :raises ValueError: If *routing* is empty, names an unknown adapter, or
         names a DoRA adapter (unsupported, as in PEFT's mixed-batch forward).
     """
-    layers = _get_cached_lora_layers(model)
+    layers = get_cached_lora_layers(model)
     if not layers:
         # Plain base model (no adapters) or PEFT not installed: nothing to
         # route, and the unfused forward is already correct.
@@ -261,6 +261,6 @@ def unset_fused_adapter_routing(model: nn.Module) -> None:
 
     :param model: The model whose LoRA layers should clear fused routing.
     """
-    for module in _get_cached_lora_layers(model):
+    for module in get_cached_lora_layers(model):
         if _is_routed_layer(module):
             _ROUTING_STATE[module] = None

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -44,7 +44,9 @@ def _lora_delta(layer: LoraLayer, adapter: str, rows: torch.Tensor) -> torch.Ten
     # nn.Module.__getattr__ as the loose Tensor | Module; narrow it to Tensor.
     lora_a_weight = lora_a.weight
     assert isinstance(lora_a_weight, torch.Tensor)
-    rows = layer.lora_dropout[adapter](rows.to(lora_a_weight.dtype))
+    rows = layer.lora_dropout[adapter](
+        layer._cast_input_dtype(rows, lora_a_weight.dtype)
+    )
     return layer.lora_B[adapter](lora_a(rows)) * layer.scaling[adapter]
 
 

--- a/tests/test_algorithms/test_core_base.py
+++ b/tests/test_algorithms/test_core_base.py
@@ -7084,3 +7084,139 @@ class TestLLMAlgorithmSyncDeepspeedGradientClipping:
             state=SimpleNamespace(deepspeed_plugin=None)
         )
         assert agent._sync_deepspeed_gradient_clipping() is None
+
+
+def _lora_wrapped_actor(dtype=torch.float32, lora_dtype=None):
+    """Tiny model with real PEFT tuner layers injected."""
+    from peft import LoraConfig, inject_adapter_in_model
+
+    model = torch.nn.Sequential()
+    model.add_module("proj", torch.nn.Linear(8, 8, bias=False))
+    model.add_module("out", torch.nn.Linear(8, 4, bias=False))
+    model = model.to(dtype)
+    model = inject_adapter_in_model(
+        LoraConfig(
+            r=2,
+            lora_alpha=4,
+            lora_dropout=0.0,
+            target_modules=["proj", "out"],
+            # Random lora_B (not zeros) so the adapter contributes a real delta.
+            init_lora_weights=False,
+        ),
+        model,
+    )
+    if lora_dtype is not None:
+        for name, param in model.named_parameters():
+            if "lora_" in name:
+                param.data = param.data.to(lora_dtype)
+    return model
+
+
+def _tuner_layers(model):
+    from peft.tuners.tuners_utils import BaseTunerLayer
+
+    return [m for m in model.modules() if isinstance(m, BaseTunerLayer)]
+
+
+@_LLM_DEPS_SKIP
+class TestLoraInputCastCtx:
+    @staticmethod
+    def _agent(actor):
+        return SimpleNamespace(actor=actor)
+
+    def test_disables_cast_inside_and_restores_after(self):
+        actor = _lora_wrapped_actor()
+        layers = _tuner_layers(actor)
+        assert layers
+
+        agent = self._agent(actor)
+        with LLMAlgorithm._lora_input_cast_ctx(agent):
+            assert all(not layer.cast_input_dtype_enabled for layer in layers)
+        assert all(layer.cast_input_dtype_enabled for layer in layers)
+
+    def test_restores_cast_when_body_raises(self):
+        actor = _lora_wrapped_actor()
+        layers = _tuner_layers(actor)
+
+        agent = self._agent(actor)
+        boom = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            with LLMAlgorithm._lora_input_cast_ctx(agent):
+                raise boom
+        assert all(layer.cast_input_dtype_enabled for layer in layers)
+
+    def test_no_adapters_is_a_noop(self):
+        agent = self._agent(torch.nn.Linear(4, 4))
+        with LLMAlgorithm._lora_input_cast_ctx(agent):
+            pass
+
+    def test_actor_none_is_a_noop(self):
+        agent = self._agent(None)
+        with LLMAlgorithm._lora_input_cast_ctx(agent):
+            pass
+
+    def test_cast_is_load_bearing_without_autocast(self):
+        """The suppressed cast is what lets a bf16 input meet an fp32 adapter."""
+        actor = _lora_wrapped_actor(dtype=torch.bfloat16, lora_dtype=torch.float32)
+        x = torch.randn(2, 8, dtype=torch.bfloat16)
+
+        actor(x)
+        agent = self._agent(actor)
+        with LLMAlgorithm._lora_input_cast_ctx(agent):
+            with pytest.raises(RuntimeError):
+                actor(x)
+
+
+@pytest.mark.gpu
+@_LLM_DEPS_SKIP
+class TestLoraInputCastUnderAutocast:
+    pytestmark = pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA not available"
+    )
+
+    @staticmethod
+    def _agent(actor):
+        agent = SimpleNamespace(actor=actor, accelerator=None, device="cuda")
+        agent._lora_input_cast_ctx = lambda: LLMAlgorithm._lora_input_cast_ctx(agent)
+        return agent
+
+    def test_amp_ctx_suppresses_the_cast(self):
+        actor = _lora_wrapped_actor().cuda()
+        layers = _tuner_layers(actor)
+
+        agent = self._agent(actor)
+        with LLMAlgorithm._amp_ctx(agent):
+            assert all(not layer.cast_input_dtype_enabled for layer in layers)
+        assert all(layer.cast_input_dtype_enabled for layer in layers)
+
+    def test_gradients_are_bitwise_identical_without_the_cast(self):
+        def lora_grads(cast_inputs):
+            torch.manual_seed(0)
+            actor = _lora_wrapped_actor(
+                dtype=torch.bfloat16, lora_dtype=torch.float32
+            ).cuda()
+            for name, param in actor.named_parameters():
+                param.requires_grad_("lora_" in name)
+
+            torch.manual_seed(1)
+            x = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+            agent = self._agent(actor)
+            ctx = (
+                nullcontext()
+                if cast_inputs
+                else LLMAlgorithm._lora_input_cast_ctx(agent)
+            )
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16), ctx:
+                actor(x).float().pow(2).sum().backward()
+            return {
+                name: param.grad.clone()
+                for name, param in actor.named_parameters()
+                if param.grad is not None
+            }
+
+        with_cast = lora_grads(True)
+        without_cast = lora_grads(False)
+
+        assert with_cast
+        assert with_cast.keys() == without_cast.keys()
+        assert all(torch.equal(with_cast[k], without_cast[k]) for k in with_cast)

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -381,3 +381,28 @@ class TestLayerCache:
         assert layers == [model.proj]
         assert _LORA_LAYER_CACHE[model] is layers
         assert _get_cached_lora_layers(model) is layers
+
+
+class TestFusedLoraInputCast:
+    @staticmethod
+    def _bf16_base_fp32_adapters():
+        model = _build_model(adapters=("actor",))
+        for name, param in model.named_parameters():
+            param.data = param.data.to(
+                torch.float32 if "lora_" in name else torch.bfloat16
+            )
+        patch_lora_for_fused_forward(model)
+        set_fused_adapter_routing(model, ["actor", "actor"])
+        return model
+
+    def test_routed_forward_casts_inputs_by_default(self):
+        model = self._bf16_base_fp32_adapters()
+        assert model(torch.randn(2, 8, dtype=torch.bfloat16)).dtype == torch.bfloat16
+
+    def test_routed_forward_honours_disabled_cast(self):
+        model = self._bf16_base_fp32_adapters()
+        for layer in _get_cached_lora_layers(model):
+            layer.cast_input_dtype_enabled = False
+
+        with pytest.raises(RuntimeError):
+            model(torch.randn(2, 8, dtype=torch.bfloat16))

--- a/tests/test_algorithms/test_llm_ops/test_fused_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_fused_lora.py
@@ -11,8 +11,8 @@ from torch import nn
 from agilerl.algorithms.core.llm_ops.fused_lora import (
     _LORA_LAYER_CACHE,
     _ROUTING_STATE,
-    _get_cached_lora_layers,
     _is_routed_layer,
+    get_cached_lora_layers,
     patch_lora_for_fused_forward,
     set_fused_adapter_routing,
     unpatch_lora_for_fused_forward,
@@ -377,10 +377,10 @@ class TestPatchLifecycle:
 class TestLayerCache:
     def test_cache_is_stored_and_reused(self):
         model = _build_model()
-        layers = _get_cached_lora_layers(model)
+        layers = get_cached_lora_layers(model)
         assert layers == [model.proj]
         assert _LORA_LAYER_CACHE[model] is layers
-        assert _get_cached_lora_layers(model) is layers
+        assert get_cached_lora_layers(model) is layers
 
 
 class TestFusedLoraInputCast:
@@ -401,7 +401,7 @@ class TestFusedLoraInputCast:
 
     def test_routed_forward_honours_disabled_cast(self):
         model = self._bf16_base_fp32_adapters()
-        for layer in _get_cached_lora_layers(model):
+        for layer in get_cached_lora_layers(model):
             layer.cast_input_dtype_enabled = False
 
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## What

This is a minor memory optimization that came up while developing the analytical peak memory model.

`get_peft_model` defaults to `autocast_adapter_dtype=True`, so LoRA adapters are fp32 while the base is bf16, and `BaseTunerLayer._cast_input_dtype` runs `x.to(fp32)` on **every wrapped linear's input**. Those copies are twice the size of the bf16 original and stay live through the backward pass.

`LLMAlgorithm._amp_ctx` now suppresses that cast for the duration of the bf16 autocast region. Adapter weights and optimizer state stay fp32.

## Why it's free

Under bf16 autocast `F.linear` autocasts both operands to bf16 regardless — the fp32 copy is built and immediately cast back down. It buys nothing.

Measured on an A100-40GB (seq 4096 / rank 64 / all-linear), with `torch.use_deterministic_algorithms` and a same-arm control run establishing a run-to-run noise floor of exactly `0.0`:

- **gradients are bitwise identical** with the cast on and off (`max_rel_err == 0.0`, `min_cos_sim == 1.000000`)

| model | micro-batch | trainer peak before | after | saving |
|---|---|---|---|---|
| Qwen2.5-0.5B | 8 | 6238 MiB | 5002 MiB | 1236 MiB (**19.8%**) |
| Qwen2.5-1.5B | 4 | 10352 MiB | 7840 MiB | 2512 MiB (**24.3%**) |

Measured with the profiling harness on `feature/memory-estimation-framework-a72caf` (real GRPO + vLLM), one process per point.

## Why not `autocast_adapter_dtype=False`

That was the obvious fix and it is **not safe**. It reaches the same peak (5056 MiB) but puts the adapter weights *and the optimizer moments* in bf16, which cannot resolve an Adam step against a kaiming-scale weight. Fraction of adapter weights an optimizer step leaves **entirely unchanged** (Qwen2.5-0.5B, rank 64):

| lr | frozen per step | loss over 20 steps |
|---|---|---|
| 1e-4 | 53.6% | 11.996 → 12.002 |
| 1e-5 | 85.8% | 12.325 → 12.845 |
| 1e-6 | 98.4% | 13.556 → 14.028 |

Loss got *worse* at every lr. **GRPO's default lr is 5e-7**, below all of those — in the real trainer at that lr, 45.6% of adapter weights never move, against 3.1% with fp32 adapters.

The fp32 adapter *weights* are load-bearing. The fp32 *activations* are not.

## Scope and gotchas

- The suppression is scoped to `_amp_ctx` rather than set once on the layers, because it is **only valid while autocast is active** — otherwise a bf16 input meets an fp32 adapter and `F.linear` raises `expected mat1 and mat2 to have the same dtype`. **SFT and DPO run their training forward outside `_amp_ctx` and still pay the cast.** Bringing them under it would extend the saving but changes their numerics, so it is left alone.
- `fused_lora._lora_delta` open-coded the same cast; it now routes through `_cast_input_dtype` so one switch governs both paths.
- No config knob: there is no benefit to trade against the cost, so there is nothing to configure.

## Hot-path cost

Negligible.

`@contextmanager` runs its body on every entry, and `_amp_ctx` is entered once per micro-batch per pass, so this is a hot path. The second commit shares `fused_lora`'s existing weak-keyed layer cache rather than walking `self.actor.modules()` each time. Measured on the `tiny_llm` fixture (218 modules, 14 LoRA layers), full enter+exit including generator machinery:

| | per entry |
|---|---|
| walk modules | 114.2 µs |
| cached | 16.7 µs (**6.8×**) |

What remains is O(LoRA layers), not O(modules), so it does not grow with model width — roughly 0.04% of a micro-batch forward/backward at seq 4096 on Qwen2.5-0.5B. It is not hoisted to a one-time setup flag because SFT/DPO need the cast left on, so it has to stay scoped.

