### PR TITLE
Make prompt datasets OpenEnv rubrics with DP-safe row sharding

### DIFF
--- a/agilerl/llm_envs/openenv.py
+++ b/agilerl/llm_envs/openenv.py
@@ -217,9 +217,6 @@ class OpenEnvSessionClient:
             # None -> unbounded; OpenEnv's annotation omits it but forwards
             # straight to asyncio.wait_for, where None means no timeout.
             message_timeout_s=self._timeout_s,  # ty: ignore[invalid-argument-type]
-            # No keepalive, so ``timeout_s`` is the sole liveness bound: a slow
-            # step must not trip the ping deadline before its message timeout.
-            websocket_ping_interval_s=None,
         ).sync()
 
     def _transport(self, call: Callable[[], _TransportT]) -> _TransportT:

--- a/agilerl/llm_envs/openenv.py
+++ b/agilerl/llm_envs/openenv.py
@@ -19,6 +19,7 @@ from typing import Any, TypeVar
 
 try:
     import websockets.exceptions
+    from openenv.core.env_server.interfaces import Environment
     from openenv.core.env_server.mcp_types import CallToolAction
 except ImportError as _exc:  # pragma: no cover - only reachable without the llm extra
     msg = (
@@ -62,18 +63,29 @@ _TransportT = TypeVar("_TransportT")
 class LocalEnvClient:
     """In-process ``EnvClientProtocol`` backend — the no-HTTP sibling of :class:`OpenEnvSessionClient`.
 
-    Drives the env through the same :class:`OpenEnvWrapper` the server hosts, so
-    in-process and URL transports behave identically on the same env. Used via
-    :meth:`RolloutEnv.local` / :meth:`RolloutEnv.from_spec`.
+    Plain-text envs are driven through the same :class:`OpenEnvWrapper` the server
+    hosts, so in-process and URL transports behave identically on the same env.
+    OpenEnv ``Environment`` worlds (e.g.
+    :class:`~agilerl.llm_envs.prompt_dataset.PromptDatasetEnv`) are driven as-is so
+    their rubric metadata is not wrapped away. Used via :meth:`RolloutEnv.local` /
+    :meth:`RolloutEnv.from_spec`.
 
-    :param env: The local env.
+    :param env: The local env — plain-text or an OpenEnv ``Environment``.
     :param instruction: Prompt returned from reset when the env's reset obs is empty.
     """
 
-    def __init__(self, env: TextEnvProtocol, *, instruction: str = "") -> None:
+    def __init__(
+        self,
+        env: TextEnvProtocol | Environment,
+        *,
+        instruction: str = "",
+    ) -> None:
         """Wrap a local ``env`` as an in-process backend."""
+        if isinstance(env, Environment):
+            self._backend: Environment = env
+        else:
+            self._backend = OpenEnvWrapper(env)
         self._env = env
-        self._wrapper = OpenEnvWrapper(env)
         self._instruction = instruction
         self._evaluation_mode = False
 
@@ -94,24 +106,31 @@ class LocalEnvClient:
         row_index: int | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Reset the local env and return ``(prompt, info)``."""
-        obs = self._wrapper.reset(
+        obs = self._backend.reset(
             seed=seed,
             row_index=row_index,
             evaluation=True if self._evaluation_mode else None,
         )
-        return (obs.prompt or self._instruction), {}
+        info = dict(obs.metadata) if obs.metadata else {}
+        prompt = getattr(obs, "prompt", None) or self._instruction
+        return str(prompt), info
 
     def step(self, action: object) -> tuple[str, float, bool, bool, dict[str, Any]]:
-        """Step the local env with the action text and return the Gym 5-tuple."""
+        """Step the local env with the action text and return the Gym 5-tuple.
+
+        Env ``info`` — including a rubric's ``rubric_scores`` — travels on the
+        observation's metadata.
+        """
         text = action if isinstance(action, str) else str(action)
-        obs = self._wrapper.step(TextAction(message=text))
-        truncated = bool(obs.truncated)
+        obs = self._backend.step(TextAction(message=text))
+        truncated = bool(getattr(obs, "truncated", False))
+        info = dict(obs.metadata) if obs.metadata else {}
         return (
-            obs.prompt,
+            str(getattr(obs, "prompt", "") or ""),
             float(obs.reward) if obs.reward is not None else 0.0,
             bool(obs.done) and not truncated,
             truncated,
-            {},
+            info,
         )
 
     def close(self) -> None:
@@ -124,12 +143,20 @@ class LocalEnvClient:
     @property
     def dataset_size(self) -> int:
         """Dataset rows the env serves (``0`` if not dataset-backed)."""
-        return int(self._wrapper.state.dataset_size or 0)
+        return int(getattr(self._backend.state, "dataset_size", 0) or 0)
 
     @property
     def tools(self) -> list[Any]:
         """Tool schemas the env advertises (empty when none)."""
-        return list(self._wrapper.state.tools or [])
+        return list(getattr(self._backend.state, "tools", None) or [])
+
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        """Leaf rubric names for component metrics (empty when none)."""
+        components = getattr(self._backend, "rubric_components", None)
+        if components is not None:
+            return tuple(components)
+        return tuple(getattr(self._backend.state, "rubric_components", None) or ())
 
 
 class OpenEnvSessionClient:
@@ -278,7 +305,9 @@ class OpenEnvSessionClient:
             if not _is_transport_error(exc):
                 raise
             result = self._retry_on_fresh_session(lambda: self._sync.reset(**kwargs))
-        return (_observation_text(result.observation) or self._instruction), {}
+        raw_meta = getattr(result, "metadata", None)
+        info = dict(raw_meta) if isinstance(raw_meta, dict) else {}
+        return (_observation_text(result.observation) or self._instruction), info
 
     def step(self, action: object) -> tuple[str, float, bool, bool, dict[str, Any]]:
         """Send one action (model text) over the session and return the Gym 5-tuple."""
@@ -300,12 +329,23 @@ class OpenEnvSessionClient:
             bool(obs.get("truncated", False)) if isinstance(obs, dict) else False
         )
         done = bool(result.done)
+        # Env ``info`` (a rubric's ``rubric_scores``, say) rides on the step
+        # result's metadata; a server that stamps it on the obs instead is read too.
+        info: dict[str, Any] = {}
+        raw_meta = getattr(result, "metadata", None)
+        if isinstance(raw_meta, dict):
+            info.update(raw_meta)
+        if isinstance(obs, dict):
+            if isinstance(obs.get("metadata"), dict):
+                info.update(obs["metadata"])
+            if "rubric_scores" in obs and "rubric_scores" not in info:
+                info["rubric_scores"] = obs["rubric_scores"]
         return (
             _observation_text(obs),
             float(reward) if reward is not None else 0.0,
             done and not truncated,
             truncated,
-            {},
+            info,
         )
 
     def close(self) -> None:
@@ -323,6 +363,11 @@ class OpenEnvSessionClient:
     def tools(self) -> list[Any]:
         """Tool schemas the env advertises over the session (empty when none)."""
         return list(self._fetch_state().get("tools") or [])
+
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        """Leaf rubric names advertised by the remote env (empty when none)."""
+        return tuple(self._fetch_state().get("rubric_components") or [])
 
     def _fetch_state(self) -> dict[str, Any]:
         """Fetch + cache the env's OpenEnv ``state`` (dataset size + tool schemas).

--- a/agilerl/llm_envs/openenv_server.py
+++ b/agilerl/llm_envs/openenv_server.py
@@ -47,21 +47,27 @@ class TextAction(Action):
 
 
 class TextObservation(Observation):
-    """OpenEnv observation carrying the next prompt text.
+    """OpenEnv observation carrying the next prompt text and optional labels.
 
     ``truncated`` is declared because the wire has only ``done`` (no
     terminated/truncated split), so it can travel and reconstruct the 5-tuple.
+
+    On reset, ``prompt`` is shown to the policy and the labels stay unset. On the
+    terminal step, ``question`` / ``answer`` are set so rubrics can score.
     """
 
     prompt: str = ""
     truncated: bool = False
+    question: Any = None
+    answer: Any = None
 
 
 class TextState(State):
-    """OpenEnv state carrying the inner env's dataset size and tool schemas."""
+    """OpenEnv state carrying dataset size, tool schemas, and rubric component names."""
 
     dataset_size: int = 0
     tools: list[Any] = Field(default_factory=list)
+    rubric_components: list[str] = Field(default_factory=list)
 
 
 class OpenEnvWrapper(Environment):
@@ -69,7 +75,7 @@ class OpenEnvWrapper(Environment):
 
     Translates between the env's string ``reset``/``step`` and OpenEnv's typed
     ``Action``/``Observation``/``State``, surfacing ``dataset_size``/``tools`` on
-    the state. Env ``info`` is not sent on the wire.
+    the state and forwarding env ``info`` into observation metadata.
 
     :param inner: The local env to host.
     :param env_name: Name in the OpenEnv metadata; defaults to ``inner``'s class name.
@@ -119,9 +125,11 @@ class OpenEnvWrapper(Environment):
         for name in ("row_index", "evaluation"):
             if name in self._reset_params and kwargs.get(name) is not None:
                 call[name] = kwargs[name]
-        prompt, _info = _normalize_reset(self._inner.reset(**call))
+        prompt, info = _normalize_reset(self._inner.reset(**call))
         self._state = State(episode_id=episode_id, step_count=0)
-        return TextObservation(prompt=prompt, reward=None, done=False)
+        return TextObservation(
+            prompt=prompt, reward=None, done=False, metadata=dict(info)
+        )
 
     def step(
         self,
@@ -131,7 +139,7 @@ class OpenEnvWrapper(Environment):
     ) -> TextObservation:
         """Step the inner env with the action's text, returning a ``TextObservation``."""
         del timeout_s, kwargs
-        prompt, reward, terminated, truncated, _info = _normalize_step(
+        prompt, reward, terminated, truncated, info = _normalize_step(
             self._inner.step(action.message)
         )
         self._state.step_count += 1
@@ -140,6 +148,7 @@ class OpenEnvWrapper(Environment):
             reward=reward,
             done=bool(terminated or truncated),
             truncated=bool(truncated),
+            metadata=dict(info),
         )
 
     @property
@@ -150,6 +159,9 @@ class OpenEnvWrapper(Environment):
             step_count=self._state.step_count,
             dataset_size=int(getattr(self._inner, "dataset_size", 0) or 0),
             tools=list(getattr(self._inner, "tools", None) or []),
+            rubric_components=list(
+                getattr(self._inner, "rubric_components", None) or []
+            ),
         )
 
     def close(self) -> None:
@@ -260,12 +272,18 @@ class OpenEnvServer:
         make_env = self._make_env
         env_name = self._env_name
 
-        def app_factory() -> OpenEnvWrapper:
+        def app_factory() -> Environment:
             # ``make_env`` -> a fresh owned env per session; ``env`` -> one shared.
-            if make_env is not None:
-                return OpenEnvWrapper(make_env(), env_name=env_name, owns_inner=True)
-            assert env is not None, "one of env / make_env is always provided"
-            return OpenEnvWrapper(env, env_name=env_name)
+            # OpenEnv Environments (e.g. PromptDatasetEnv) are hosted as-is.
+            built = make_env() if make_env is not None else env
+            assert built is not None, "one of env / make_env is always provided"
+            if isinstance(built, Environment):
+                return built
+            return OpenEnvWrapper(
+                built,
+                env_name=env_name,
+                owns_inner=make_env is not None,
+            )
 
         display_name = env_name or (
             type(env).__name__ if env is not None else "OpenEnvServer"

--- a/agilerl/llm_envs/prompt_dataset.py
+++ b/agilerl/llm_envs/prompt_dataset.py
@@ -1,0 +1,154 @@
+# Copyright 2026 AgileRL
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dataset-backed single-turn text environment scored by an OpenEnv rubric."""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import numpy as np
+from openenv.core.env_server.interfaces import Environment
+from openenv.core.rubrics.base import Rubric
+
+from agilerl.llm_envs.openenv import TextObservation, TextState
+from agilerl.llm_envs.rubrics import _require_rubric, register_component_hooks
+
+
+def _json_safe(value: object) -> object:
+    """Coerce numpy / nested containers toward JSON-friendly Python types.
+
+    Already-safe values pass through untouched. Unrecognised types pass through
+    with a one-time warning (hosting requires pydantic-serializable labels).
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()  # ty: ignore[no-matching-overload]
+    if isinstance(value, Mapping):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    warnings.warn(
+        f"label value of type {type(value).__name__} is not coerced; "
+        "hosting over /ws requires a pydantic-serializable label",
+        UserWarning,
+        stacklevel=2,
+    )
+    return value
+
+
+class PromptDatasetEnv(Environment):
+    """Serve (question, answer) rows as single-turn prompts, scored by a rubric.
+
+    ``reset`` returns the prompt with labels unset. The terminal ``step``
+    observation keeps that same ``prompt`` and adds ``question`` / ``answer``
+    so rubrics can score (including when ``prompt_builder`` differs from the
+    raw question); the policy never sees labels at reset.
+    """
+
+    SUPPORTS_CONCURRENT_SESSIONS = True
+
+    def __init__(
+        self,
+        dataset: Sequence[Mapping[str, Any]],
+        *,
+        rubric: Rubric,
+        test_dataset: Sequence[Mapping[str, Any]] | None = None,
+        prompt_builder: Callable[[Mapping[str, Any]], str] | None = None,
+        question_column: str = "question",
+        answer_column: str = "answer",
+    ) -> None:
+        super().__init__(rubric=_require_rubric(rubric))
+        self._components = register_component_hooks(self.rubric)
+        self._train = dataset
+        self._test = test_dataset
+        self._prompt_builder = prompt_builder
+        self._question_column = question_column
+        self._answer_column = answer_column
+        self._cursor = 0
+        self._split = ""
+        self._prompt: str = ""
+        self._question: Any = None
+        self._answer: Any = None
+        self._episode_id: str | None = None
+        self._step_count = 0
+
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        """Leaf rubric names reported in ``metadata["rubric_scores"]``."""
+        return self._components
+
+    @property
+    def state(self) -> TextState:
+        return TextState(
+            episode_id=self._episode_id,
+            step_count=self._step_count,
+            dataset_size=len(self._train),
+            rubric_components=list(self._components),
+        )
+
+    def _next_index(
+        self,
+        row_index: int | None,
+        rows: Sequence[Mapping[str, Any]],
+    ) -> int:
+        if row_index is not None:
+            return int(row_index)
+        idx = self._cursor
+        self._cursor = (self._cursor + 1) % max(len(rows), 1)
+        return idx
+
+    def reset(
+        self,
+        seed: int | None = None,
+        episode_id: str | None = None,
+        *,
+        row_index: int | None = None,
+        evaluation: bool | None = None,
+        **kwargs: Any,
+    ) -> TextObservation:
+        del seed, kwargs
+        rows = self._test if (evaluation and self._test is not None) else self._train
+        if not rows:
+            msg = "PromptDatasetEnv has no rows to serve"
+            raise RuntimeError(msg)
+        row = rows[self._next_index(row_index, rows) % len(rows)]
+        self._question = _json_safe(row[self._question_column])
+        self._answer = _json_safe(row[self._answer_column])
+        self._episode_id = episode_id
+        self._step_count = 0
+        self._split = "test" if (evaluation and self._test is not None) else "train"
+        self._prompt = (
+            self._prompt_builder(row)
+            if self._prompt_builder is not None
+            else str(self._question)
+        )
+        return TextObservation(prompt=self._prompt, done=False)
+
+    def step(
+        self,
+        action: object,
+        timeout_s: float | None = None,
+        **kwargs: Any,
+    ) -> TextObservation:
+        del timeout_s, kwargs
+        obs = TextObservation(
+            prompt=self._prompt,
+            done=True,
+            question=self._question,
+            answer=self._answer,
+        )
+        score = self._apply_rubric(action, obs)
+        if inspect.iscoroutine(score):
+            score.close()
+            msg = "async rubrics require step_async; see OpenEnv docs"
+            raise TypeError(msg)
+        obs.reward = float(score)
+        self._step_count += 1
+        return obs

--- a/agilerl/llm_envs/rollout_env.py
+++ b/agilerl/llm_envs/rollout_env.py
@@ -39,6 +39,8 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
+    from openenv.core.env_server.interfaces import Environment
+    from openenv.core.rubrics.base import Rubric
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
     from agilerl.typing import RolloutPrompts
@@ -105,6 +107,7 @@ class RolloutEnv:
         self.full_ids: torch.Tensor | None = None
         self.turn_boundaries: list[tuple[int, int, int]] = []
         self.turn_rewards: list[float] = []
+        self.rubric_score_sums: dict[str, float] = {}
         self._turn_idx = 0
         self._prompt_text: str = ""
         self._gen_texts: list[str] = []
@@ -120,7 +123,7 @@ class RolloutEnv:
     @classmethod
     def local(
         cls,
-        env: TextEnvProtocol,
+        env: TextEnvProtocol | Environment,
         tokenizer: PreTrainedTokenizerBase,
         max_turns: int = 1,
         *,
@@ -129,7 +132,7 @@ class RolloutEnv:
     ) -> RolloutEnv:
         """Drive a local env **in-process** (no HTTP) via a :class:`LocalEnvClient`.
 
-        :param env: A local env (plain-text ``reset`` / ``step``).
+        :param env: A plain-text env or an OpenEnv ``Environment``.
         :param tokenizer: Tokenizer for the token-level loop.
         :param max_turns: Generation turns per episode.
         :param instruction: Prompt returned when the env's reset obs renders empty.
@@ -150,7 +153,14 @@ class RolloutEnv:
         max_turns: int = 1,
         **kwargs: Any,
     ) -> RolloutEnv:
-        """Build a ``RolloutEnv`` from an env ``spec``: a URL is driven remotely, the rest in-process.
+        """Build a ``RolloutEnv`` from an env ``spec``.
+
+        A **URL** is driven remotely; anything else is built with ``env_config`` and
+        driven in-process: an **env factory callable** directly, a spec claimed by a
+        :func:`registered resolver <register_env_spec_resolver>` (GEM registry ids,
+        say) through the factory it returns, and otherwise a ``module:Class`` /
+        ``path.py:Class`` entrypoint. For rows + a rubric instead of an env, see
+        :meth:`from_dataset`.
 
         :param spec: A URL, an env factory callable, a resolver-claimed id, or a
             ``module:Class`` / ``path.py:Class`` entrypoint.
@@ -179,7 +189,7 @@ class RolloutEnv:
     def from_dataset(
         cls,
         dataset: Sequence[Mapping[str, Any]],
-        reward_fn: Callable[[str, Any, Any], float],
+        rubric: Rubric,
         tokenizer: PreTrainedTokenizerBase,
         *,
         test_dataset: Sequence[Mapping[str, Any]] | None = None,
@@ -188,13 +198,16 @@ class RolloutEnv:
         answer_column: str = "answer",
         **kwargs: Any,
     ) -> RolloutEnv:
-        """Build a single-turn ``RolloutEnv`` from (question, answer) rows and a reward fn.
+        """Build a single-turn ``RolloutEnv`` from (question, answer) rows and a rubric.
 
-        Rows + reward fn are served in-process as a single-turn env (``max_turns`` fixed
-        to 1); ``test_dataset`` rows are served under :meth:`eval_mode`.
+        Rows + rubric are served in-process as a single-turn
+        :class:`~agilerl.llm_envs.prompt_dataset.PromptDatasetEnv` (``max_turns`` fixed
+        to 1); ``test_dataset`` rows are served under :meth:`eval_mode`. Wrap a
+        ``(completion, answer, question) -> float`` callable with
+        :func:`~agilerl.llm_envs.rubrics.reward_fn_to_rubric` first.
 
         :param dataset: Train rows, indexable to mappings with the question/answer keys.
-        :param reward_fn: ``(completion, answer, question) -> float`` scorer.
+        :param rubric: OpenEnv ``Rubric`` scoring each completion.
         :param tokenizer: Tokenizer for the token-level loop.
         :param test_dataset: Held-out rows served under eval mode (falls back to ``dataset``).
         :param prompt_builder: Maps a row to the served prompt text; ``None`` serves
@@ -204,16 +217,19 @@ class RolloutEnv:
         :param kwargs: Forwarded to :class:`RolloutEnv`.
         :rtype: RolloutEnv
         """
+        from agilerl.llm_envs.prompt_dataset import PromptDatasetEnv
+        from agilerl.llm_envs.rubrics import _require_rubric
+
         if "max_turns" in kwargs:
             msg = "from_dataset builds a single-turn env; max_turns is fixed to 1"
             raise TypeError(msg)
-        env = _PromptDatasetEnv(
+        env = PromptDatasetEnv(
             dataset,
-            test_dataset,
-            reward_fn,
-            prompt_builder,
-            question_column,
-            answer_column,
+            rubric=_require_rubric(rubric),
+            test_dataset=test_dataset,
+            prompt_builder=prompt_builder,
+            question_column=question_column,
+            answer_column=answer_column,
         )
         return cls.local(env, tokenizer, max_turns=1, **kwargs)
 
@@ -367,6 +383,11 @@ class RolloutEnv:
         """Rows in the env's dataset (``0`` for a procedural env)."""
         return self._env_client.dataset_size
 
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        """Leaf rubric names for component metrics (empty when none)."""
+        return tuple(self._env_client.rubric_components)
+
     @contextmanager
     def eval_mode(self) -> Iterator[None]:
         """Serve the env client's held-out split for the duration of the block."""
@@ -408,6 +429,7 @@ class RolloutEnv:
         self.full_ids = self._tokenize_initial_prompt(obs_text)
         self.turn_boundaries = []
         self.turn_rewards = []
+        self.rubric_score_sums = {}
         self._turn_idx = 0
         self._prompt_text = obs_text
         self._gen_texts = []
@@ -464,6 +486,10 @@ class RolloutEnv:
         """Apply the env round-trip result: rewards, truncation, feedback tokens."""
         next_obs, reward, terminated, truncated, info = env_result
         self.turn_rewards.append(float(reward))
+        for name, value in (info.get("rubric_scores") or {}).items():
+            self.rubric_score_sums[name] = self.rubric_score_sums.get(
+                name, 0.0
+            ) + float(value)
         self._turn_idx += 1
 
         if not (terminated or truncated) and self._turn_idx >= self.max_turns:
@@ -596,69 +622,6 @@ class RolloutEnv:
             "turn_details": turn_details,
             "feedback_texts": self._feedback_texts,
         }
-
-
-class _PromptDatasetEnv:
-    """(question, answer) rows + a reward fn, served as a single-turn text env.
-
-    Backend for :meth:`RolloutEnv.from_dataset`: ``reset`` serves the row's prompt (by
-    ``row_index`` or a cursor), ``step`` scores the completion with ``reward_fn``.
-    """
-
-    def __init__(
-        self,
-        dataset: Sequence[Mapping[str, Any]],
-        test_dataset: Sequence[Mapping[str, Any]] | None,
-        reward_fn: Callable[[str, Any, Any], float],
-        prompt_builder: Callable[[Mapping[str, Any]], str] | None,
-        question_column: str,
-        answer_column: str,
-    ) -> None:
-        self._train = dataset
-        self._test = test_dataset
-        self._reward_fn = reward_fn
-        self._prompt_builder = prompt_builder
-        self._question_column = question_column
-        self._answer_column = answer_column
-        # Cursor for the standalone (no row_index) path; the batch path always passes one.
-        self._cursor = 0
-        self._split = ""
-        self._question: Any = None
-        self._answer: Any = None
-
-    @property
-    def dataset_size(self) -> int:
-        """Number of train rows backing this env (sizes the ``TaskAssigner``)."""
-        return len(self._train)
-
-    def reset(
-        self,
-        seed: int | None = None,
-        *,
-        row_index: int | None = None,
-        evaluation: bool | None = None,
-    ) -> tuple[str, dict[str, Any]]:
-        """Select a row and return its prompt text plus an empty info dict."""
-        del seed
-        if evaluation and self._test is not None:
-            rows, split = self._test, "eval"
-        else:
-            rows, split = self._train, "train"
-        if row_index is None:
-            if split != self._split:
-                self._cursor, self._split = 0, split
-            row_index, self._cursor = self._cursor, self._cursor + 1
-        row = rows[int(row_index) % len(rows)]
-        self._question = row[self._question_column]
-        self._answer = row[self._answer_column]
-        if self._prompt_builder is not None:
-            return self._prompt_builder(row), {}
-        return str(self._question), {}
-
-    def step(self, action: str) -> tuple[str, float, bool, bool, dict[str, Any]]:
-        """Score the completion against the current row; always single-turn."""
-        reward = float(self._reward_fn(action, self._answer, self._question))
-        return "", reward, True, False, {}
 
 
 class TaskAssigner:
@@ -807,6 +770,8 @@ class BatchRolloutEnv:
         self._task_assigner: TaskAssigner | None = None
         # Thread pool for overlapping env round-trips; built lazily, closed in ``close``.
         self._io_pool: ThreadPoolExecutor | None = None
+        # Component key set for ``reward_*`` metrics, frozen when the envs are built.
+        self.rubric_component_names: tuple[str, ...] = ()
         self._rank = int(rank)
         self._world_size = int(world_size)
         # --- per-episode state (untouched by the lock-step path) ---
@@ -880,6 +845,22 @@ class BatchRolloutEnv:
             env._reset_apply(obs_text, info)
 
         return self._get_prompts()
+
+    def get_rubric_score_means(self) -> dict[str, float]:
+        """Mean per-episode component sums over the frozen component key set.
+
+        A component missing from every episode reports ``nan`` rather than ``0``,
+        so a never-scored criterion is not logged as a zero reward.
+        """
+        means: dict[str, float] = {}
+        for name in self.rubric_component_names:
+            values = [
+                env.rubric_score_sums[name]
+                for env in self.envs
+                if name in env.rubric_score_sums
+            ]
+            means[name] = sum(values) / len(values) if values else float("nan")
+        return means
 
     def step(
         self,
@@ -1100,6 +1081,7 @@ class BatchRolloutEnv:
                 rank=self._rank,
                 world_size=self._world_size,
             )
+            self.rubric_component_names = tuple(self.envs[0].rubric_components)
 
     def _ensure_slots(self) -> None:
         """Build the envs, the task assigner and the free-slot queue once (thread-safe)."""

--- a/agilerl/llm_envs/rubrics.py
+++ b/agilerl/llm_envs/rubrics.py
@@ -1,0 +1,123 @@
+# Copyright 2026 AgileRL
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgileRL rubric helpers on top of OpenEnv's ``Rubric`` API.
+
+The simple path is one reward function wrapped with :func:`reward_fn_to_rubric`.
+Component-level metrics come from composing OpenEnv ``Rubric``s (child attributes
+auto-register); AgileRL does not add its own aggregation containers.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+from openenv.core.rubrics.base import Rubric
+
+_COMPONENT_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.]*")
+
+
+def _snake_case(name: str) -> str:
+    """Convert ``PascalCase`` / ``camelCase`` to ``snake_case``."""
+    name = name.lstrip("_")
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _identifier_or(name: str, fallback: str) -> str:
+    """Return ``name`` when it is a valid component identifier, else ``fallback``."""
+    return name if _COMPONENT_NAME_RE.fullmatch(name) else fallback
+
+
+def _require_rubric(rubric: Rubric) -> Rubric:
+    """Require an OpenEnv ``Rubric``; point callers at ``reward_fn_to_rubric`` otherwise."""
+    if not isinstance(rubric, Rubric):
+        msg = (
+            f"rubric must be an openenv Rubric, got {type(rubric).__name__}. "
+            "Wrap a (completion, answer, question) -> float callable with "
+            "reward_fn_to_rubric(...)."
+        )
+        raise TypeError(msg)
+    return rubric
+
+
+def reward_fn_to_rubric(
+    fn: Callable[[str, Any, Any], float],
+    name: str | None = None,
+) -> Rubric:
+    """Wrap a ``(completion, answer, question) -> float`` callable as a ``Rubric``.
+
+    One scorer, one scalar reward. For per-criterion metrics, write OpenEnv
+    ``Rubric`` subclasses and compose them (assign children as attributes so
+    they auto-register).
+
+    :param fn: Scorer taking completion text, answer label, and question.
+    :param name: Component name for metrics; defaults to ``fn.__name__`` when valid.
+    :returns: An OpenEnv ``Rubric`` instance.
+    """
+    return RewardFnRubric(fn, name)
+
+
+class RewardFnRubric(Rubric):
+    """Adapter for :func:`reward_fn_to_rubric`."""
+
+    def __init__(
+        self,
+        fn: Callable[[str, Any, Any], float],
+        name: str | None,
+    ) -> None:
+        super().__init__()
+        self._fn = fn
+        self.component_name = name or _identifier_or(getattr(fn, "__name__", ""), "fn")
+
+    def forward(self, action: Any, observation: Any) -> float:  # noqa: ANN401
+        return float(self._fn(action.message, observation.answer, observation.question))
+
+
+def register_component_hooks(rubric: Rubric | None) -> tuple[str, ...]:
+    """Register leaf forward hooks that write into ``observation.metadata``.
+
+    OpenEnv's observability pattern: each leaf's post-``forward`` hook stamps
+    ``observation.metadata["rubric_scores"][name]`` for that call. Returns the
+    ordered leaf names (empty when ``rubric`` is ``None``). Give each env its
+    own rubric tree — sharing registers duplicate hooks on the same nodes.
+    """
+    if rubric is None:
+        return ()
+
+    names: list[str] = []
+
+    def walk(node: Rubric, path: str) -> None:
+        children = list(node.named_children())
+        if children:
+            for child_name, child in children:
+                walk(child, f"{path}.{child_name}" if path else child_name)
+            return
+
+        name = (
+            getattr(node, "component_name", None)
+            or path
+            or _snake_case(type(node).__name__)
+        )
+        if not isinstance(name, str) or not name:
+            name = _snake_case(type(node).__name__)
+
+        def hook(
+            _rubric: Rubric,
+            _action: object,
+            observation: object,
+            result: float,
+            *,
+            _name: str = name,
+        ) -> None:
+            metadata = getattr(observation, "metadata", None)
+            if metadata is not None:
+                metadata.setdefault("rubric_scores", {})[_name] = float(result)
+
+        node.register_forward_hook(hook)
+        names.append(name)
+
+    walk(rubric, "")
+    return tuple(names)

--- a/agilerl/llm_envs/spec_resolvers.py
+++ b/agilerl/llm_envs/spec_resolvers.py
@@ -40,9 +40,9 @@ def _gem_spec_resolver(spec: str) -> Callable[..., TextEnvProtocol] | None:
     .. _GEM registry ids: https://github.com/axon-rl/gem
     """
     try:
-        import gem  # ty: ignore[unresolved-import]
-        import gem.envs  # ty: ignore[unresolved-import]  -- populates the registry
-        from gem.envs.registration import (  # ty: ignore[unresolved-import]
+        import gem
+        import gem.envs  # populates the registry
+        from gem.envs.registration import (
             ENV_REGISTRY,
         )
     except ImportError:

--- a/agilerl/models/env.py
+++ b/agilerl/models/env.py
@@ -27,7 +27,7 @@ from agilerl.typing import EnvFactory, WrapperSpec
 from agilerl.utils.env_utils import (
     GymEnvType,
     apply_wrappers,
-    get_reward_fn,
+    get_rubric,
     make_conversation_template,
     resolve_entrypoint_target,
 )
@@ -288,11 +288,28 @@ class PzEnvSpec(EnvSpec):
 class LLMEnvSpec(BaseModel):
     """Environment specification for LLM training.
 
-    Builds a :class:`~agilerl.llm_envs.RolloutEnv` (generative) or a
-    :class:`~agilerl.llm_envs.DatasetEnv` (teacher-forced). A rollout env comes
-    from exactly one source — ``dataset`` + reward, ``env_name`` (GEM id),
-    ``entrypoint``, or ``env_url`` (already hosted; ``max_turns`` required);
-    a dataset env always from ``dataset`` + ``objective``.
+    Declaratively captures what is needed to build either a
+    :class:`~agilerl.llm_envs.RolloutEnv` (generative) or a
+    :class:`~agilerl.llm_envs.DatasetEnv` (teacher-forced). Fields are aligned
+    with what Arena expects for LLM training jobs.
+
+    A ``rollout`` env comes from exactly one source:
+
+    * ``dataset`` + ``rubric_file_path`` / ``rubric_name`` / ``prompt_template``
+      -- labelled ``(question, answer)`` rows scored by an OpenEnv rubric
+      (single-turn; ``max_turns`` is 1).
+    * ``env_name`` -- a GEM environment id (e.g. ``"game:Sudoku-v0-easy"``).
+    * ``entrypoint`` -- a dotted path to a callable returning a text env.
+    * ``env_url`` -- a URL to an already-hosted OpenEnv service (driven over
+      HTTP); ``max_turns`` must be set since it can't be probed remotely.
+
+    ``env_name`` / ``entrypoint`` run **in-process**; to run an env elsewhere,
+    host it as an OpenEnv service (a container, a Space, or a server a Ray actor
+    stands up) and point ``env_url`` at it. Transport is thus a deployment
+    concern, not a code change: the same env trains in-process for dev and
+    against a hosted URL in production.
+
+    A ``dataset`` env always comes from ``dataset`` and an ``objective``.
 
     :param env_type: ``"rollout"`` (generative) or ``"dataset"`` (teacher-forced).
     :type env_type: LLMEnvType
@@ -310,9 +327,12 @@ class LLMEnvSpec(BaseModel):
     :type max_reward: float | None
     :param train_test_split: Fraction of the dataset used for training.
     :type train_test_split: float
-    :param reward_file_path: Path to a Python file containing the reward
-        function. Required for a dataset-backed rollout env.
-    :type reward_file_path: str | None
+    :param rubric_file_path: Path to a Python file containing the rubric
+        (a ``Rubric`` instance or subclass). Required for a dataset-backed
+        rollout env.
+    :type rubric_file_path: str | None
+    :param rubric_name: Name of the rubric symbol in ``rubric_file_path``.
+    :type rubric_name: str | None
     :param dataset: Path to a Parquet dataset file or a HuggingFace dataset.
     :type dataset: str | None
     :param env_name: GEM environment id. Mutually exclusive with ``entrypoint``.
@@ -349,8 +369,8 @@ class LLMEnvSpec(BaseModel):
     prompt_template: dict[str, Any] | None = Field(default=None)
     max_reward: float | None = Field(default=None)
     train_test_split: float = Field(default=0.9, ge=0.0, le=1.0)
-    reward_file_path: str | None = Field(default=None)
-    reward_fn_name: str | None = Field(default=None)
+    rubric_file_path: str | None = Field(default=None)
+    rubric_name: str | None = Field(default=None)
     response_column: str = Field(default="response")
 
     # Env-backed rollout fields
@@ -391,6 +411,24 @@ class LLMEnvSpec(BaseModel):
             return 300.0
         return self.request_timeout_s or None
 
+    def _seed_kwargs(self) -> dict[str, int]:
+        """Seed kwarg for gym construction; omitted when unset so the gym default applies."""
+        return {} if self.seed is None else {"seed": self.seed}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_legacy_reward_keys(cls, data: object) -> object:
+        if isinstance(data, dict):
+            legacy = [k for k in ("reward_file_path", "reward_fn_name") if data.get(k)]
+            if legacy:
+                msg = (
+                    f"{', '.join(legacy)} renamed to rubric_file_path / rubric_name; "
+                    "export a Rubric (or wrap a callable with reward_fn_to_rubric) "
+                    "and point rubric_name at it."
+                )
+                raise ValueError(msg)
+        return data
+
     @model_validator(mode="after")
     def _validate_rollout_fields(self) -> Self:
         if self.env_type != LLMEnvType.ROLLOUT:
@@ -420,13 +458,11 @@ class LLMEnvSpec(BaseModel):
             )
             raise ValueError(msg)
         if self.dataset is not None:
-            if self.reward_file_path is None:
-                msg = "reward_file_path is required for dataset-backed rollout environments"
+            if self.rubric_file_path is None:
+                msg = "rubric_file_path is required for dataset-backed rollout environments"
                 raise ValueError(msg)
-            if self.reward_fn_name is None:
-                msg = (
-                    "reward_fn_name is required for dataset-backed rollout environments"
-                )
+            if self.rubric_name is None:
+                msg = "rubric_name is required for dataset-backed rollout environments"
                 raise ValueError(msg)
             if self.prompt_template is None:
                 msg = "Prompt template is required for dataset-backed rollout environments"
@@ -435,9 +471,9 @@ class LLMEnvSpec(BaseModel):
                 msg = "A dataset-backed rollout environment is single-turn; max_turns must be 1."
                 raise ValueError(msg)
             self.max_turns = 1
-        elif self.reward_file_path is not None:
+        elif self.rubric_file_path is not None:
             msg = (
-                "Reward file path is not supported for env-backed rollout environments."
+                "rubric_file_path is not supported for env-backed rollout environments."
             )
             raise ValueError(msg)
         return self
@@ -452,8 +488,8 @@ class LLMEnvSpec(BaseModel):
         if self.objective is None:
             msg = "objective is required for dataset environments"
             raise ValueError(msg)
-        if self.reward_file_path is not None:
-            msg = "Reward file path has been specified, but is not supported for dataset environments."
+        if self.rubric_file_path is not None:
+            msg = "rubric_file_path has been specified, but is not supported for dataset environments."
             raise ValueError(msg)
         return self
 
@@ -601,7 +637,8 @@ class LLMEnvSpec(BaseModel):
         pad_id = tokenizer.pad_token_id
 
         if self.dataset_backed_rollout:
-            # Reward file + dataset load on the first env build, not factory construction.
+            # The rubric file and the dataset are read once, on the first env
+            # build, so constructing the factory stays free of I/O.
             resolved: dict[str, Any] = {}
 
             def _resolve() -> dict[str, Any]:
@@ -610,11 +647,11 @@ class LLMEnvSpec(BaseModel):
 
                     if (
                         self.prompt_template is None
-                        or self.reward_fn_name is None
-                        or self.reward_file_path is None
+                        or self.rubric_name is None
+                        or self.rubric_file_path is None
                     ):
                         msg = (
-                            "reward_fn_name, reward_file_path, and prompt_template "
+                            "rubric_name, rubric_file_path, and prompt_template "
                             "are required for dataset-backed rollout environments"
                         )
                         raise ValueError(msg)
@@ -632,9 +669,9 @@ class LLMEnvSpec(BaseModel):
                         train_ds=train_ds,
                         test_ds=test_ds,
                         prompt_builder=_prompt_builder,
-                        reward_fn=get_reward_fn(
-                            reward_fn_name=self.reward_fn_name,
-                            file_path=self.reward_file_path,
+                        rubric=get_rubric(
+                            rubric_name=self.rubric_name,
+                            file_path=self.rubric_file_path,
                         ),
                     )
                 return resolved
@@ -643,7 +680,7 @@ class LLMEnvSpec(BaseModel):
                 parts = _resolve()
                 return RolloutEnv.from_dataset(
                     parts["train_ds"],
-                    parts["reward_fn"],
+                    parts["rubric"],
                     tokenizer,
                     test_dataset=parts["test_ds"],
                     prompt_builder=parts["prompt_builder"],
@@ -680,7 +717,7 @@ class LLMEnvSpec(BaseModel):
         if self.env_name is not None:
             try:
                 # gem-llm is an optional runtime dependency, never installed for checks.
-                import gem  # ty: ignore[unresolved-import]
+                import gem
             except ImportError:
                 msg = (
                     f"The 'gem-llm' package is required to use env_name={self.env_name!r}. "

--- a/agilerl/models/env.py
+++ b/agilerl/models/env.py
@@ -328,10 +328,13 @@ class LLMEnvSpec(BaseModel):
     :param train_test_split: Fraction of the dataset used for training.
     :type train_test_split: float
     :param rubric_file_path: Path to a Python file containing the rubric
-        (a ``Rubric`` instance or subclass). Required for a dataset-backed
-        rollout env.
+        (a ``Rubric`` instance or subclass, or a legacy reward callable wrapped
+        by :func:`~agilerl.llm_envs.rubrics.reward_fn_to_rubric`). Required for
+        a dataset-backed rollout env. Accepts the Arena alias
+        ``reward_file_path``.
     :type rubric_file_path: str | None
-    :param rubric_name: Name of the rubric symbol in ``rubric_file_path``.
+    :param rubric_name: Name of the rubric (or legacy reward) symbol in
+        ``rubric_file_path``. Accepts the Arena alias ``reward_fn_name``.
     :type rubric_name: str | None
     :param dataset: Path to a Parquet dataset file or a HuggingFace dataset.
     :type dataset: str | None
@@ -369,8 +372,14 @@ class LLMEnvSpec(BaseModel):
     prompt_template: dict[str, Any] | None = Field(default=None)
     max_reward: float | None = Field(default=None)
     train_test_split: float = Field(default=0.9, ge=0.0, le=1.0)
-    rubric_file_path: str | None = Field(default=None)
-    rubric_name: str | None = Field(default=None)
+    rubric_file_path: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("rubric_file_path", "reward_file_path"),
+    )
+    rubric_name: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("rubric_name", "reward_fn_name"),
+    )
     response_column: str = Field(default="response")
 
     # Env-backed rollout fields
@@ -414,20 +423,6 @@ class LLMEnvSpec(BaseModel):
     def _seed_kwargs(self) -> dict[str, int]:
         """Seed kwarg for gym construction; omitted when unset so the gym default applies."""
         return {} if self.seed is None else {"seed": self.seed}
-
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_legacy_reward_keys(cls, data: object) -> object:
-        if isinstance(data, dict):
-            legacy = [k for k in ("reward_file_path", "reward_fn_name") if data.get(k)]
-            if legacy:
-                msg = (
-                    f"{', '.join(legacy)} renamed to rubric_file_path / rubric_name; "
-                    "export a Rubric (or wrap a callable with reward_fn_to_rubric) "
-                    "and point rubric_name at it."
-                )
-                raise ValueError(msg)
-        return data
 
     @model_validator(mode="after")
     def _validate_rollout_fields(self) -> Self:

--- a/agilerl/population.py
+++ b/agilerl/population.py
@@ -753,14 +753,15 @@ class Population(Generic[AgentT]):
     def _collect_additional_metrics(self) -> list[dict[str, float]]:
         """Collect per-agent mean values for all registered additional metrics.
 
-        :returns: Per-agent mean values for all registered additional metrics.
-        :rtype: list[dict[str, float]]
+        Uses the union of names registered on each agent so metrics registered
+        during training (e.g. ``reward_*``, ``accuracy``) are reported.
         """
         result: list[dict[str, float]] = []
         for agent in self.agents:
             d: dict[str, float] = {}
             metrics = agent.metrics
-            for name in self.additional_metric_names:
+            names = list(metrics.additional_metrics)
+            for name in names:
                 if isinstance(metrics, MultiAgentMetrics):
                     for agent_id in metrics.agent_ids:
                         d[f"{name}/{agent_id}"] = metrics.get_mean(name, agent_id)

--- a/agilerl/protocols.py
+++ b/agilerl/protocols.py
@@ -697,5 +697,9 @@ class EnvClientProtocol(Protocol):
     def tools(self) -> list[Any]:
         """Tool schemas advertised by the env (empty when none)."""
 
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        """Leaf rubric names for component metrics (empty when none)."""
+
     def eval_mode(self) -> AbstractContextManager[None]:
         """Serve the held-out split for the duration of the context."""

--- a/agilerl/training/llm/rollout.py
+++ b/agilerl/training/llm/rollout.py
@@ -201,11 +201,16 @@ def train_llm_rollout(
     # guard after the per-agent loop).
     consecutive_stalls = 0
     group_size = getattr(pop[0], "group_size", 1)
-    # Seed from the agent's seed, offset by rank, so data-parallel ranks draw
-    # decorrelated dataset rows and env tasks.
+    # Rank-offset seed for procedural env reset(seed=...) uniqueness only. Dataset
+    # rows are split by the TaskAssigner's contiguous per-rank shard instead.
     group_seed = int(pop[0].seed) + _distributed_rank(accelerator) * (1 << 31)
     rollout_env = BatchRolloutEnv(
-        env_factory, batch_size, group_size, io_timeout_s=io_timeout_s
+        env_factory,
+        batch_size,
+        group_size,
+        io_timeout_s=io_timeout_s,
+        rank=_distributed_rank(accelerator),
+        world_size=_distributed_world_size(accelerator),
     )
     test_env: RolloutEnv | None = None
     try:
@@ -282,6 +287,16 @@ def train_llm_rollout(
                     agg_accuracy = safe_aggregate_metrics(accelerator, accuracy)
                     if accelerator is None or accelerator.is_main_process:
                         agent.metrics.log("accuracy", agg_accuracy)
+
+                for name, mean_value in rollout_env.get_rubric_score_means().items():
+                    metric = f"reward_{name}"
+                    if metric not in agent.metrics.additional_metrics:
+                        agent.metrics.register(metric)
+                    agg = safe_aggregate_metrics(
+                        accelerator, mean_score.new_tensor(mean_value)
+                    )
+                    if accelerator is None or accelerator.is_main_process:
+                        agent.metrics.log(metric, agg)
 
                 effective_batch_steps = batch_steps * data_increment
                 agent.finalize_training_step(batch_steps)

--- a/agilerl/utils/env_utils.py
+++ b/agilerl/utils/env_utils.py
@@ -45,46 +45,57 @@ def make_conversation_template(prompt_template: dict[str, str]) -> list[dict[str
 
 
 def get_reward_fn(reward_fn_name: str, file_path: str) -> Callable[..., float]:
-    """Get the reward function for the environment.
+    """Removed — use :func:`get_rubric`."""
+    msg = (
+        "get_reward_fn is removed; use get_rubric(rubric_name, file_path) and "
+        "export a Rubric instance (or subclass) from the file. Wrap a legacy "
+        "(completion, answer, question) -> float callable with "
+        "agilerl.llm_envs.rubrics.reward_fn_to_rubric(...)."
+    )
+    raise ValueError(msg)
 
-    :param reward_fn_name: The name of the reward function to get
-    :type reward_fn_name: str
-    :param file_path: The absolute path to the reward function file
-    :type file_path: str
-    :return: The reward function
-    :rtype: Callable
+
+def get_rubric(rubric_name: str, file_path: str) -> Any:  # noqa: ANN401
+    """Load a Rubric instance (or instantiate a Rubric subclass) from a file.
+
+    :param rubric_name: Name of the symbol in ``file_path``.
+    :param file_path: Path to the Python module defining the rubric.
+    :returns: An OpenEnv ``Rubric`` instance.
+    :raises TypeError: If the symbol is not a Rubric instance or subclass.
     """
+    from openenv.core.rubrics.base import Rubric
+
     file_path_obj = Path(file_path)
-    if file_path_obj.exists():
-        try:
-            # Get the absolute path to ensure proper module loading
-            abs_file_path = file_path_obj.resolve()
-
-            # Extract module name from the file path
-            # Remove .py extension and convert path separators to dots for module name
-            module_name = file_path_obj.stem
-
-            # Use spec_from_file_location to load from the specific file path
-            spec = importlib_util.spec_from_file_location(
-                module_name,
-                str(abs_file_path),
-            )
-
-            if spec is None or spec.loader is None:
-                msg = f"Could not create spec for {abs_file_path}"
-                raise ValueError(msg)
-
-            reward_module = importlib_util.module_from_spec(spec)
-            spec.loader.exec_module(reward_module)
-            return getattr(reward_module, reward_fn_name)
-        except Exception as e:
-            msg = f"Error importing reward function {reward_fn_name} from {file_path}: {e}"
-            raise ValueError(
-                msg,
-            ) from e
-    else:
+    if not file_path_obj.exists():
         msg = f"{file_path} not found"
         raise ValueError(msg)
+    try:
+        abs_file_path = file_path_obj.resolve()
+        module_name = file_path_obj.stem
+        spec = importlib_util.spec_from_file_location(
+            module_name,
+            str(abs_file_path),
+        )
+        if spec is None or spec.loader is None:
+            msg = f"Could not create spec for {abs_file_path}"
+            raise ValueError(msg)
+        rubric_module = importlib_util.module_from_spec(spec)
+        spec.loader.exec_module(rubric_module)
+        obj = getattr(rubric_module, rubric_name)
+    except Exception as e:
+        msg = f"Error importing rubric {rubric_name} from {file_path}: {e}"
+        raise ValueError(msg) from e
+
+    if isinstance(obj, Rubric):
+        return obj
+    if isinstance(obj, type) and issubclass(obj, Rubric):
+        return obj()
+    msg = (
+        f"{rubric_name!r} in {file_path} must be a Rubric instance or subclass, "
+        f"got {type(obj).__name__}. Export e.g. "
+        f"RUBRIC = reward_fn_to_rubric(combined_rewards)."
+    )
+    raise TypeError(msg)
 
 
 def escape_non_format_braces(

--- a/agilerl/utils/env_utils.py
+++ b/agilerl/utils/env_utils.py
@@ -56,14 +56,20 @@ def get_reward_fn(reward_fn_name: str, file_path: str) -> Callable[..., float]:
 
 
 def get_rubric(rubric_name: str, file_path: str) -> Any:  # noqa: ANN401
-    """Load a Rubric instance (or instantiate a Rubric subclass) from a file.
+    """Load a Rubric from a file, wrapping legacy reward callables.
+
+    Accepts a ``Rubric`` instance, a ``Rubric`` subclass (instantiated here), or a
+    ``(completion, answer, question) -> float`` callable (Arena / older manifests),
+    which is wrapped with :func:`~agilerl.llm_envs.rubrics.reward_fn_to_rubric`.
 
     :param rubric_name: Name of the symbol in ``file_path``.
-    :param file_path: Path to the Python module defining the rubric.
+    :param file_path: Path to the Python module defining the rubric or reward fn.
     :returns: An OpenEnv ``Rubric`` instance.
-    :raises TypeError: If the symbol is not a Rubric instance or subclass.
+    :raises TypeError: If the symbol is not a Rubric, Rubric subclass, or callable.
     """
     from openenv.core.rubrics.base import Rubric
+
+    from agilerl.llm_envs.rubrics import reward_fn_to_rubric
 
     file_path_obj = Path(file_path)
     if not file_path_obj.exists():
@@ -90,10 +96,12 @@ def get_rubric(rubric_name: str, file_path: str) -> Any:  # noqa: ANN401
         return obj
     if isinstance(obj, type) and issubclass(obj, Rubric):
         return obj()
+    if callable(obj):
+        return reward_fn_to_rubric(obj)
     msg = (
-        f"{rubric_name!r} in {file_path} must be a Rubric instance or subclass, "
-        f"got {type(obj).__name__}. Export e.g. "
-        f"RUBRIC = reward_fn_to_rubric(combined_rewards)."
+        f"{rubric_name!r} in {file_path} must be a Rubric instance, Rubric "
+        f"subclass, or (completion, answer, question) -> float callable, "
+        f"got {type(obj).__name__}."
     )
     raise TypeError(msg)
 

--- a/configs/training/llm_finetuning/cispo.yaml
+++ b/configs/training/llm_finetuning/cispo.yaml
@@ -22,8 +22,8 @@ environment:
     columns:
         nums: question
         target: answer
-    reward_file_path: reward.py
-    reward_fn_name: combined_rewards
+    rubric_file_path: reward.py
+    rubric_name: RUBRIC
     prompt_template:
         system_0: You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer.
         user_1: Using each number in this list only once {question}, create an equation that equals {answer}. You can use basic arithmetic operations (+,

--- a/configs/training/llm_finetuning/grpo.yaml
+++ b/configs/training/llm_finetuning/grpo.yaml
@@ -24,8 +24,8 @@ environment:
     columns:
         nums: question
         target: answer
-    reward_file_path: reward.py
-    reward_fn_name: combined_rewards
+    rubric_file_path: reward.py
+    rubric_name: RUBRIC
     prompt_template:
         system_0: You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer.
         user_1: Using each number in this list only once {question}, create an equation that equals {answer}. You can use basic arithmetic operations (+,

--- a/configs/training/llm_finetuning/gspo.yaml
+++ b/configs/training/llm_finetuning/gspo.yaml
@@ -22,8 +22,8 @@ environment:
     columns:
         nums: question
         target: answer
-    reward_file_path: reward.py
-    reward_fn_name: combined_rewards
+    rubric_file_path: reward.py
+    rubric_name: RUBRIC
     prompt_template:
         system_0: You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer.
         user_1: Using each number in this list only once {question}, create an equation that equals {answer}. You can use basic arithmetic operations (+,

--- a/configs/training/llm_finetuning/ppo_llm.yaml
+++ b/configs/training/llm_finetuning/ppo_llm.yaml
@@ -25,8 +25,8 @@ environment:
     columns:
         nums: question
         target: answer
-    reward_file_path: reward.py
-    reward_fn_name: combined_rewards
+    rubric_file_path: reward.py
+    rubric_name: RUBRIC
     prompt_template:
         system_0: You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer.
         user_1: Using each number in this list only once {question}, create an equation that equals {answer}. You can use basic arithmetic operations (+,

--- a/configs/training/llm_finetuning/ppo_llm_quant_bench.yaml
+++ b/configs/training/llm_finetuning/ppo_llm_quant_bench.yaml
@@ -36,8 +36,8 @@ environment:
     columns:
         nums: question
         target: answer
-    reward_file_path: reward.py
-    reward_fn_name: combined_rewards
+    rubric_file_path: reward.py
+    rubric_name: RUBRIC
     prompt_template:
         system_0: You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer.
         user_1: Using each number in this list only once {question}, create an equation that equals {answer}. You can use basic arithmetic operations (+,

--- a/configs/training/llm_finetuning/reinforce_llm.yaml
+++ b/configs/training/llm_finetuning/reinforce_llm.yaml
@@ -23,8 +23,8 @@ environment:
     columns:
         nums: question
         target: answer
-    reward_file_path: reward.py
-    reward_fn_name: combined_rewards
+    rubric_file_path: reward.py
+    rubric_name: RUBRIC
     prompt_template:
         system_0: You are a helpful assistant. You first think about the reasoning process in your mind and then provide the user with the answer.
         user_1: Using each number in this list only once {question}, create an equation that equals {answer}. You can use basic arithmetic operations (+,

--- a/docs/_static/examples/gsm8k-grpo/reward.py
+++ b/docs/_static/examples/gsm8k-grpo/reward.py
@@ -48,8 +48,6 @@ def _combined(completion: str, answer, question) -> float:
     return correctness_reward(answer, completion) + format_reward(completion)
 
 
-# Nightly-compatible: one scorer. For per-criterion metrics, split into Rubric
-# subclasses and register them as children on a parent Rubric.
 RUBRIC = reward_fn_to_rubric(_combined, name="gsm8k")
 
 

--- a/docs/_static/examples/gsm8k-grpo/reward.py
+++ b/docs/_static/examples/gsm8k-grpo/reward.py
@@ -3,10 +3,9 @@
 
 import re
 
+from openenv.core.rubrics.base import Rubric
 
-def reward(question: str, answer: str, completion: str) -> float:
-    """Combined GSM8K reward: answer correctness plus output format."""
-    return correctness_reward(answer, completion) + format_reward(completion)
+from agilerl.llm_envs.rubrics import reward_fn_to_rubric
 
 
 def extract_gold_answer(answer: str) -> str | None:
@@ -25,7 +24,6 @@ def extract_model_answer(completion: str) -> str | None:
 
 
 def correctness_reward(answer: str, completion: str) -> float:
-    """Reward 1.0 when the model's final answer matches the gold answer, else 0.0."""
     gold = extract_gold_answer(answer)
     predicted = extract_model_answer(completion)
     if gold is None or predicted is None:
@@ -34,7 +32,49 @@ def correctness_reward(answer: str, completion: str) -> float:
 
 
 def format_reward(completion: str) -> float:
-    """Reward 1.0 when the completion follows ``<think>...</think>\\n<answer>...</answer>``."""
     text = "<think>" + completion
     regex = r"^<think>[\s\S]*?</think>\n<answer>[\s\S]*?</answer>$"
     return 1.0 if re.match(regex, text.strip()) else 0.0
+
+
+def reward(question: str, answer: str, completion: str) -> float:
+    """Combined GSM8K reward: answer correctness plus output format."""
+    del question
+    return correctness_reward(answer, completion) + format_reward(completion)
+
+
+def _combined(completion: str, answer, question) -> float:
+    del question
+    return correctness_reward(answer, completion) + format_reward(completion)
+
+
+# Nightly-compatible: one scorer. For per-criterion metrics, split into Rubric
+# subclasses and register them as children on a parent Rubric.
+RUBRIC = reward_fn_to_rubric(_combined, name="gsm8k")
+
+
+class Correctness(Rubric):
+    """Example leaf rubric for component-level reporting."""
+
+    def forward(self, action, observation) -> float:
+        return correctness_reward(str(observation.answer), action.message)
+
+
+class Format(Rubric):
+    """Example leaf rubric for component-level reporting."""
+
+    def forward(self, action, observation) -> float:
+        del observation
+        return format_reward(action.message)
+
+
+class Combined(Rubric):
+    """Example composition: OpenEnv auto-registers ``correct`` / ``fmt`` children."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.correct = Correctness()
+        self.fmt = Format()
+
+    def forward(self, action, observation) -> float:
+        return self.correct(action, observation) + self.fmt(action, observation)

--- a/tests/helpers/rollout_doubles.py
+++ b/tests/helpers/rollout_doubles.py
@@ -78,6 +78,10 @@ class FakeEnvClient:
     def tools(self) -> list[Any]:
         return self._tools
 
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        return ()
+
     @contextmanager
     def eval_mode(self):
         self.eval_mode_entries += 1
@@ -90,6 +94,10 @@ class FakeEnvClient:
 
 class RolloutEnvDoubleMixin:
     """Map ``BatchRolloutEnv``'s phased reset/step onto a double's reset()/step()."""
+
+    @property
+    def rubric_components(self) -> tuple[str, ...]:
+        return ()
 
     def _reset_fetch(
         self, seed: int | None = None, *, row_index: int | None = None

--- a/tests/test_algorithms/test_llms/test_dpo.py
+++ b/tests/test_algorithms/test_llms/test_dpo.py
@@ -43,6 +43,7 @@ def make_preference_gym(
     tokenizer: AutoTokenizer,
     data_batch_size_per_gpu: int = 8,
 ):
+    del accelerator  # DatasetEnv shards via rank/world_size, not accelerator
     train_dataset = Dataset.from_dict(
         {
             "prompt": [f"Prompt {i}" for i in range(num_samples)],
@@ -63,7 +64,6 @@ def make_preference_gym(
         tokenizer=tokenizer,
         objective="preference",
         data_batch_size_per_gpu=data_batch_size_per_gpu,
-        accelerator=accelerator,
     )
 
 
@@ -415,7 +415,6 @@ class TestDPOLearn:
             tokenizer=tokenizer,
             objective="preference",
             data_batch_size_per_gpu=data_batch_size,
-            accelerator=dpo.accelerator,
         )
         for name, param in dpo.actor.named_parameters():
             if ("lora_A" in name or "lora_B" in name) and param is not None:
@@ -530,7 +529,6 @@ class TestDPOTest:
             tokenizer=tokenizer,
             objective="preference",
             data_batch_size_per_gpu=data_batch_size,
-            accelerator=dpo.accelerator,
         )
         fitness = dpo.test(env, loop=loop)
         assert isinstance(fitness, np.ndarray)

--- a/tests/test_algorithms/test_llms/test_sft.py
+++ b/tests/test_algorithms/test_llms/test_sft.py
@@ -40,6 +40,7 @@ def make_sft_gym(
     data_batch_size_per_gpu: int = 8,
     response_column: str = "response",
 ):
+    del accelerator  # DatasetEnv shards via rank/world_size, not accelerator
     train_dataset = Dataset.from_dict(
         {
             "prompt": [f"Prompt {i}" for i in range(num_samples)],
@@ -59,7 +60,6 @@ def make_sft_gym(
         objective="sft",
         data_batch_size_per_gpu=data_batch_size_per_gpu,
         response_column=response_column,
-        accelerator=accelerator,
     )
 
 
@@ -372,7 +372,6 @@ class TestSFTLearn:
             tokenizer=tokenizer,
             objective="sft",
             data_batch_size_per_gpu=data_batch_size,
-            accelerator=sft.accelerator,
         )
         for name, param in sft.actor.named_parameters():
             if ("lora_A" in name or "lora_B" in name) and param is not None:
@@ -510,7 +509,6 @@ class TestSFTTest:
             tokenizer=tokenizer,
             objective="sft",
             data_batch_size_per_gpu=data_batch_size,
-            accelerator=sft.accelerator,
         )
         fitness = sft.test(env, loop=loop)
         assert isinstance(fitness, np.ndarray)

--- a/tests/test_models/test_env.py
+++ b/tests/test_models/test_env.py
@@ -296,29 +296,29 @@ def mark_wrapped(env):
 
 
 class TestLLMEnvSpec:
-    def test_reasoning_requires_reward_file_path(self):
-        with pytest.raises(ValueError, match="reward_file_path is required"):
-            LLMEnvSpec(env_type=LLMEnvType.ROLLOUT, dataset="ds", reward_file_path=None)
+    def test_reasoning_requires_rubric_file_path(self):
+        with pytest.raises(ValueError, match="rubric_file_path is required"):
+            LLMEnvSpec(env_type=LLMEnvType.ROLLOUT, dataset="ds", rubric_file_path=None)
 
-    def test_dataset_does_not_require_reward_file_path(self):
+    def test_dataset_does_not_require_rubric_file_path(self):
         spec = LLMEnvSpec(
             env_type=LLMEnvType.DATASET,
             objective="preference",
             dataset="ds",
-            reward_file_path=None,
+            rubric_file_path=None,
         )
-        assert spec.reward_file_path is None
+        assert spec.rubric_file_path is None
 
     def test_default_fields(self):
         spec = LLMEnvSpec(
             env_type=LLMEnvType.ROLLOUT,
             dataset="dataset.parquet",
-            reward_file_path="reward.py",
-            reward_fn_name="reward_fn",
+            rubric_file_path="reward.py",
+            rubric_name="reward_fn",
             prompt_template={"role": "user", "content": "{q}"},
         )
         assert spec.train_test_split == 0.9
-        assert spec.reward_file_path == "reward.py"
+        assert spec.rubric_file_path == "reward.py"
         assert spec.dataset == "dataset.parquet"
         assert spec.columns is None
         assert spec.max_reward is None
@@ -327,8 +327,8 @@ class TestLLMEnvSpec:
         spec = LLMEnvSpec(
             env_type=LLMEnvType.ROLLOUT,
             dataset="dataset.parquet",
-            reward_file_path="reward.py",
-            reward_fn_name="reward_fn",
+            rubric_file_path="reward.py",
+            rubric_name="reward_fn",
             prompt_template={"role": "user", "content": "{q}"},
         )
         assert not hasattr(spec, "num_envs")
@@ -340,15 +340,15 @@ class TestLLMEnvSpec:
             prompt_template={"role": "user", "content": "{question}"},
             max_reward=5.0,
             train_test_split=0.8,
-            reward_file_path="my_reward.py",
-            reward_fn_name="my_reward",
+            rubric_file_path="my_reward.py",
+            rubric_name="my_reward",
             dataset="data/train.parquet",
         )
         assert spec.columns == {"question": "input", "answer": "output"}
         assert spec.prompt_template == {"role": "user", "content": "{question}"}
         assert spec.max_reward == 5.0
         assert spec.train_test_split == 0.8
-        assert spec.reward_file_path == "my_reward.py"
+        assert spec.rubric_file_path == "my_reward.py"
         assert spec.dataset == "data/train.parquet"
 
     def test_train_test_split_bounds(self):
@@ -358,15 +358,15 @@ class TestLLMEnvSpec:
             LLMEnvSpec(env_type=LLMEnvType.ROLLOUT, dataset="ds", train_test_split=-0.1)
 
     @patch("agilerl.models.env.make_conversation_template")
-    @patch("agilerl.models.env.get_reward_fn")
+    @patch("agilerl.models.env.get_rubric")
     @patch.object(LLMEnvSpec, "_load_dataset")
     def test_dataset_backed_rollout_factory(
-        self, mock_load, mock_reward_fn, mock_conv_tmpl
+        self, mock_load, mock_get_rubric, mock_conv_tmpl
     ):
         mock_train_ds = MagicMock()
         mock_test_ds = MagicMock()
         mock_load.return_value = (mock_train_ds, mock_test_ds)
-        reward_fn = mock_reward_fn.return_value
+        rubric = mock_get_rubric.return_value
         mock_conv_tmpl.return_value = [{"role": "user", "content": "{question}"}]
         mock_tokenizer = MagicMock()
         mock_tokenizer.pad_token_id = 0
@@ -374,8 +374,8 @@ class TestLLMEnvSpec:
         spec = LLMEnvSpec(
             env_type=LLMEnvType.ROLLOUT,
             dataset="dataset.parquet",
-            reward_file_path="reward.py",
-            reward_fn_name="reward_fn",
+            rubric_file_path="reward.py",
+            rubric_name="reward_fn",
             prompt_template={"user_0": "{question}"},
         )
         # A dataset-backed rollout is single-turn by construction.
@@ -386,17 +386,17 @@ class TestLLMEnvSpec:
             factory = spec.make_rollout_env_factory(mock_tokenizer)
             # Building the factory reads nothing.
             mock_load.assert_not_called()
-            mock_reward_fn.assert_not_called()
+            mock_get_rubric.assert_not_called()
             factory()
 
-        mock_reward_fn.assert_called_once_with(
-            reward_fn_name="reward_fn", file_path="reward.py"
+        mock_get_rubric.assert_called_once_with(
+            rubric_name="reward_fn", file_path="reward.py"
         )
         mock_conv_tmpl.assert_called_once()
         mock_rollout_cls.from_dataset.assert_called_once()
         args, kwargs = mock_rollout_cls.from_dataset.call_args
         assert args[0] is mock_train_ds
-        assert args[1] is reward_fn
+        assert args[1] is rubric
         assert kwargs["test_dataset"] is mock_test_ds
         assert kwargs["apply_chat_template"] is False
 
@@ -420,7 +420,7 @@ class TestLLMEnvSpec:
             env_type=LLMEnvType.DATASET,
             objective="preference",
             dataset="dataset.parquet",
-            reward_file_path=None,
+            rubric_file_path=None,
         )
 
         with patch("agilerl.llm_envs.DatasetEnv") as MockEnv:
@@ -437,8 +437,8 @@ class TestLLMEnvSpec:
             columns={"q": "question"},
             max_reward=10.0,
             dataset="data.parquet",
-            reward_file_path="reward.py",
-            reward_fn_name="reward_fn",
+            rubric_file_path="reward.py",
+            rubric_name="reward_fn",
             prompt_template={"role": "user", "content": "{q}"},
         )
         data = spec.model_dump()
@@ -578,7 +578,7 @@ class TestLLMEnvSpecSFT:
         assert spec.env_type == LLMEnvType.DATASET
         assert spec.dataset == "my_dataset.parquet"
         assert spec.response_column == "answer"
-        assert spec.reward_file_path is None
+        assert spec.rubric_file_path is None
 
     def test_sft_default_response_column(self):
         spec = LLMEnvSpec(env_type=LLMEnvType.DATASET, objective="sft", dataset="ds")
@@ -610,22 +610,22 @@ class TestLLMEnvSpecSFT:
         assert call_kwargs["objective"] == "sft"
         assert call_kwargs["response_column"] == "completion"
 
-    def test_sft_rejects_reward_file_path(self):
+    def test_sft_rejects_rubric_file_path(self):
         with pytest.raises(ValueError, match="not supported for dataset"):
             LLMEnvSpec(
                 env_type=LLMEnvType.DATASET,
                 objective="sft",
                 dataset="ds",
-                reward_file_path="reward.py",
+                rubric_file_path="reward.py",
             )
 
-    def test_preference_rejects_reward_file_path(self):
+    def test_preference_rejects_rubric_file_path(self):
         with pytest.raises(ValueError, match="not supported for dataset"):
             LLMEnvSpec(
                 env_type=LLMEnvType.DATASET,
                 objective="preference",
                 dataset="ds",
-                reward_file_path="reward.py",
+                rubric_file_path="reward.py",
             )
 
     def test_dataset_alias_name(self):
@@ -633,8 +633,8 @@ class TestLLMEnvSpecSFT:
             {
                 "name": "my_dataset",
                 "env_type": "rollout",
-                "reward_file_path": "r.py",
-                "reward_fn_name": "fn",
+                "rubric_file_path": "r.py",
+                "rubric_name": "fn",
                 "prompt_template": {"role": "user", "content": "{q}"},
             }
         )
@@ -872,18 +872,18 @@ class TestLLMEnvSpecRollout:
             LLMEnvSpec(
                 env_type=LLMEnvType.ROLLOUT,
                 dataset="ds",
-                reward_file_path="r.py",
-                reward_fn_name="fn",
+                rubric_file_path="r.py",
+                rubric_name="fn",
                 prompt_template={"user_0": "Q: {question}"},
                 max_turns=4,
             )
 
-    def test_env_backed_rollout_rejects_reward_file_path(self):
+    def test_env_backed_rollout_rejects_rubric_file_path(self):
         with pytest.raises(ValueError, match="not supported for env-backed"):
             LLMEnvSpec(
                 env_type=LLMEnvType.ROLLOUT,
                 env_name="game:Test-v0",
-                reward_file_path="r.py",
+                rubric_file_path="r.py",
                 max_turns=5,
             )
 
@@ -1155,8 +1155,8 @@ class TestLLMEnvSpecRollout:
         with pytest.raises(ValueError, match="Exactly one of dataset, env_name"):
             LLMEnvSpec(
                 env_type=LLMEnvType.ROLLOUT,
-                reward_file_path="r.py",
-                reward_fn_name="fn",
+                rubric_file_path="r.py",
+                rubric_name="fn",
                 prompt_template={"user_0": "Q: {question}"},
             )
 
@@ -1196,8 +1196,8 @@ class TestDatasetBackedRolloutRewardFields:
     """Defensive guard for a dataset-backed rollout missing its reward fields."""
 
     def test_missing_reward_fields_raises(self):
-        # A validated dataset-backed rollout always carries reward_fn_name /
-        # reward_file_path / prompt_template; model_construct bypasses that
+        # A validated dataset-backed rollout always carries rubric_name /
+        # rubric_file_path / prompt_template; model_construct bypasses that
         # validator so we can reach the factory's own defensive guard, which
         # fires on first resolve — before any dataset or tokenizer is touched.
         mock_tokenizer = MagicMock()
@@ -1205,12 +1205,12 @@ class TestDatasetBackedRolloutRewardFields:
         spec = LLMEnvSpec.model_construct(
             env_type=LLMEnvType.ROLLOUT, dataset="dummy/dataset"
         )
-        assert spec.reward_fn_name is None
+        assert spec.rubric_name is None
 
         factory = spec.make_rollout_env_factory(mock_tokenizer)
         with pytest.raises(
             ValueError,
-            match="reward_fn_name, reward_file_path, and prompt_template",
+            match="rubric_name, rubric_file_path, and prompt_template",
         ):
             factory()
 

--- a/tests/test_models/test_env.py
+++ b/tests/test_models/test_env.py
@@ -300,20 +300,17 @@ class TestLLMEnvSpec:
         with pytest.raises(ValueError, match="rubric_file_path is required"):
             LLMEnvSpec(env_type=LLMEnvType.ROLLOUT, dataset="ds", rubric_file_path=None)
 
-    def test_rejects_legacy_reward_keys(self):
-        with pytest.raises(ValueError, match="renamed to rubric_file_path"):
-            LLMEnvSpec(
-                env_type=LLMEnvType.ROLLOUT,
-                dataset="ds",
-                reward_file_path="reward.py",
-            )
-        with pytest.raises(ValueError, match="renamed to rubric_file_path"):
-            LLMEnvSpec(
-                env_type=LLMEnvType.ROLLOUT,
-                dataset="ds",
-                rubric_file_path="reward.py",
-                reward_fn_name="reward_fn",
-            )
+    def test_accepts_legacy_reward_keys(self):
+        """Arena manifests may still send reward_file_path / reward_fn_name."""
+        spec = LLMEnvSpec(
+            env_type=LLMEnvType.ROLLOUT,
+            dataset="ds",
+            reward_file_path="reward.py",
+            reward_fn_name="combined_rewards",
+            prompt_template={"user_0": "{question}"},
+        )
+        assert spec.rubric_file_path == "reward.py"
+        assert spec.rubric_name == "combined_rewards"
 
     def test_dataset_does_not_require_rubric_file_path(self):
         spec = LLMEnvSpec(

--- a/tests/test_models/test_env.py
+++ b/tests/test_models/test_env.py
@@ -300,6 +300,21 @@ class TestLLMEnvSpec:
         with pytest.raises(ValueError, match="rubric_file_path is required"):
             LLMEnvSpec(env_type=LLMEnvType.ROLLOUT, dataset="ds", rubric_file_path=None)
 
+    def test_rejects_legacy_reward_keys(self):
+        with pytest.raises(ValueError, match="renamed to rubric_file_path"):
+            LLMEnvSpec(
+                env_type=LLMEnvType.ROLLOUT,
+                dataset="ds",
+                reward_file_path="reward.py",
+            )
+        with pytest.raises(ValueError, match="renamed to rubric_file_path"):
+            LLMEnvSpec(
+                env_type=LLMEnvType.ROLLOUT,
+                dataset="ds",
+                rubric_file_path="reward.py",
+                reward_fn_name="reward_fn",
+            )
+
     def test_dataset_does_not_require_rubric_file_path(self):
         spec = LLMEnvSpec(
             env_type=LLMEnvType.DATASET,

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -1038,8 +1038,8 @@ class TestLocalTrainerLLM:
             algo=algo,
             env={
                 "dataset": "train.parquet",
-                "reward_file_path": "reward.py",
-                "reward_fn_name": "combined_rewards",
+                "rubric_file_path": "reward.py",
+                "rubric_name": "combined_rewards",
                 "prompt_template": {
                     "system_0": "You are a helpful assistant.",
                     "user_1": "Solve {question} to get {answer}.",
@@ -1123,8 +1123,8 @@ class TestLocalTrainerLLM:
     def test_grpo_env_fields(self):
         trainer = LocalTrainer.from_manifest(self._grpo_manifest())
         assert trainer.env_spec.dataset == "train.parquet"
-        assert trainer.env_spec.reward_file_path == "reward.py"
-        assert trainer.env_spec.reward_fn_name == "combined_rewards"
+        assert trainer.env_spec.rubric_file_path == "reward.py"
+        assert trainer.env_spec.rubric_name == "combined_rewards"
         assert trainer.env_spec.max_reward == 10.0
         assert trainer.env_spec.train_test_split == 0.8
         assert trainer.env_spec.prompt_template == {

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -335,13 +335,13 @@ class TestLLMEnvSpec:
         )
         assert spec.name == "my_dataset"
 
-    def test_reasoning_missing_reward_fn_name(self):
-        """reasoning without reward_fn_name."""
-        with pytest.raises(ValueError, match="reward_fn_name is required"):
+    def test_reasoning_missing_rubric_name(self):
+        """reasoning without rubric_name."""
+        with pytest.raises(ValueError, match="rubric_name is required"):
             LLMEnvSpec(
                 env_type=LLMEnvType.ROLLOUT,
                 dataset="ds",
-                reward_file_path="some/path.py",
+                rubric_file_path="some/path.py",
                 prompt_template={"system": "hi"},
             )
 
@@ -351,8 +351,8 @@ class TestLLMEnvSpec:
             LLMEnvSpec(
                 env_type=LLMEnvType.ROLLOUT,
                 dataset="ds",
-                reward_file_path="some/path.py",
-                reward_fn_name="my_fn",
+                rubric_file_path="some/path.py",
+                rubric_name="my_fn",
             )
 
     def test_dataset_missing_dataset(self):
@@ -437,8 +437,8 @@ class TestLLMEnvSpec:
         spec = LLMEnvSpec(
             env_type=LLMEnvType.ROLLOUT,
             dataset="ds",
-            reward_file_path="some/path.py",
-            reward_fn_name="my_fn",
+            rubric_file_path="some/path.py",
+            rubric_name="my_fn",
             prompt_template={"system_0": "hi"},
         )
         with pytest.raises(TypeError, match="make_rollout_env_factory"):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -326,6 +326,7 @@ class TestEnvClientProtocol:
         EnvClientProtocol.close(client)
         _ = EnvClientProtocol.dataset_size.fget(client)
         _ = EnvClientProtocol.tools.fget(client)
+        _ = EnvClientProtocol.rubric_components.fget(client)
         _ = EnvClientProtocol.eval_mode(client)
 
 

--- a/tests/test_train/test_train_llm.py
+++ b/tests/test_train/test_train_llm.py
@@ -1122,6 +1122,49 @@ class TestTrainLlmRollout:
 
         mock_agent.metrics.register.assert_called_with("accuracy")
 
+    def test_train_llm_rollout_logs_rubric_component_metrics(self):
+        mock_agent = _make_rollout_mock_agent()
+        mock_agent.metrics.additional_metrics = ["loss", "mean_reward"]
+
+        mock_rollout_env = MagicMock()
+        mock_rollout_env.num_epochs = 0
+        mock_rollout_env.get_rubric_score_means.return_value = {"fmt": 0.75}
+
+        def _agg(_accelerator, value):
+            return (
+                value if isinstance(value, torch.Tensor) else torch.tensor(float(value))
+            )
+
+        with (
+            patch("agilerl.training.llm.rollout.default_progress_bar") as mock_pbar_fn,
+            patch("agilerl.training.llm.rollout.init_loggers", return_value=[]),
+            patch(
+                "agilerl.training.llm.rollout.safe_aggregate_metrics",
+                side_effect=_agg,
+            ),
+            patch("agilerl.training.llm.rollout.save_llm_checkpoint"),
+            patch(
+                "agilerl.training.llm.rollout.BatchRolloutEnv",
+                return_value=mock_rollout_env,
+            ),
+            patch("agilerl.training.llm.rollout.collect_rollouts_llm") as mock_collect,
+        ):
+            mock_pbar_fn.return_value = MagicMock()
+            mock_collect.return_value = _rollout_collect_return(batch_steps=3)
+            train_llm_rollout(
+                pop=[mock_agent],
+                env_factory=MagicMock(),
+                max_turns=2,
+                init_hp={"BATCH_SIZE": 1, "ALGO": "LLMPPO"},
+                max_steps=3,
+                evaluation_interval=100,
+                verbose=False,
+                accelerator=None,
+            )
+
+        mock_agent.metrics.register.assert_any_call("reward_fmt")
+        mock_agent.metrics.log.assert_any_call("reward_fmt", ANY)
+
     def test_train_llm_rollout_stops_at_wall_clock_limit(self, capsys):
         mock_agent = _make_rollout_mock_agent()
 

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -1541,8 +1541,11 @@ class TestLLMLocalTrainer:
 
         assert mock_llm_env_spec.max_context_length == dpo_spec.max_model_len
         assert mock_llm_env_spec.seed == dpo_spec.seed
+        mock_accel = mock_create_accel.return_value
         mock_llm_env_spec.make_env.assert_called_once_with(
-            tokenizer=mock_tokenizer, accelerator=mock_create_accel.return_value
+            tokenizer=mock_tokenizer,
+            rank=mock_accel.process_index,
+            world_size=mock_accel.num_processes,
         )
         assert trainer.env is mock_env
 

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -1958,7 +1958,10 @@ class TestLocalTrainerIntegration:
 
         reward_file = tmp_path / "reward.py"
         reward_file.write_text(
-            "def simple_reward(completion, answer, prompt, **kwargs):\n    return 1.0\n"
+            "from agilerl.llm_envs.rubrics import reward_fn_to_rubric\n"
+            "def simple_reward(completion, answer, prompt, **kwargs):\n"
+            "    return 1.0\n"
+            "RUBRIC = reward_fn_to_rubric(simple_reward)\n"
         )
 
         import pandas as pd
@@ -1983,8 +1986,8 @@ class TestLocalTrainerIntegration:
         env_spec = LLMEnvSpec(
             env_type=LLMEnvType.ROLLOUT,
             dataset=str(dataset_path),
-            reward_file_path=str(reward_file),
-            reward_fn_name="simple_reward",
+            rubric_file_path=str(reward_file),
+            rubric_name="RUBRIC",
             prompt_template={"user_0": "Solve: {question}"},
             data_batch_size_per_gpu=4,
         )
@@ -2709,8 +2712,8 @@ class TestLocalTrainerResolveEnvSpecBranches:
             AgentType.LLMAgent,
             env_data={
                 "dataset": "gsm8k",
-                "reward_file_path": "/tmp/reward.py",
-                "reward_fn_name": "reward_fn",
+                "rubric_file_path": "/tmp/reward.py",
+                "rubric_name": "reward_fn",
                 "prompt_template": {"system": "You are helpful"},
             },
             algo_cls=LLMAlgorithmSpec,

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -1728,6 +1728,14 @@ class TestLocalTrainerIntegration:
         return mock_tokenizer
 
     @staticmethod
+    def _mock_llm_accelerator() -> MagicMock:
+        """Accelerator stand-in with real DP shard ints for DatasetEnv."""
+        mock_accel = MagicMock()
+        mock_accel.process_index = 0
+        mock_accel.num_processes = 1
+        return mock_accel
+
+    @staticmethod
     @contextlib.contextmanager
     def _llm_trainer_patches(mock_pop: list[MagicMock]):
         """Patches population, accelerator, and tokenizer loading for LLM tests."""
@@ -1739,7 +1747,7 @@ class TestLocalTrainerIntegration:
             ),
             patch(
                 "agilerl.training.trainer.create_llm_accelerator",
-                return_value=MagicMock(),
+                return_value=TestLocalTrainerIntegration._mock_llm_accelerator(),
             ),
             patch(
                 "agilerl.training.trainer.AutoTokenizer.from_pretrained",
@@ -2615,6 +2623,8 @@ class TestMakeEnvBranches:
         trainer.algorithm_spec.batch_size = 8
         trainer.tokenizer = MagicMock()
         trainer.accelerator = MagicMock()
+        trainer.accelerator.process_index = 0
+        trainer.accelerator.num_processes = 1
 
         with patch(
             "agilerl.training.trainer.isinstance",
@@ -2633,6 +2643,9 @@ class TestMakeEnvBranches:
         assert trainer.env_spec.max_context_length == 1024
         assert trainer.env_spec.seed == 42
         assert trainer.env_spec.data_batch_size_per_gpu == 8
+        trainer.env_spec.make_env.assert_called_once_with(
+            tokenizer=trainer.tokenizer, rank=0, world_size=1
+        )
 
     def test_standard_env_calls_make_env(self):
         """Non-LLM env spec calls make_env() with no args."""

--- a/tests/test_utils/test_env_utils.py
+++ b/tests/test_utils/test_env_utils.py
@@ -93,6 +93,26 @@ class TestGetRubric:
 
         assert isinstance(rubric, Rubric)
 
+    def test_loads_rubric_subclass(self, tmp_path):
+        rubric_file = tmp_path / "rubric_cls.py"
+        rubric_file.write_text(
+            "from openenv.core.rubrics.base import Rubric\n"
+            "class MyRubric(Rubric):\n"
+            "    def forward(self, action, observation):\n"
+            "        return 1.0\n",
+            encoding="utf-8",
+        )
+        rubric = env_utils.get_rubric("MyRubric", str(rubric_file))
+        from openenv.core.rubrics.base import Rubric
+
+        assert isinstance(rubric, Rubric)
+
+    def test_non_rubric_export_raises(self, tmp_path):
+        rubric_file = tmp_path / "not_rubric.py"
+        rubric_file.write_text("NOT_A_RUBRIC = 42\n", encoding="utf-8")
+        with pytest.raises(TypeError, match="must be a Rubric"):
+            env_utils.get_rubric("NOT_A_RUBRIC", str(rubric_file))
+
 
 class TestResolveWrapper:
     def test_invalid_string_wrapper_raises(self):

--- a/tests/test_utils/test_env_utils.py
+++ b/tests/test_utils/test_env_utils.py
@@ -107,6 +107,53 @@ class TestGetRubric:
 
         assert isinstance(rubric, Rubric)
 
+    def test_loads_legacy_reward_callable(self, tmp_path):
+        """Arena reward modules export a callable; wrap with RewardFnRubric."""
+        reward_file = tmp_path / "reward.py"
+        reward_file.write_text(
+            "def combined_rewards(completion, answer, question):\n"
+            "    del answer, question\n"
+            "    return 1.0 if completion else 0.0\n",
+            encoding="utf-8",
+        )
+        rubric = env_utils.get_rubric("combined_rewards", str(reward_file))
+        from openenv.core.rubrics.base import Rubric
+
+        from agilerl.llm_envs.rubrics import RewardFnRubric
+
+        assert isinstance(rubric, Rubric)
+        assert isinstance(rubric, RewardFnRubric)
+
+    def test_loads_weighted_sum_rubric_instance(self, tmp_path):
+        """OpenEnv composition exports (e.g. WeightedSum) must not be re-wrapped."""
+        reward_file = tmp_path / "reward.py"
+        reward_file.write_text(
+            "from openenv.core.rubrics.base import Rubric\n"
+            "from openenv.core.rubrics import WeightedSum\n"
+            "\n"
+            "class TestsPassRubric(Rubric):\n"
+            "    def forward(self, action, observation) -> float:\n"
+            "        return 1.0\n"
+            "\n"
+            "class StyleRubric(Rubric):\n"
+            "    def forward(self, action, observation) -> float:\n"
+            "        return 0.6\n"
+            "\n"
+            "reward = WeightedSum(\n"
+            "    [TestsPassRubric(), StyleRubric()],\n"
+            "    weights=[0.7, 0.3],\n"
+            ")\n",
+            encoding="utf-8",
+        )
+        rubric = env_utils.get_rubric("reward", str(reward_file))
+        from openenv.core.rubrics import WeightedSum
+
+        from agilerl.llm_envs.rubrics import RewardFnRubric
+
+        assert isinstance(rubric, WeightedSum)
+        assert not isinstance(rubric, RewardFnRubric)
+        assert list(rubric.named_children())  # leaves registered for metrics
+
     def test_non_rubric_export_raises(self, tmp_path):
         rubric_file = tmp_path / "not_rubric.py"
         rubric_file.write_text("NOT_A_RUBRIC = 42\n", encoding="utf-8")

--- a/tests/test_utils/test_env_utils.py
+++ b/tests/test_utils/test_env_utils.py
@@ -49,35 +49,49 @@ class TestParseEntrypoint:
 
 
 class TestGetRewardFn:
+    def test_removed_raises_with_migration_hint(self, tmp_path):
+        rubric_file = tmp_path / "reward.py"
+        rubric_file.write_text("def reward(): return 1.0\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="get_reward_fn is removed"):
+            env_utils.get_reward_fn("reward", str(rubric_file))
+
+
+class TestGetRubric:
     def test_missing_file_raises(self, tmp_path):
         missing = tmp_path / "missing.py"
         with pytest.raises(ValueError, match="not found"):
-            env_utils.get_reward_fn("reward", str(missing))
+            env_utils.get_rubric("rubric", str(missing))
 
     def test_import_error_wrapped(self, tmp_path):
         bad_file = tmp_path / "bad.py"
         bad_file.write_text(
             "raise RuntimeError('intentional import failure')\n", encoding="utf-8"
         )
-        with pytest.raises(ValueError, match="Error importing reward function"):
-            env_utils.get_reward_fn("reward", str(bad_file))
+        with pytest.raises(ValueError, match="Error importing rubric"):
+            env_utils.get_rubric("rubric", str(bad_file))
 
     def test_spec_none_raises(self, tmp_path):
-        reward_file = tmp_path / "reward.py"
-        reward_file.write_text("def reward(): return 1.0\n", encoding="utf-8")
+        rubric_file = tmp_path / "rubric.py"
+        rubric_file.write_text("def rubric(): return 1.0\n", encoding="utf-8")
         with patch(
             "agilerl.utils.env_utils.importlib_util.spec_from_file_location",
             return_value=None,
         ):
             with pytest.raises(ValueError, match="Could not create spec"):
-                env_utils.get_reward_fn("reward", str(reward_file))
+                env_utils.get_rubric("rubric", str(rubric_file))
 
-    def test_loads_callable(self, tmp_path):
-        reward_file = tmp_path / "reward.py"
-        reward_file.write_text("def my_reward(obs): return 1.0\n", encoding="utf-8")
-        fn = env_utils.get_reward_fn("my_reward", str(reward_file))
-        assert callable(fn)
-        assert fn({}) == 1.0
+    def test_loads_rubric_instance(self, tmp_path):
+        rubric_file = tmp_path / "rubric.py"
+        rubric_file.write_text(
+            "from agilerl.llm_envs.rubrics import reward_fn_to_rubric\n"
+            "def my_reward(obs): return 1.0\n"
+            "RUBRIC = reward_fn_to_rubric(my_reward)\n",
+            encoding="utf-8",
+        )
+        rubric = env_utils.get_rubric("RUBRIC", str(rubric_file))
+        from openenv.core.rubrics.base import Rubric
+
+        assert isinstance(rubric, Rubric)
 
 
 class TestResolveWrapper:

--- a/tests/test_wrappers/test_openenv.py
+++ b/tests/test_wrappers/test_openenv.py
@@ -485,7 +485,6 @@ class TestTaskAssigner:
             TaskAssigner(4, seed=0, rank=4, world_size=4)
 
 
-
 # --- /state strictness + MCP tools/list fallback ----------------------------
 class _StubSync:
     """Stand-in for OpenEnv's ``SyncEnvClient`` — records reset/step, scripts errors."""

--- a/tests/test_wrappers/test_openenv.py
+++ b/tests/test_wrappers/test_openenv.py
@@ -41,6 +41,8 @@ from agilerl.llm_envs.openenv_server import (
     _normalize_reset,
     _normalize_step,
 )
+from agilerl.llm_envs.prompt_dataset import PromptDatasetEnv
+from agilerl.llm_envs.rubrics import reward_fn_to_rubric
 from tests.helpers.rollout_doubles import MiniTokenizer
 
 
@@ -476,6 +478,13 @@ class TestTaskAssigner:
         """``dataset_size=0`` never draws rows, so any rank/world_size is fine."""
         assert TaskAssigner(0, rank=3, world_size=8).assign(1, 2) == [(None, None)] * 2
 
+    def test_invalid_rank_or_world_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="world_size"):
+            TaskAssigner(4, seed=0, rank=0, world_size=0)
+        with pytest.raises(ValueError, match="rank"):
+            TaskAssigner(4, seed=0, rank=4, world_size=4)
+
+
 
 # --- /state strictness + MCP tools/list fallback ----------------------------
 class _StubSync:
@@ -548,6 +557,35 @@ def test_session_state_reports_dataset_size_and_tools() -> None:
     client = _session_client(state={"dataset_size": 5, "tools": [{"name": "t"}]})
     assert client.dataset_size == 5
     assert client.tools == [{"name": "t"}]
+
+
+def test_session_state_reports_rubric_components() -> None:
+    client = _session_client(state={"rubric_components": ["fmt", "correct"]})
+    assert client.rubric_components == ("fmt", "correct")
+
+
+def test_session_step_forwards_metadata_and_obs_rubric_scores() -> None:
+    """Result metadata merges into info; obs-level rubric_scores fill gaps."""
+    client = _session_client()
+
+    def _step(action: Any) -> Any:
+        del action
+        return SimpleNamespace(
+            observation={
+                "prompt": "hi",
+                "rubric_scores": {"fmt": 1.0},
+                "metadata": {"extra": 2},
+            },
+            reward=1.0,
+            done=True,
+            metadata={"from_result": True},
+        )
+
+    client._sync.step = _step  # type: ignore[method-assign]
+    _obs, _reward, _term, _trunc, info = client.step("go")
+    assert info["from_result"] is True
+    assert info["extra"] == 2
+    assert info["rubric_scores"] == {"fmt": 1.0}
 
 
 # --- broken mid-episode, re-dialled at the next reset ------------------------
@@ -1270,3 +1308,18 @@ def test_reset_retries_once_when_the_server_closed_an_idle_session() -> None:
     assert prompt == "prompt"
     assert client._sync is fresh
     assert client._redials == 1
+
+
+def test_server_hosts_prompt_dataset_environment_as_is() -> None:
+    """OpenEnv ``Environment`` subclasses are hosted without ``OpenEnvWrapper``."""
+    world = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=reward_fn_to_rubric(lambda c, a, q: 1.0),
+    )
+    with OpenEnvServer(world) as server:
+        client = OpenEnvSessionClient(server.base_url)
+        assert client.reset(row_index=0)[0] == "q"
+        _obs, reward, terminated, _truncated, _info = client.step("done")
+        assert reward == 1.0
+        assert terminated is True
+        assert client.rubric_components == ("fn",)

--- a/tests/test_wrappers/test_prompt_dataset_rubrics.py
+++ b/tests/test_wrappers/test_prompt_dataset_rubrics.py
@@ -5,13 +5,16 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import numpy as np
 import pytest
 from openenv.core.rubrics.base import Rubric
 from openenv.core.rubrics.containers import Sequential
 
 from agilerl.llm_envs.openenv import LocalEnvClient, TextAction
-from agilerl.llm_envs.prompt_dataset import PromptDatasetEnv
-from agilerl.llm_envs.rubrics import reward_fn_to_rubric
+from agilerl.llm_envs.prompt_dataset import PromptDatasetEnv, _json_safe
+from agilerl.llm_envs.rubrics import register_component_hooks, reward_fn_to_rubric
 
 
 class _Leaf(Rubric):
@@ -163,3 +166,53 @@ def test_local_env_client_does_not_double_wrap_prompt_dataset() -> None:
     )
     client = LocalEnvClient(world)
     assert client._env is world
+
+
+def test_json_safe_coerces_numpy_and_nested_containers() -> None:
+    assert _json_safe(np.int64(3)) == 3
+    assert _json_safe(np.array([1, 2])) == [1, 2]
+    coerced = _json_safe({"k": np.float32(1.5)})
+    assert isinstance(coerced, dict)
+    assert coerced["k"] == pytest.approx(1.5)
+    assert _json_safe((np.int64(1), "x")) == [1, "x"]
+
+
+def test_json_safe_warns_on_unrecognised_type() -> None:
+    with pytest.warns(UserWarning, match="not coerced"):
+        assert _json_safe(object()) is not None
+
+
+def test_prompt_dataset_empty_rows_raises() -> None:
+    env = PromptDatasetEnv([], rubric=reward_fn_to_rubric(lambda c, a, q: 0.0))
+    with pytest.raises(RuntimeError, match="no rows"):
+        env.reset()
+
+
+def test_async_rubric_score_raises_type_error() -> None:
+    env = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=reward_fn_to_rubric(lambda c, a, q: 1.0),
+    )
+    env.reset(row_index=0)
+
+    async def _coro() -> float:
+        return 1.0
+
+    with (
+        patch.object(env, "_apply_rubric", return_value=_coro()),
+        pytest.raises(TypeError, match="async rubrics"),
+    ):
+        env.step(TextAction(message="x"))
+
+
+def test_register_component_hooks_none_and_empty_name() -> None:
+    assert register_component_hooks(None) == ()
+
+    class _OddName(Rubric):
+        component_name = 123  # non-str forces the snake_case fallback
+
+        def forward(self, action, observation) -> float:
+            del action, observation
+            return 1.0
+
+    assert register_component_hooks(_OddName()) == ("odd_name",)

--- a/tests/test_wrappers/test_prompt_dataset_rubrics.py
+++ b/tests/test_wrappers/test_prompt_dataset_rubrics.py
@@ -1,0 +1,165 @@
+# Copyright 2026 AgileRL
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused coverage for PromptDatasetEnv and reward_fn_to_rubric."""
+
+from __future__ import annotations
+
+import pytest
+from openenv.core.rubrics.base import Rubric
+from openenv.core.rubrics.containers import Sequential
+
+from agilerl.llm_envs.openenv import LocalEnvClient, TextAction
+from agilerl.llm_envs.prompt_dataset import PromptDatasetEnv
+from agilerl.llm_envs.rubrics import reward_fn_to_rubric
+
+
+class _Leaf(Rubric):
+    def __init__(self, value: float) -> None:
+        super().__init__()
+        self.value = value
+
+    def forward(self, action, observation) -> float:
+        del action, observation
+        return self.value
+
+
+class _Parent(Rubric):
+    """OpenEnv-style composition: children register via attribute assignment."""
+
+    def __init__(self, **children: Rubric) -> None:
+        super().__init__()
+        for name, child in children.items():
+            setattr(self, name, child)
+
+    def forward(self, action, observation) -> float:
+        return float(sum(child(action, observation) for child in self.children()))
+
+
+def test_reward_fn_to_rubric_positional_call() -> None:
+    seen: list[tuple] = []
+
+    def fn(completion, answer, question):
+        seen.append((completion, answer, question))
+        return 0.5
+
+    rubric = reward_fn_to_rubric(fn)
+    rows = [{"question": "q", "answer": "a"}]
+    env = PromptDatasetEnv(rows, rubric=rubric)
+    env.reset(row_index=0)
+    obs = env.step(TextAction(message="done"))
+    assert obs.reward == 0.5
+    assert seen == [("done", "a", "q")]
+    assert env.rubric_components == ("fn",)
+
+
+def test_prompt_dataset_rejects_callable_rubric() -> None:
+    with pytest.raises(TypeError, match="reward_fn_to_rubric"):
+        PromptDatasetEnv(
+            [{"question": "q", "answer": "a"}],
+            rubric=lambda c, a, q: 1.0,  # type: ignore[arg-type]
+        )
+
+
+def test_reset_hides_labels() -> None:
+    env = PromptDatasetEnv(
+        [{"question": "q", "answer": "secret"}],
+        rubric=reward_fn_to_rubric(lambda c, a, q: 1.0),
+    )
+    obs = env.reset(row_index=0)
+    assert obs.answer is None
+    assert obs.question is None
+    assert obs.prompt == "q"
+
+
+def test_terminal_obs_keeps_rendered_prompt() -> None:
+    """Terminal step keeps the rendered prompt (may differ from ``question``)."""
+    seen: list[str] = []
+
+    class _PromptRubric(Rubric):
+        def forward(self, action, observation) -> float:
+            del action
+            seen.append(observation.prompt)
+            return 1.0 if observation.prompt.startswith("Ask:") else 0.0
+
+    env = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=_PromptRubric(),
+        prompt_builder=lambda row: f"Ask: {row['question']}",
+    )
+    assert env.reset(row_index=0).prompt == "Ask: q"
+    terminal = env.step(TextAction(message="x"))
+    assert terminal.prompt == "Ask: q"
+    assert terminal.question == "q"
+    assert terminal.answer == "a"
+    assert terminal.reward == 1.0
+    assert seen == ["Ask: q"]
+
+
+def test_openenv_children_report_components() -> None:
+    env = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=_Parent(fmt=_Leaf(1.0), correct=_Leaf(1.0)),
+    )
+    env.reset(row_index=0)
+    obs = env.step(TextAction(message="x"))
+    assert obs.reward == 2.0
+    assert obs.metadata["rubric_scores"] == {"fmt": 1.0, "correct": 1.0}
+    assert env.rubric_components == ("fmt", "correct")
+
+
+def test_each_env_owns_its_rubric_hooks() -> None:
+    """Each env should get its own rubric tree (one hook per leaf per env)."""
+    rows = [{"question": str(i), "answer": str(i)} for i in range(4)]
+    envs = [PromptDatasetEnv(rows, rubric=_Parent(a=_Leaf(1.0))) for _ in range(3)]
+    assert all(env.rubric_components == ("a",) for env in envs)
+    for env in envs:
+        leaf = next(env.rubric.children())
+        assert len(leaf._forward_hooks) == 1
+
+
+def test_short_circuit_omits_skipped_child() -> None:
+    class Zero(Rubric):
+        def forward(self, action, observation) -> float:
+            del action, observation
+            return 0.0
+
+    class Never(Rubric):
+        def forward(self, action, observation) -> float:
+            del action, observation
+            msg = "should be short-circuited"
+            raise AssertionError(msg)
+
+    env = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=Sequential(Zero(), Never()),
+    )
+    env.reset(row_index=0)
+    obs = env.step(TextAction(message="x"))
+    assert obs.reward == 0.0
+    scores = obs.metadata.get("rubric_scores") or {}
+    assert "rubric_0" in scores
+    assert "rubric_1" not in scores
+
+
+def test_local_env_client_forwards_rubric_scores() -> None:
+    """``LocalEnvClient`` surfaces leaf ``rubric_scores`` in step info."""
+    env = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=_Parent(fmt=_Leaf(1.0), correct=_Leaf(1.0)),
+    )
+    client = LocalEnvClient(env)
+    assert client.rubric_components == ("fmt", "correct")
+    client.reset(row_index=0)
+    _prompt, _reward, _terminated, _truncated, info = client.step("x")
+    assert info["rubric_scores"] == {"fmt": 1.0, "correct": 1.0}
+
+
+def test_local_env_client_does_not_double_wrap_prompt_dataset() -> None:
+    """OpenEnv ``Environment`` instances are stored as-is on the client."""
+    world = PromptDatasetEnv(
+        [{"question": "q", "answer": "a"}],
+        rubric=reward_fn_to_rubric(lambda c, a, q: 1.0),
+    )
+    client = LocalEnvClient(world)
+    assert client._env is world

--- a/tests/test_wrappers/test_rollout_env.py
+++ b/tests/test_wrappers/test_rollout_env.py
@@ -915,6 +915,19 @@ class TestBatchRolloutEnvHelpers:
             vec.envs.append(_SyncStubEnv())
         assert vec._is_initialized is True
 
+    def test_get_rubric_score_means_averages_and_nans(self) -> None:
+        vec = BatchRolloutEnv(env_factory=_SyncStubEnv, batch_size=1, group_size=2)
+        e0 = _SyncStubEnv()
+        e1 = _SyncStubEnv()
+        e0.rubric_score_sums = {"fmt": 1.0, "correct": 2.0}
+        e1.rubric_score_sums = {"fmt": 3.0}
+        vec.envs = [e0, e1]
+        vec.rubric_component_names = ("fmt", "correct", "missing")
+        means = vec.get_rubric_score_means()
+        assert means["fmt"] == 2.0
+        assert means["correct"] == 2.0
+        assert means["missing"] != means["missing"]  # NaN
+
 
 class TestBatchRolloutEnvActiveEnvs:
     def test_active_envs_excludes_done_and_preserves_list_order(self) -> None:

--- a/tests/test_wrappers/test_rollout_env.py
+++ b/tests/test_wrappers/test_rollout_env.py
@@ -15,6 +15,7 @@ from agilerl.llm_envs import (
     BatchRolloutEnv,
     RolloutEnv,
 )
+from agilerl.llm_envs.rubrics import reward_fn_to_rubric
 from tests.helpers.rollout_doubles import (
     FakeEnvClient,
     RolloutEnvDoubleMixin,
@@ -411,7 +412,7 @@ class TestRolloutEnvPolicyObservationFromState:
 
 
 class TestRolloutEnvFromDataset:
-    """from_dataset bundles (question, answer) rows + a reward fn into a single-turn env."""
+    """from_dataset bundles (question, answer) rows + a rubric into a single-turn env."""
 
     _ROWS: ClassVar[list[dict]] = [
         {"question": "q0", "answer": "a0"},
@@ -429,7 +430,7 @@ class TestRolloutEnvFromDataset:
 
         env = RolloutEnv.from_dataset(
             self._ROWS,
-            reward_fn,
+            reward_fn_to_rubric(reward_fn),
             _ChrTokenizer(),
             test_dataset=self._TEST_ROWS,
             prompt_builder=lambda row: f"P:{row['question']}",
@@ -471,7 +472,7 @@ class TestRolloutEnvFromDataset:
         """With no ``prompt_builder`` the prompt is ``str(question)`` verbatim."""
         env = RolloutEnv.from_dataset(
             self._ROWS,
-            lambda c, a, q: 0.0,
+            reward_fn_to_rubric(lambda c, a, q: 0.0),
             _ChrTokenizer(),
             pad_id=None,
             apply_chat_template=False,
@@ -482,7 +483,7 @@ class TestRolloutEnvFromDataset:
         with pytest.raises(TypeError, match="single-turn"):
             RolloutEnv.from_dataset(
                 self._ROWS,
-                lambda c, a, q: 0.0,
+                reward_fn_to_rubric(lambda c, a, q: 0.0),
                 _ChrTokenizer(),
                 max_turns=2,
             )

--- a/tutorials/llm_finetuning/grpo_reasoning.py
+++ b/tutorials/llm_finetuning/grpo_reasoning.py
@@ -13,6 +13,7 @@ from agilerl.algorithms import GRPO
 from agilerl.training.llm import train_llm_rollout
 from agilerl.utils.algo_utils import VLLMConfig
 from agilerl.llm_envs import RolloutEnv
+from agilerl.llm_envs.rubrics import reward_fn_to_rubric
 
 MODEL_PATH = "Qwen/Qwen2.5-0.5B"
 DATASET = "Jiayi-Pan/Countdown-Tasks-3to4"
@@ -66,7 +67,7 @@ def equation_reward_func(completions, target, nums, **kwargs):
             equation = answer_tags[0].strip()
             used_numbers = [int(n) for n in re.findall(r"\d+", equation)]
 
-            if sorted(used_numbers) != sorted(numbers.flatten().tolist()):
+            if sorted(used_numbers) != sorted(list(numbers)):
                 rewards.append(0.0)
                 continue
 
@@ -135,9 +136,10 @@ def main():
     # BatchRolloutEnv owns the dataset cursor, giving each GRPO group a
     # deterministic, group-consistent dataset order.
     def env_factory(evaluation_mode: bool = False):
-        env = RolloutEnv.from_dataset(
+        del evaluation_mode
+        return RolloutEnv.from_dataset(
             train_dataset,
-            combined_rewards,
+            reward_fn_to_rubric(combined_rewards),
             tokenizer,
             test_dataset=test_dataset,
             prompt_builder=prompt_builder,
@@ -145,8 +147,6 @@ def main():
             apply_chat_template=True,
             max_model_len=MAX_CONTEXT_LENGTH,
         )
-        env.evaluation_mode = evaluation_mode
-        return env
 
     # Define the LoRA configuration
     lora_config = LoraConfig(

--- a/tutorials/llm_finetuning/grpo_reasoning_hpo.py
+++ b/tutorials/llm_finetuning/grpo_reasoning_hpo.py
@@ -13,6 +13,7 @@ from agilerl.hpo.tournament import TournamentSelection
 from agilerl.training.llm import train_llm_rollout
 from agilerl.utils.algo_utils import VLLMConfig
 from agilerl.llm_envs import RolloutEnv
+from agilerl.llm_envs.rubrics import reward_fn_to_rubric
 from agilerl.utils.utils import create_population
 
 if HAS_LLM_DEPENDENCIES:
@@ -76,7 +77,7 @@ def equation_reward_func(completions, target, nums, **kwargs):
             equation = answer_tags[0].strip()
             used_numbers = [int(n) for n in re.findall(r"\d+", equation)]
 
-            if sorted(used_numbers) != sorted(numbers.flatten().tolist()):
+            if sorted(used_numbers) != sorted(list(numbers)):
                 rewards.append(0.0)
                 continue
 
@@ -137,9 +138,10 @@ def main(init_hp, mut_p):
     # them into one. The BatchRolloutEnv owns the dataset cursor, keeping each
     # GRPO group's dataset order deterministic and consistent.
     def env_factory(evaluation_mode: bool = False):
-        env = RolloutEnv.from_dataset(
+        del evaluation_mode
+        return RolloutEnv.from_dataset(
             train_dataset,
-            combined_rewards,
+            reward_fn_to_rubric(combined_rewards),
             tokenizer,
             test_dataset=test_dataset,
             prompt_builder=prompt_builder,
@@ -147,8 +149,6 @@ def main(init_hp, mut_p):
             apply_chat_template=True,
             max_model_len=init_hp["MAX_MODEL_LEN"],
         )
-        env.evaluation_mode = evaluation_mode
-        return env
 
     hp_config = HyperparameterConfig(
         beta=RLParameter(min=mut_p["MIN_BETA"], max=mut_p["MAX_BETA"]),


### PR DESCRIPTION
Summary
- Replace reward-fn _PromptDatasetEnv with OpenEnv-native PromptDatasetEnv scored by Rubrics (reward_fn_to_rubric for migration), with leaf hooks stamping metadata["rubric_scores"].
- Restore EnvClientProtocol (LocalEnvClient / RemoteEnvClient) so RolloutEnv only sees text + Gym 5-tuples; forward component scores into dynamic reward_* metrics in train_llm_rollout.
- Fix multi-GPU dataset sampling: shared shuffle_seed for one global shuffle, DistributedSampler-style order[rank::world_size] shards; rank-offset seeds only for procedural envs.