### PR TITLE
Add expert LoRA for packed MoE weights

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -148,12 +148,15 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
     from safetensors.torch import load_file
 
     from agilerl.algorithms.core.llm_ops.fused_lora import (
+        adapter_aligned_chunks,
         get_cached_lora_layers,
         patch_lora_for_fused_forward,
         set_fused_adapter_routing,
         unset_fused_adapter_routing,
     )
+    from agilerl.algorithms.core.llm_ops.moe_lora import upgrade_moe_param_wrappers
     from agilerl.algorithms.core.llm_ops.vllm_colocate import (
+        patch_vllm_3d_moe_lora_flag,
         patch_vllm_lora_keep_resident,
         patch_vllm_strip_multimodal_towers,
     )
@@ -165,6 +168,7 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
         build_vllm_llm_init_kwargs,
         build_vllm_rollout_lora_request,
         create_model_from_name_or_path,
+        expert_lora_vllm_key_map,
         gather_if_ds_param,
         gather_if_zero3,
         get_lora_params,
@@ -4368,6 +4372,27 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                 lora_target_scope=self.lora_target_scope,
             )
             self.lora_config = lora_config
+            expert_target_parameters = getattr(lora_config, "target_parameters", None)
+            if expert_target_parameters:
+                if lora_config.lora_dropout:
+                    msg = (
+                        "lora_config.target_parameters (packed-experts LoRA) "
+                        "requires lora_dropout=0.0: PEFT's parameter-level "
+                        "LoRA cannot factor dropout out of the low-rank "
+                        "product."
+                    )
+                    raise ValueError(msg)
+                extra_adapters = [a for a in self.selected_adapters if a != "actor"]
+                if extra_adapters:
+                    msg = (
+                        "lora_config.target_parameters (packed-experts LoRA) "
+                        "supports only the 'actor' adapter — PEFT allows one "
+                        "adapter per model with target_parameters, but "
+                        f"selected_adapters also lists {extra_adapters}. Use "
+                        "use_separate_reference_adapter=False and no value "
+                        "head with expert LoRA."
+                    )
+                    raise ValueError(msg)
             keep_adapter_base_dtype = self.zero_stage == 3 and not quantized_base
             peft_target = get_peft_model(
                 peft_target,
@@ -4404,6 +4429,13 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                 for name, param in peft_target.named_parameters():
                     if "lora" in name and param.dtype != torch.bfloat16:
                         param.data = param.data.to(torch.bfloat16)
+
+            if expert_target_parameters:
+                n_expert_lora = upgrade_moe_param_wrappers(peft_target)
+                logger.info(
+                    "Split expert-LoRA execution enabled on %d packed-experts modules.",
+                    n_expert_lora,
+                )
 
             # Apply Liger Kernel optimizations (fused RMSNorm, RoPE, SwiGLU,
             # CrossEntropy) to the inner causal-LM *after* PEFT wrapping.
@@ -4603,10 +4635,13 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
         if self.calc_position_embeddings:
             position_ids = self._position_ids_from_mask(fused_mask)
 
+        # Micro-batches never straddle an adapter run: packed-experts LoRA
+        # layers see expert-sorted rows and can only apply one adapter per
+        # forward call.
         chunks = (
             [(0, total)]
             if batch_size is None
-            else [(s, min(s + batch_size, total)) for s in range(0, total, batch_size)]
+            else adapter_aligned_chunks(routing, batch_size)
         )
 
         fused_fn, lm_head_weight, lm_head_bias = self._fused_logprob_fn_and_head()
@@ -5202,14 +5237,20 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                 msg = "lora_config is required for vLLM LoRA adapter export."
                 raise ValueError(msg)
             target_modules = self.lora_config.target_modules
-            assert target_modules is not None, (
-                "lora_config.target_modules is required for vLLM LoRA adapter export."
+            target_parameters = getattr(self.lora_config, "target_parameters", None)
+            assert target_modules is not None or target_parameters, (
+                "lora_config.target_modules or target_parameters is required "
+                "for vLLM LoRA adapter export."
+            )
+            expert_key_map = (
+                expert_lora_vllm_key_map(peft_ref) if target_parameters else None
             )
             adapter_path = save_peft_adapter_for_vllm_rollout(
                 peft_ref,
                 staging_dir,
                 self._vllm_rollout_adapter,
                 target_modules=target_modules,
+                expert_key_map=expert_key_map,
             )
         if self.accelerator is not None:
             self.accelerator.wait_for_everyone()
@@ -6124,6 +6165,14 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                 f"(max_num_seqs={self.vllm_config.max_num_seqs} "
                 f"max_model_len={self.max_model_len})",
                 stacklevel=2,
+            )
+
+        if getattr(self.lora_config, "target_parameters", None) and (
+            patch_vllm_3d_moe_lora_flag(llm_kwargs["model"])
+        ):
+            logger.info(
+                "Marked vLLM %s as taking stacked-3D MoE LoRA adapters.",
+                llm_kwargs["model"],
             )
 
         try:

--- a/agilerl/algorithms/core/llm_ops/fused_lora.py
+++ b/agilerl/algorithms/core/llm_ops/fused_lora.py
@@ -26,7 +26,7 @@ from weakref import WeakKeyDictionary
 
 import torch
 import torch.nn as nn
-from peft.tuners.lora.layer import LoraLayer
+from peft.tuners.lora.layer import LoraLayer, ParamWrapper
 
 # Remembers each model's LoRA layers so we don't rescan on every call.
 # Weak keys: caching a model here never stops it being garbage-collected.
@@ -35,6 +35,38 @@ _LORA_LAYER_CACHE: WeakKeyDictionary[nn.Module, list[LoraLayer]] = WeakKeyDictio
 # Which adapter each layer currently routes to (kept off the layer so it stays typed).
 # Weak keys: tracking a layer here never stops it being garbage-collected.
 _ROUTING_STATE: WeakKeyDictionary[LoraLayer, list[str] | None] = WeakKeyDictionary()
+
+
+def uniform_routed_adapter(layer: LoraLayer) -> str | None:
+    """The single adapter the active routing assigns *layer*, or ``None`` when routing is inactive.
+
+    Parameter-level LoRA applies its delta to whole parameters (and packed
+    experts see rows grouped by expert, not by sample), so only uniform
+    routings are computable there; mixed routings raise.
+    """
+    routing = _ROUTING_STATE.get(layer)
+    if routing is None:
+        return None
+    names = set(routing)
+    if len(names) > 1:
+        msg = (
+            "Fused multi-adapter routing is not supported on parameter-level "
+            "LoRA layers (LoraConfig.target_parameters). Use a single-adapter "
+            "configuration (e.g. use_separate_reference_adapter=False, no "
+            "value head)."
+        )
+        raise RuntimeError(msg)
+    return next(iter(names))
+
+
+def _handles_own_routing(module: LoraLayer) -> bool:
+    """Whether *module*'s class forward consults the routing state itself."""
+    return getattr(module, "_self_routed_lora", False)
+
+
+def _is_routing_managed(module: LoraLayer) -> bool:
+    """Whether *module* will honor fused routing (patched or self-routing)."""
+    return _is_routed_layer(module) or _handles_own_routing(module)
 
 
 def _lora_delta(layer: LoraLayer, adapter: str, rows: torch.Tensor) -> torch.Tensor:
@@ -115,10 +147,63 @@ def _routed_forward(
     return pieces[0] if len(pieces) == 1 else torch.cat(pieces)
 
 
+def _param_wrapper_routed_forward(
+    layer: LoraLayer,
+    original_forward: Callable[..., torch.Tensor],
+    x: torch.Tensor,
+    *forward_args: Any,
+    **forward_kwargs: Any,
+) -> torch.Tensor:
+    """Replacement ``forward`` for parameter-level LoRA wrappers under fused routing.
+
+    The routed adapter runs the ordinary forward; ``"__base__"`` (or a
+    foreign adapter) runs with adapters disabled.
+    """
+    name = uniform_routed_adapter(layer)
+    if name is None:
+        return original_forward(layer, x, *forward_args, **forward_kwargs)
+    if name in layer.lora_A:
+        if list(layer.active_adapters) != [name]:
+            msg = (
+                f"Fused routing requested adapter {name!r} on a "
+                "parameter-level LoRA wrapper whose active adapters are "
+                f"{list(layer.active_adapters)}; set the adapter before "
+                "routing."
+            )
+            raise RuntimeError(msg)
+        return original_forward(layer, x, *forward_args, **forward_kwargs)
+    previously_disabled = layer.disable_adapters
+    layer.enable_adapters(False)
+    try:
+        return original_forward(layer, x, *forward_args, **forward_kwargs)
+    finally:
+        if not previously_disabled:
+            layer.enable_adapters(True)
+
+
 def _is_routed_layer(module: LoraLayer) -> bool:
     """Whether *module* has the fused-routing ``forward`` installed."""
     fwd = module.__dict__.get("forward")
-    return isinstance(fwd, partial) and fwd.func is _routed_forward
+    return isinstance(fwd, partial) and fwd.func in (
+        _routed_forward,
+        _param_wrapper_routed_forward,
+    )
+
+
+def adapter_aligned_chunks(
+    routing: Sequence[str], batch_size: int
+) -> list[tuple[int, int]]:
+    """Micro-batch ``(start, end)`` spans of at most *batch_size* rows that never straddle an adapter run."""
+    chunks: list[tuple[int, int]] = []
+    run_start = 0
+    for _, run in itertools.groupby(routing):
+        run_len = sum(1 for _ in run)
+        chunks.extend(
+            (start, min(start + batch_size, run_start + run_len))
+            for start in range(run_start, run_start + run_len, batch_size)
+        )
+        run_start += run_len
+    return chunks
 
 
 def _store_layer_cache(model: nn.Module, layers: list[LoraLayer]) -> None:
@@ -197,8 +282,13 @@ def patch_lora_for_fused_forward(model: nn.Module) -> None:
         if not isinstance(module, LoraLayer):
             continue
         layers.append(module)
-        if not _is_routed_layer(module):
-            module.forward = partial(_routed_forward, module, type(module).forward)
+        if not _is_routing_managed(module):
+            routed = (
+                _param_wrapper_routed_forward
+                if isinstance(module, ParamWrapper)
+                else _routed_forward
+            )
+            module.forward = partial(routed, module, type(module).forward)
     _store_layer_cache(model, layers)
 
 
@@ -214,7 +304,7 @@ def unpatch_lora_for_fused_forward(model: nn.Module) -> None:
         if _is_routed_layer(module):
             # Drop the monkeypatched instance forward, restoring the class one.
             module.__dict__.pop("forward", None)
-            _ROUTING_STATE.pop(module, None)
+        _ROUTING_STATE.pop(module, None)
     _LORA_LAYER_CACHE.pop(model, None)
 
 
@@ -238,7 +328,7 @@ def set_fused_adapter_routing(model: nn.Module, routing: Sequence[str]) -> None:
         # Plain base model (no adapters) or PEFT not installed: nothing to
         # route, and the unfused forward is already correct.
         return
-    if any(not _is_routed_layer(m) for m in layers):
+    if any(not _is_routing_managed(m) for m in layers):
         msg = (
             "set_fused_adapter_routing called on a model with LoRA layers that "
             "have no fused-routing forward; the routing would be silently "
@@ -262,5 +352,5 @@ def unset_fused_adapter_routing(model: nn.Module) -> None:
     :param model: The model whose LoRA layers should clear fused routing.
     """
     for module in get_cached_lora_layers(model):
-        if _is_routed_layer(module):
+        if _is_routing_managed(module):
             _ROUTING_STATE[module] = None

--- a/agilerl/algorithms/core/llm_ops/moe_lora.py
+++ b/agilerl/algorithms/core/llm_ops/moe_lora.py
@@ -1,0 +1,417 @@
+# Copyright 2026 AgileRL
+# SPDX-License-Identifier: Apache-2.0
+
+"""Split low-rank adapter execution for packed mixture-of-experts weights.
+
+PEFT's ``ParamWrapper`` (``LoraConfig.target_parameters``) supports stacked 3D
+expert weights but applies adapters by materializing the full-rank delta
+``B @ A`` for every expert on every forward — an allocation the size of the
+expert weights themselves, per wrapped parameter, per layer. The wrappers here
+keep the low-rank factorization split instead: tokens are grouped per expert
+and pushed through that expert's rank-``r`` slice of ``lora_A``/``lora_B``, so
+the largest adapter intermediate is ``[tokens, r]``. Wrappers on modules
+matching neither supported calling convention stay on PEFT's default path.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import warnings
+from collections.abc import Sequence
+from functools import cache
+from typing import Any
+
+import torch
+import torch.nn as nn
+from peft.tuners.lora.layer import ParamWrapper
+
+from agilerl.algorithms.core.llm_ops.fused_lora import uniform_routed_adapter
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def _grouped_mm_supported(device_index: int, dtype: torch.dtype) -> bool:
+    """Whether ``torch._grouped_mm`` computes correct results (fwd and bwd, transposed views) here."""
+    if not hasattr(torch, "_grouped_mm"):
+        return False
+    try:
+        device = torch.device("cuda", device_index)
+        generator = torch.Generator(device=device).manual_seed(0)
+        x = torch.randn(8, 16, device=device, dtype=dtype, generator=generator)
+        w = torch.randn(2, 4, 16, device=device, dtype=dtype, generator=generator)
+        x = x.requires_grad_(True)
+        w = w.requires_grad_(True)
+        offs = torch.tensor([5, 8], device=device, dtype=torch.int32)
+        out = torch._grouped_mm(x, w.transpose(-2, -1), offs=offs)
+        reference = torch.cat([x[:5] @ w[0].mT, x[5:] @ w[1].mT])
+        if not torch.allclose(out.float(), reference.float(), atol=1e-2):
+            return False
+        # square() materializes the incoming gradient; the op's backward
+        # rejects the zero-stride expanded grad a bare sum() would feed it.
+        out.square().sum().backward()
+    except Exception:
+        return False
+    return x.grad is not None and w.grad is not None
+
+
+def _use_grouped_mm(x: torch.Tensor) -> bool:
+    """Whether the grouped-GEMM fast path applies to *x*'s device and dtype."""
+    if not x.is_cuda:
+        return False
+    index = x.device.index
+    if index is None:
+        index = torch.cuda.current_device()
+    return _grouped_mm_supported(index, x.dtype)
+
+
+def _counts_list(counts: Sequence[int] | torch.Tensor) -> list[int]:
+    """Per-expert row counts as a plain list (host sync only when needed)."""
+    if isinstance(counts, torch.Tensor):
+        return [int(count) for count in counts.tolist()]
+    return [int(count) for count in counts]
+
+
+def _counts_tensor(
+    counts: Sequence[int] | torch.Tensor, device: torch.device
+) -> torch.Tensor:
+    """Per-expert row counts as a device tensor."""
+    if isinstance(counts, torch.Tensor):
+        return counts
+    return torch.as_tensor(counts, device=device)
+
+
+def _group_offsets(
+    counts: Sequence[int] | torch.Tensor, device: torch.device
+) -> torch.Tensor:
+    """Cumulative per-expert row offsets in the layout ``torch._grouped_mm`` takes."""
+    return torch.cumsum(_counts_tensor(counts, device), dim=0).to(torch.int32)
+
+
+def _dims_aligned(itemsize: int, *dims: int) -> bool:
+    """Whether row strides over these inner dims meet the op's 16-byte alignment."""
+    return all(dim * itemsize % 16 == 0 for dim in dims)
+
+
+def _is_partitioned(*tensors: torch.Tensor) -> bool:
+    """Whether any tensor is a DeepSpeed ZeRO-3 partitioned parameter."""
+    return any(hasattr(t, "ds_id") for t in tensors)
+
+
+def _grouped_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    counts: Sequence[int] | torch.Tensor,
+    offs: torch.Tensor | None = None,
+    *,
+    copy_for_gmm: bool = False,
+) -> torch.Tensor:
+    """Per-expert linear over expert-sorted rows with a stacked ``[experts, out, in]`` weight."""
+    if (
+        x.dtype == weight.dtype
+        and _dims_aligned(x.element_size(), weight.shape[1], weight.shape[2])
+        and _use_grouped_mm(x)
+    ):
+        operand = weight.transpose(-2, -1)
+        if copy_for_gmm:
+            # grouped_mm is only validated for a plain last-two-dims transpose;
+            # weights on other stride patterns are copied (rank-sized here).
+            operand = operand.contiguous()
+        if offs is None:
+            offs = _group_offsets(counts, x.device)
+        return torch._grouped_mm(x, operand, offs=offs)
+    outputs = [
+        nn.functional.linear(rows, weight[expert])
+        for expert, rows in enumerate(x.split(_counts_list(counts)))
+    ]
+    return torch.cat(outputs)
+
+
+def _forward_param_names(module: nn.Module) -> list[str]:
+    """Positional parameter names of a module's ``forward``, excluding ``self``."""
+    try:
+        signature = inspect.signature(type(module).forward)
+    except (TypeError, ValueError):
+        return []
+    return [name for name in signature.parameters if name != "self"]
+
+
+def _is_sorted_experts_module(module: nn.Module) -> bool:
+    """Whether *module* is a grouped linear over expert-sorted rows with a stacked 3D ``weight``."""
+    weight = getattr(module, "weight", None)
+    if not isinstance(weight, torch.Tensor) or weight.ndim != 3:
+        return False
+    return _forward_param_names(module)[:2] == ["inputs", "expert_size"]
+
+
+def _routed_projection_names(module: nn.Module) -> tuple[str, bool] | None:
+    """The up-projection parameter name and gatedness of a self-routing packed-experts block.
+
+    Gated (``gate_up_proj``, Qwen3-MoE/granite: ``act(gate) * up``) and
+    ungated (``up_proj``, NemotronH: ``act(up)``) variants are supported;
+    per-expert biases or other layouts are off-convention and return ``None``.
+    """
+    down = getattr(module, "down_proj", None)
+    if not isinstance(down, torch.Tensor) or down.ndim != 3:
+        return None
+    if not callable(getattr(module, "act_fn", None)):
+        return None
+    if getattr(module, "down_proj_bias", None) is not None:
+        return None
+    if _forward_param_names(module)[:3] != [
+        "hidden_states",
+        "top_k_index",
+        "top_k_weights",
+    ]:
+        return None
+    for up_name, gated in (("gate_up_proj", True), ("up_proj", False)):
+        up = getattr(module, up_name, None)
+        if not isinstance(up, torch.Tensor) or up.ndim != 3:
+            continue
+        if getattr(module, f"{up_name}_bias", None) is not None:
+            continue
+        num_experts, up_out, in_dim = up.shape
+        if gated and up_out % 2:
+            continue
+        intermediate = up_out // 2 if gated else up_out
+        if down.shape == (num_experts, in_dim, intermediate):
+            return up_name, gated
+    return None
+
+
+def _is_routed_experts_module(module: nn.Module) -> bool:
+    """Whether *module* is a self-routing packed-experts block in the transformers-5 convention."""
+    return _routed_projection_names(module) is not None
+
+
+def _expert_counts(
+    expert_size: Sequence[int] | torch.Tensor, num_experts: int
+) -> list[int]:
+    """Normalize a per-expert row-count spec, validating the calling convention."""
+    counts = _counts_list(expert_size)
+    if len(counts) != num_experts:
+        msg = (
+            f"Expected {num_experts} per-expert counts, got {len(counts)}; "
+            "the wrapped experts module does not follow the sorted-rows "
+            "calling convention."
+        )
+        raise ValueError(msg)
+    return counts
+
+
+def _resolve_adapters(wrapper: ParamWrapper) -> list[str]:
+    """Adapter names to apply on this forward, honoring fused routing and adapter state."""
+    routed = uniform_routed_adapter(wrapper)
+    if routed is not None:
+        return [routed] if routed in wrapper.lora_A else []
+    if wrapper.disable_adapters:
+        if wrapper.merged:
+            wrapper.unmerge()
+        return []
+    return [
+        name
+        for name in wrapper.active_adapters
+        if name in wrapper.lora_A and name not in wrapper.merged_adapters
+    ]
+
+
+def _split_lora_delta(
+    wrapper: ParamWrapper,
+    x: torch.Tensor,
+    counts: Sequence[int] | torch.Tensor,
+    adapter: str,
+    offs: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Low-rank delta for expert-sorted rows without materializing per-expert full-rank weights."""
+    lora_a = wrapper.lora_A[adapter]
+    lora_b = wrapper.lora_B[adapter]
+    weight_a = lora_a.weight
+    weight_b = lora_b.weight
+    assert isinstance(weight_a, torch.Tensor)
+    assert isinstance(weight_b, torch.Tensor)
+    scaling = wrapper.scaling[adapter]
+    num_experts = wrapper.num_experts
+    rank = wrapper.r[adapter]
+    x = x.to(weight_a.dtype)
+
+    if _is_partitioned(weight_a, weight_b):
+        # ZeRO-3 shards are only gathered by module pre-forward hooks, so the
+        # adapter Linears run as modules and each token keeps only its own
+        # expert's block: lora_A rows are expert-major, lora_B columns rank-major.
+        total = x.shape[0]
+        expert_ids = torch.repeat_interleave(
+            torch.arange(num_experts, device=x.device),
+            _counts_tensor(counts, x.device),
+        )
+        rows = torch.arange(total, device=x.device)
+        a_full = lora_a(x).view(total, num_experts, rank)
+        gated = torch.zeros(
+            total, rank, num_experts, dtype=a_full.dtype, device=x.device
+        )
+        gated[rows, :, expert_ids] = a_full[rows, expert_ids]
+        return lora_b(gated.reshape(total, rank * num_experts)) * scaling
+
+    a3 = weight_a.view(num_experts, rank, weight_a.shape[1])
+    b3 = weight_b.view(weight_b.shape[0], rank, num_experts)
+    down = _grouped_linear(x, a3, counts, offs)
+    up = _grouped_linear(down, b3.permute(2, 0, 1), counts, offs, copy_for_gmm=True)
+    return up * scaling
+
+
+def _wrapper_chain(wrapper: ParamWrapper) -> dict[str, ParamWrapper]:
+    """Map targeted parameter name to wrapper for a (possibly nested) wrapper chain."""
+    chain: dict[str, ParamWrapper] = {}
+    module: nn.Module = wrapper
+    while isinstance(module, ParamWrapper):
+        chain[module.parameter_name] = module
+        module = module.base_layer
+    return chain
+
+
+class SortedExpertsLoraWrapper(ParamWrapper):
+    """Split-LoRA ``ParamWrapper`` for grouped linears taking expert-sorted rows."""
+
+    _self_routed_lora = True
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        expert_size: Sequence[int] | torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        adapters = _resolve_adapters(self)
+        result = self.base_layer(x, expert_size, *args, **kwargs)
+        if not adapters:
+            return result
+        counts = _expert_counts(expert_size, self.num_experts)
+        offs = _group_offsets(counts, x.device) if x.is_cuda else None
+        for name in adapters:
+            delta = _split_lora_delta(self, x, counts, name, offs)
+            result = result + delta.to(result.dtype)
+        return result
+
+
+class RoutedExpertsLoraWrapper(ParamWrapper):
+    """Split-LoRA ``ParamWrapper`` for self-routing packed-experts modules."""
+
+    _self_routed_lora = True
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if args or kwargs or hidden_states.dim() != 2:
+            return ParamWrapper.forward(
+                self, hidden_states, top_k_index, top_k_weights, *args, **kwargs
+            )
+        chain = _wrapper_chain(self)
+        experts = self.get_base_layer()
+        adapters = {name: _resolve_adapters(w) for name, w in chain.items()}
+        if not any(adapters.values()):
+            return experts(hidden_states, top_k_index, top_k_weights)
+
+        projections = _routed_projection_names(experts)
+        if projections is None:
+            return ParamWrapper.forward(self, hidden_states, top_k_index, top_k_weights)
+        up_name, gated = projections
+        up_weight = getattr(experts, up_name)
+        down_weight = experts.down_proj
+        act_fn = experts.act_fn
+        assert isinstance(up_weight, torch.Tensor)
+        assert isinstance(down_weight, torch.Tensor)
+        assert not isinstance(act_fn, torch.Tensor)
+        if _is_partitioned(up_weight, down_weight):
+            msg = (
+                "Split expert LoRA cannot read ZeRO-3 partitioned expert "
+                "weights outside their owning module's forward. Use ZeRO "
+                "stage <= 2 with expert LoRA on this architecture."
+            )
+            raise RuntimeError(msg)
+
+        num_experts = up_weight.shape[0]
+        top_k = top_k_index.shape[-1]
+        flat_experts = top_k_index.reshape(-1)
+        order = torch.argsort(flat_experts, stable=True)
+        counts = torch.bincount(flat_experts, minlength=num_experts)
+        offs = torch.cumsum(counts, dim=0).to(torch.int32)
+        token_idx = torch.div(order, top_k, rounding_mode="floor")
+        x = hidden_states[token_idx]
+
+        projected = _grouped_linear(x, up_weight, counts, offs)
+        for name in adapters.get(up_name, []):
+            delta = _split_lora_delta(chain[up_name], x, counts, name, offs)
+            projected = projected + delta.to(projected.dtype)
+        if gated:
+            gate, up = projected.chunk(2, dim=-1)
+            intermediate = act_fn(gate) * up
+        else:
+            intermediate = act_fn(projected)
+        down = _grouped_linear(intermediate, down_weight, counts, offs)
+        for name in adapters.get("down_proj", []):
+            delta = _split_lora_delta(
+                chain["down_proj"], intermediate, counts, name, offs
+            )
+            down = down + delta.to(down.dtype)
+
+        routed_weights = top_k_weights.reshape(-1)[order].unsqueeze(-1)
+        result = torch.zeros_like(hidden_states)
+        result.index_add_(0, token_idx, (down * routed_weights).to(result.dtype))
+        return result
+
+
+def upgrade_moe_param_wrappers(model: nn.Module) -> int:
+    """Swap eligible ``ParamWrapper`` instances to split-LoRA execution, returning how many."""
+    wrapped_bases = {
+        id(module.base_layer)
+        for module in model.modules()
+        if isinstance(module, ParamWrapper)
+    }
+    upgraded = 0
+    fallbacks: list[str] = []
+    for name, module in model.named_modules():
+        if not isinstance(module, ParamWrapper) or id(module) in wrapped_bases:
+            continue
+        if type(module) is not ParamWrapper:
+            continue
+        chain = _wrapper_chain(module)
+        base = module.get_base_layer()
+        projections = _routed_projection_names(base)
+        if (
+            len(chain) == 1
+            and module.parameter_name == "weight"
+            and _is_sorted_experts_module(base)
+        ):
+            module.__class__ = SortedExpertsLoraWrapper
+            upgraded += 1
+        elif projections is not None and set(chain) <= {projections[0], "down_proj"}:
+            module.__class__ = RoutedExpertsLoraWrapper
+            upgraded += 1
+        elif module.get_param().ndim == 3:
+            fallbacks.append(name)
+    if fallbacks:
+        warnings.warn(
+            "Packed-experts LoRA wrappers on unrecognized module conventions "
+            "stay on PEFT's delta-materializing forward (memory-hungry): "
+            f"{fallbacks}.",
+            stacklevel=2,
+        )
+    return upgraded
+
+
+def moe_expert_target_parameters(model: nn.Module) -> list[str]:
+    """Parameter-path suffixes of packed expert weights for ``LoraConfig.target_parameters``."""
+    suffixes: set[str] = set()
+    for name, module in model.named_modules():
+        prefix = ".".join(name.split(".")[-2:])
+        if _is_sorted_experts_module(module):
+            suffixes.add(f"{prefix}.weight")
+        elif (projections := _routed_projection_names(module)) is not None:
+            suffixes.add(f"{prefix}.{projections[0]}")
+            suffixes.add(f"{prefix}.down_proj")
+    return sorted(suffixes)

--- a/agilerl/algorithms/core/llm_ops/vllm_colocate.py
+++ b/agilerl/algorithms/core/llm_ops/vllm_colocate.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "get_vllm_internal_model",
+    "patch_vllm_3d_moe_lora_flag",
     "patch_vllm_lora_keep_resident",
     "patch_vllm_strip_multimodal_towers",
 ]
@@ -129,6 +130,33 @@ def patch_vllm_strip_multimodal_towers(
     return freed
 
 
+def patch_vllm_3d_moe_lora_flag(model_name_or_path: str) -> bool:
+    """Mark the model's vLLM class as taking stacked-3D MoE LoRA adapters.
+
+    vLLM only parses the stacked-experts (PEFT ``target_parameters``) adapter
+    format when the model class declares ``is_3d_moe_weight``; classes
+    predating the flag reject the adapter in ``add_lora``. Call before engine
+    construction — the colocated in-process worker then sees the class patch.
+    """
+    try:
+        from transformers import AutoConfig
+        from vllm.model_executor.models.registry import ModelRegistry
+
+        architecture = AutoConfig.from_pretrained(model_name_or_path).architectures[0]
+        entry = getattr(ModelRegistry, "models", {}).get(architecture)
+        if entry is not None:
+            model_cls = entry.load_model_cls()
+        else:
+            # Older vLLM without the lazy-entry mapping.
+            model_cls, _ = ModelRegistry.resolve_model_cls(architecture)
+    except Exception:
+        return False
+    if getattr(model_cls, "is_3d_moe_weight", False):
+        return False
+    model_cls.is_3d_moe_weight = True
+    return True
+
+
 def patch_vllm_lora_keep_resident(llm: Any) -> int:  # noqa: ANN401 -- opaque vLLM engine handle walked via getattr
     """Keep vLLM's LoRA slot weights resident by neutralizing ``reset_lora``.
 
@@ -153,10 +181,14 @@ def patch_vllm_lora_keep_resident(llm: Any) -> int:  # noqa: ANN401 -- opaque vL
 
     count = 0
     for module in model.modules():
-        # A LoRA-wrapped layer exposes both reset_lora and the stacked GPU slot.
+        # A LoRA-wrapped layer exposes reset_lora and a stacked GPU slot
+        # (lora_b_stacked on linears, w13/w2_lora_b_stacked on fused MoE).
         if (
             hasattr(module, "reset_lora")
-            and hasattr(module, "lora_b_stacked")
+            and (
+                hasattr(module, "lora_b_stacked")
+                or hasattr(module, "w13_lora_b_stacked")
+            )
             and not getattr(module, "_agilerl_lora_resident", False)
         ):
             # Deliberate monkeypatch of a live vLLM module.

--- a/agilerl/models/networks.py
+++ b/agilerl/models/networks.py
@@ -443,6 +443,9 @@ class LoraConfigDict(BaseModel):
     lora_r: int = Field(default=16, ge=1)
     lora_alpha: int = Field(default=32, ge=1)
     target_modules: list[str] | str | set[str] = Field(default="all-linear")
+    # Packed MoE expert parameter paths (PEFT ``target_parameters``), e.g.
+    # ["block_sparse_moe.experts.gate_up_proj", ...]; requires lora_dropout=0.
+    target_parameters: list[str] | None = Field(default=None)
     task_type: str = Field(default="CAUSAL_LM", min_length=1)
     lora_dropout: float = Field(default=0.05, ge=0.0, le=1.0)
 
@@ -475,10 +478,12 @@ def _peft_lora_config_to_manifest_dict(cfg: LoraConfig) -> dict[str, Any]:
     else:
         tm_out = tm
 
+    target_parameters = getattr(cfg, "target_parameters", None)
     return {
         "lora_r": cfg.r,
         "lora_alpha": cfg.lora_alpha,
         "target_modules": tm_out,
+        "target_parameters": (sorted(target_parameters) if target_parameters else None),
         "task_type": task_type,
         "lora_dropout": cfg.lora_dropout,
     }

--- a/agilerl/utils/algo_utils.py
+++ b/agilerl/utils/algo_utils.py
@@ -71,6 +71,8 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
     from peft import PeftConfig, PeftModel, get_peft_model
     from transformers import PreTrainedModel
 
+    from agilerl.algorithms.core.llm_ops.moe_lora import upgrade_moe_param_wrappers
+
     PreTrainedModelType = PeftModel | PreTrainedModel
 else:
     # Annotations referencing PreTrainedModelType are evaluated at function
@@ -2612,6 +2614,8 @@ def clone_llm(
             for name, param in model.named_parameters():
                 if "lora" in name and param.dtype != torch.bfloat16:
                     param.data = param.data.to(torch.bfloat16)
+        if getattr(peft_configs[first_adapter], "target_parameters", None):
+            upgrade_moe_param_wrappers(model)
         model.disable_adapter()
 
     if state_dict is not None:

--- a/agilerl/utils/llm_utils.py
+++ b/agilerl/utils/llm_utils.py
@@ -2245,15 +2245,58 @@ def remap_peft_lora_key_for_vllm(key: str) -> str:
     return key.replace(".base_layer.", ".")
 
 
+def expert_lora_vllm_key_map(peft_model: nn.Module) -> dict[str, str]:
+    """Map packed-experts LoRA module keys to the paths vLLM's fused-MoE loader reads (down on ``<experts>``, gate/up on ``<experts>.base_layer``)."""
+    from peft.tuners.lora.layer import ParamWrapper
+
+    key_map: dict[str, str] = {}
+    unmapped: list[str] = []
+    for name, module in peft_model.named_modules():
+        if not isinstance(module, ParamWrapper):
+            continue
+        experts_path = name
+        while experts_path.endswith(".base_layer"):
+            experts_path = experts_path.removesuffix(".base_layer")
+        parameter_name = module.parameter_name
+        parent, _, leaf = experts_path.rpartition(".")
+        sibling_prefix = f"{parent}." if parent else ""
+        if parameter_name in ("gate_up_proj", "up_proj"):
+            key_map[name] = f"{experts_path}.base_layer"
+        elif parameter_name == "down_proj":
+            key_map[name] = experts_path
+        elif parameter_name == "weight" and leaf == "input_linear":
+            key_map[name] = f"{sibling_prefix}experts.base_layer"
+        elif parameter_name == "weight" and leaf == "output_linear":
+            key_map[name] = f"{sibling_prefix}experts"
+        else:
+            unmapped.append(f"{name} ({parameter_name})")
+    if unmapped:
+        msg = (
+            "No vLLM fused-MoE LoRA mapping for wrapped parameters "
+            f"{unmapped}; rollout would silently diverge from the trainer "
+            "policy. Restrict target_parameters to supported experts modules."
+        )
+        raise ValueError(msg)
+    return key_map
+
+
 def filter_peft_state_dict_for_vllm_lora(
     state_dict: dict[str, torch.Tensor],
-    target_modules: str | list[str],
+    target_modules: str | list[str] | None,
+    *,
+    expert_key_map: dict[str, str] | None = None,
 ) -> dict[str, torch.Tensor]:
-    """Keep LoRA tensors whose modules match the trainer ``target_modules`` spec."""
+    """Keep LoRA tensors whose modules match the trainer ``target_modules`` spec or expert map."""
     filtered: dict[str, torch.Tensor] = {}
     for key, tensor in state_dict.items():
         module_key = peft_lora_state_dict_key_to_module_key(key)
-        if not peft_target_key_matches(module_key, target_modules):
+        if expert_key_map is not None and module_key in expert_key_map:
+            suffix = key.removeprefix(module_key)
+            filtered[f"{expert_key_map[module_key]}{suffix}"] = tensor
+            continue
+        if target_modules is None or not peft_target_key_matches(
+            module_key, target_modules
+        ):
             continue
         filtered[remap_peft_lora_key_for_vllm(key)] = tensor
     return filtered
@@ -2277,14 +2320,16 @@ def save_peft_adapter_for_vllm_rollout(
     staging_dir: Path | str,
     adapter_name: str,
     *,
-    target_modules: str | list[str],
+    target_modules: str | list[str] | None,
+    expert_key_map: dict[str, str] | None = None,
 ) -> Path:
     """Export a PEFT adapter checkpoint that vLLM can load for colocated rollout.
 
     Keeps only tensors that match the same ``target_modules`` spec used for PEFT
-    training (from :func:`adapt_lora_config_for_model`). Rewrites ClippableLinear
-    ``.linear`` suffixes in keys for vLLM. ``staging_dir`` must be
-    process-private (AgileRL stages per-rank when distributed): every caller
+    training (from :func:`adapt_lora_config_for_model`) or the packed-experts
+    ``expert_key_map`` (from :func:`expert_lora_vllm_key_map`). Rewrites
+    ClippableLinear ``.linear`` suffixes in keys for vLLM. ``staging_dir`` must
+    be process-private (AgileRL stages per-rank when distributed): every caller
     writes the adapter files.
     """
     if not HAS_LLM_DEPENDENCIES:
@@ -2297,7 +2342,9 @@ def save_peft_adapter_for_vllm_rollout(
     adapter_path = Path(staging_dir) / adapter_name
     state = get_peft_model_state_dict(peft_model, adapter_name=adapter_name)
     n_before = len(state)
-    state = filter_peft_state_dict_for_vllm_lora(state, target_modules)
+    state = filter_peft_state_dict_for_vllm_lora(
+        state, target_modules, expert_key_map=expert_key_map
+    )
     if not state:
         msg = (
             f"No LoRA tensors left for vLLM export after filtering with "
@@ -2321,7 +2368,7 @@ def save_peft_adapter_for_vllm_rollout(
     cfg_dict: dict[str, JSONValue] = {
         str(key): _json_safe_value(value) for key, value in peft_cfg.to_dict().items()
     }
-    cfg_dict["target_modules"] = _json_safe_value(target_modules)
+    cfg_dict["target_modules"] = _json_safe_value(target_modules or [])
 
     import json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ include = ["agilerl", "agilerl/arena"]
 include = [
     "agilerl/algorithms/core/base.py",
     "agilerl/algorithms/core/llm_ops/fused_loss.py",
+    "agilerl/algorithms/core/llm_ops/vllm_colocate.py",
     "agilerl/algorithms/grpo.py",
     "agilerl/algorithms/sft.py",
     "agilerl/utils/llm_utils.py",

--- a/tests/test_algorithms/test_llm_ops/test_moe_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_moe_lora.py
@@ -1,0 +1,598 @@
+# Copyright 2026 AgileRL
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+
+import pytest
+import torch
+import torch.nn.functional as F
+from peft import LoraConfig, inject_adapter_in_model
+from peft.tuners.lora.layer import ParamWrapper
+from torch import nn
+
+from agilerl.algorithms.core.llm_ops.fused_lora import (
+    adapter_aligned_chunks,
+    patch_lora_for_fused_forward,
+    set_fused_adapter_routing,
+    unpatch_lora_for_fused_forward,
+    unset_fused_adapter_routing,
+)
+from agilerl.algorithms.core.llm_ops.moe_lora import (
+    RoutedExpertsLoraWrapper,
+    SortedExpertsLoraWrapper,
+    moe_expert_target_parameters,
+    upgrade_moe_param_wrappers,
+)
+from agilerl.utils.llm_utils import (
+    expert_lora_vllm_key_map,
+    filter_peft_state_dict_for_vllm_lora,
+)
+
+NUM_EXPERTS = 4
+TOP_K = 2
+HIDDEN = 8
+INTERMEDIATE = 6
+
+
+class _SortedExperts(nn.Module):
+    """Grouped linear over expert-sorted rows (GraniteMoe ``ParallelExperts`` convention)."""
+
+    def __init__(self, input_size: int, output_size: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.randn(NUM_EXPERTS, output_size, input_size) * 0.1
+        )
+        self.num_experts = NUM_EXPERTS
+
+    def forward(self, inputs, expert_size):
+        rows = inputs.split(expert_size, dim=0)
+        return torch.cat(
+            [F.linear(rows[e], self.weight[e]) for e in range(self.num_experts)]
+        )
+
+
+class _SortedMoeBlock(nn.Module):
+    """Routing parent for :class:`_SortedExperts`, mirroring GraniteMoeHybridMoE."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.router = nn.Linear(HIDDEN, NUM_EXPERTS, bias=False)
+        self.input_linear = _SortedExperts(HIDDEN, 2 * INTERMEDIATE)
+        self.output_linear = _SortedExperts(INTERMEDIATE, HIDDEN)
+
+    def forward(self, hidden_states):
+        logits = self.router(hidden_states)
+        top_k_logits, top_k_indices = logits.topk(TOP_K, dim=1)
+        gates = torch.softmax(top_k_logits, dim=1)
+        flat_experts = top_k_indices.flatten()
+        expert_size = (
+            torch.bincount(flat_experts, minlength=NUM_EXPERTS).long().tolist()
+        )
+        order = flat_experts.argsort(stable=True)
+        batch_index = order.div(TOP_K, rounding_mode="trunc")
+        expert_inputs = hidden_states[batch_index]
+        inner = self.input_linear(expert_inputs, expert_size)
+        gate, up = inner.chunk(2, dim=-1)
+        expert_outputs = self.output_linear(F.silu(gate) * up, expert_size)
+        expert_outputs = expert_outputs * gates.flatten()[order, None]
+        out = torch.zeros_like(hidden_states)
+        return out.index_add(0, batch_index, expert_outputs)
+
+
+class _RoutedExperts(nn.Module):
+    """Self-routing packed experts (transformers-5 ``Qwen3MoeExperts`` convention)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_experts = NUM_EXPERTS
+        self.gate_up_proj = nn.Parameter(
+            torch.randn(NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN) * 0.1
+        )
+        self.down_proj = nn.Parameter(
+            torch.randn(NUM_EXPERTS, HIDDEN, INTERMEDIATE) * 0.1
+        )
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        final = torch.zeros_like(hidden_states)
+        expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts)
+        expert_mask = expert_mask.permute(2, 1, 0)
+        for expert_idx in range(self.num_experts):
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current = hidden_states[token_idx]
+            gate, up = F.linear(current, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
+            current = F.linear(self.act_fn(gate) * up, self.down_proj[expert_idx])
+            current = current * top_k_weights[token_idx, top_k_pos, None]
+            final.index_add_(0, token_idx, current)
+        return final
+
+
+class _RoutedMoeBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.router = nn.Linear(HIDDEN, NUM_EXPERTS, bias=False)
+        self.experts = _RoutedExperts()
+
+    def forward(self, hidden_states):
+        logits = self.router(hidden_states)
+        top_k_weights, top_k_index = torch.softmax(logits, dim=-1).topk(TOP_K, dim=-1)
+        return self.experts(hidden_states, top_k_index, top_k_weights)
+
+
+class _UngatedExperts(nn.Module):
+    """Self-routing packed experts without a gate (NemotronH convention)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_experts = NUM_EXPERTS
+        self.up_proj = nn.Parameter(
+            torch.randn(NUM_EXPERTS, INTERMEDIATE, HIDDEN) * 0.1
+        )
+        self.down_proj = nn.Parameter(
+            torch.randn(NUM_EXPERTS, HIDDEN, INTERMEDIATE) * 0.1
+        )
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        final = torch.zeros_like(hidden_states)
+        expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts)
+        expert_mask = expert_mask.permute(2, 1, 0)
+        for expert_idx in range(self.num_experts):
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current = F.linear(hidden_states[token_idx], self.up_proj[expert_idx])
+            current = F.linear(self.act_fn(current), self.down_proj[expert_idx])
+            current = current * top_k_weights[token_idx, top_k_pos, None]
+            final.index_add_(0, token_idx, current)
+        return final
+
+
+class _UngatedMoeBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.router = nn.Linear(HIDDEN, NUM_EXPERTS, bias=False)
+        self.experts = _UngatedExperts()
+
+    def forward(self, hidden_states):
+        logits = self.router(hidden_states)
+        top_k_weights, top_k_index = torch.softmax(logits, dim=-1).topk(TOP_K, dim=-1)
+        return self.experts(hidden_states, top_k_index, top_k_weights)
+
+
+def _lora_config(target_parameters, **overrides):
+    config = {
+        "r": 2,
+        "lora_alpha": 4,
+        "target_modules": [],
+        "target_parameters": target_parameters,
+        "lora_dropout": 0.0,
+        "init_lora_weights": False,
+    }
+    config.update(overrides)
+    return LoraConfig(**config)
+
+
+def _build_pair(block_cls, target_parameters):
+    """A (reference, upgraded) pair of adapter-injected blocks with identical weights."""
+    torch.manual_seed(0)
+    reference = inject_adapter_in_model(
+        _lora_config(target_parameters), block_cls(), adapter_name="actor"
+    )
+    torch.manual_seed(0)
+    upgraded = inject_adapter_in_model(
+        _lora_config(target_parameters), block_cls(), adapter_name="actor"
+    )
+    assert upgrade_moe_param_wrappers(upgraded) > 0
+    return reference, upgraded
+
+
+def _sorted_pair():
+    return _build_pair(_SortedMoeBlock, ["input_linear.weight", "output_linear.weight"])
+
+
+def _routed_pair():
+    return _build_pair(_RoutedMoeBlock, ["experts.gate_up_proj", "experts.down_proj"])
+
+
+def _ungated_pair():
+    return _build_pair(_UngatedMoeBlock, ["experts.up_proj", "experts.down_proj"])
+
+
+def _wrappers(model):
+    return [m for m in model.modules() if isinstance(m, ParamWrapper)]
+
+
+def _assert_grad_parity(reference, upgraded, atol):
+    ref_grads = {
+        name: p.grad for name, p in reference.named_parameters() if p.grad is not None
+    }
+    up_grads = {
+        name: p.grad for name, p in upgraded.named_parameters() if p.grad is not None
+    }
+    assert set(ref_grads) == set(up_grads)
+    assert any("lora" in name for name in ref_grads)
+    for name, grad in ref_grads.items():
+        assert torch.allclose(grad, up_grads[name], atol=atol), name
+
+
+@pytest.fixture(autouse=True)
+def _seed():
+    torch.manual_seed(42)
+
+
+@pytest.mark.parametrize("pair_factory", [_sorted_pair, _routed_pair, _ungated_pair])
+def test_split_lora_matches_peft_default(pair_factory):
+    reference, upgraded = pair_factory()
+    x = torch.randn(12, HIDDEN)
+
+    ref_out = reference(x)
+    up_out = upgraded(x)
+    assert torch.allclose(ref_out, up_out, atol=1e-6)
+
+    ref_out.square().mean().backward()
+    up_out.square().mean().backward()
+    _assert_grad_parity(reference, upgraded, atol=1e-5)
+
+
+def test_upgrade_selects_wrapper_classes():
+    _, sorted_block = _sorted_pair()
+    assert {type(m) for m in _wrappers(sorted_block)} == {SortedExpertsLoraWrapper}
+
+    _, routed_block = _routed_pair()
+    # Only the outer wrapper of the nested chain is upgraded; the inner one is
+    # bypassed by the outer's replacement forward.
+    assert RoutedExpertsLoraWrapper in {type(m) for m in _wrappers(routed_block)}
+
+    _, ungated_block = _ungated_pair()
+    assert RoutedExpertsLoraWrapper in {type(m) for m in _wrappers(ungated_block)}
+
+
+class _OddExperts(nn.Module):
+    """A stacked 3D weight used through neither supported calling convention."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(NUM_EXPERTS, 6, HIDDEN))
+
+    def forward(self, x):
+        return torch.einsum("th,eoh->teo", x, self.weight).mean(1)
+
+
+def _odd_model():
+    model = nn.Sequential()
+    model.odd = _OddExperts()
+    return model
+
+
+def test_upgrade_is_idempotent_and_skips_unknown_conventions():
+    model = inject_adapter_in_model(
+        _lora_config(["odd.weight"]), _odd_model(), adapter_name="actor"
+    )
+    with pytest.warns(UserWarning, match="unrecognized module conventions"):
+        assert upgrade_moe_param_wrappers(model) == 0
+
+    _, upgraded = _sorted_pair()
+    assert upgrade_moe_param_wrappers(upgraded) == 0
+
+
+def test_disabled_adapters_match_base():
+    torch.manual_seed(0)
+    base = _SortedMoeBlock()
+    upgraded = inject_adapter_in_model(
+        _lora_config(["input_linear.weight", "output_linear.weight"]),
+        copy.deepcopy(base),
+        adapter_name="actor",
+    )
+    upgrade_moe_param_wrappers(upgraded)
+    for module in _wrappers(upgraded):
+        module.enable_adapters(False)
+    x = torch.randn(10, HIDDEN)
+    assert torch.allclose(upgraded(x), base(x), atol=1e-6)
+
+
+def test_merged_adapters_match_split_forward():
+    _, upgraded = _sorted_pair()
+    x = torch.randn(10, HIDDEN)
+    with torch.no_grad():
+        split_out = upgraded(x)
+        for module in _wrappers(upgraded):
+            module.merge()
+        merged_out = upgraded(x)
+        for module in _wrappers(upgraded):
+            module.unmerge()
+        unmerged_out = upgraded(x)
+    assert torch.allclose(split_out, merged_out, atol=1e-5)
+    assert torch.allclose(split_out, unmerged_out, atol=1e-5)
+
+
+def test_zero3_partitioned_adapters_use_module_call_path():
+    reference, upgraded = _sorted_pair()
+    for module in _wrappers(upgraded):
+        for adapter in module.lora_A:
+            module.lora_A[adapter].weight.ds_id = 1
+            module.lora_B[adapter].weight.ds_id = 1
+    x = torch.randn(10, HIDDEN)
+    assert torch.allclose(reference(x), upgraded(x), atol=1e-5)
+
+
+def test_zero3_partitioned_base_weights_raise_on_routed_convention():
+    _, upgraded = _routed_pair()
+    experts = _wrappers(upgraded)[0].get_base_layer()
+    experts.gate_up_proj.ds_id = 1
+    with pytest.raises(RuntimeError, match="ZeRO-3 partitioned expert weights"):
+        upgraded(torch.randn(10, HIDDEN))
+
+
+@pytest.mark.parametrize("pair_factory", [_sorted_pair, _routed_pair, _ungated_pair])
+def test_fused_routing_uniform_and_base(pair_factory):
+    _, upgraded = pair_factory()
+    patch_lora_for_fused_forward(upgraded)
+    x = torch.randn(12, HIDDEN)
+    with torch.no_grad():
+        plain = upgraded(x)
+
+        set_fused_adapter_routing(upgraded, ["actor"] * 12)
+        routed = upgraded(x)
+        unset_fused_adapter_routing(upgraded)
+
+        set_fused_adapter_routing(upgraded, ["__base__"] * 12)
+        base_routed = upgraded(x)
+        unset_fused_adapter_routing(upgraded)
+
+        for module in _wrappers(upgraded):
+            module.enable_adapters(False)
+        base = upgraded(x)
+    assert torch.allclose(routed, plain, atol=1e-6)
+    assert torch.allclose(base_routed, base, atol=1e-6)
+    unpatch_lora_for_fused_forward(upgraded)
+
+
+def test_fused_mixed_routing_raises():
+    _, upgraded = _sorted_pair()
+    patch_lora_for_fused_forward(upgraded)
+    set_fused_adapter_routing(upgraded, ["actor"] * 6 + ["__base__"] * 6)
+    with pytest.raises(RuntimeError, match="Fused multi-adapter routing"):
+        upgraded(torch.randn(12, HIDDEN))
+    unset_fused_adapter_routing(upgraded)
+    unpatch_lora_for_fused_forward(upgraded)
+
+
+def test_fused_mixed_routing_raises_on_fallback_param_wrapper():
+    model = inject_adapter_in_model(
+        _lora_config(["odd.weight"]), _odd_model(), adapter_name="actor"
+    )
+    with pytest.warns(UserWarning, match="unrecognized module conventions"):
+        upgrade_moe_param_wrappers(model)
+    patch_lora_for_fused_forward(model)
+    x = torch.randn(12, HIDDEN)
+    with torch.no_grad():
+        set_fused_adapter_routing(model, ["actor"] * 12)
+        uniform = model(x)
+        unset_fused_adapter_routing(model)
+        plain = model(x)
+        set_fused_adapter_routing(model, ["actor"] * 6 + ["__base__"] * 6)
+        with pytest.raises(RuntimeError, match="parameter-level LoRA"):
+            model(x)
+        unset_fused_adapter_routing(model)
+    assert torch.allclose(uniform, plain, atol=1e-6)
+    unpatch_lora_for_fused_forward(model)
+
+
+def test_adapter_aligned_chunks():
+    routing = ["ref"] * 5 + ["actor"] * 5
+    assert adapter_aligned_chunks(routing, 4) == [(0, 4), (4, 5), (5, 9), (9, 10)]
+    assert adapter_aligned_chunks(routing, 5) == [(0, 5), (5, 10)]
+    assert adapter_aligned_chunks(["actor"] * 4, 8) == [(0, 4)]
+
+
+def test_moe_expert_target_parameters_detects_both_conventions():
+    assert moe_expert_target_parameters(_SortedMoeBlock()) == [
+        "input_linear.weight",
+        "output_linear.weight",
+    ]
+    routed = nn.Sequential()
+    routed.moe = _RoutedMoeBlock()
+    assert moe_expert_target_parameters(routed) == [
+        "moe.experts.down_proj",
+        "moe.experts.gate_up_proj",
+    ]
+    ungated = nn.Sequential()
+    ungated.mixer = _UngatedMoeBlock()
+    assert moe_expert_target_parameters(ungated) == [
+        "mixer.experts.down_proj",
+        "mixer.experts.up_proj",
+    ]
+
+
+def test_expert_lora_vllm_key_map_and_filter():
+    _, sorted_block = _sorted_pair()
+    key_map = expert_lora_vllm_key_map(sorted_block)
+    assert key_map == {
+        "input_linear": "experts.base_layer",
+        "output_linear": "experts",
+    }, key_map
+
+    _, routed_block = _routed_pair()
+    key_map = expert_lora_vllm_key_map(routed_block)
+    # Whatever the nesting order, gate_up lands on <experts>.base_layer and
+    # down on <experts> — the file format vLLM's fused-MoE loader parses.
+    assert set(key_map.values()) == {"experts", "experts.base_layer"}
+    gate_up_key = next(
+        name
+        for name, module in routed_block.named_modules()
+        if isinstance(module, ParamWrapper) and module.parameter_name == "gate_up_proj"
+    )
+    assert key_map[gate_up_key] == "experts.base_layer"
+
+    state = {
+        f"{gate_up_key}.lora_A.weight": torch.zeros(2, 2),
+        "other.lora_A.weight": torch.zeros(2, 2),
+    }
+    filtered = filter_peft_state_dict_for_vllm_lora(state, None, expert_key_map=key_map)
+    assert list(filtered) == ["experts.base_layer.lora_A.weight"]
+
+    _, ungated_block = _ungated_pair()
+    key_map = expert_lora_vllm_key_map(ungated_block)
+    up_key = next(
+        name
+        for name, module in ungated_block.named_modules()
+        if isinstance(module, ParamWrapper) and module.parameter_name == "up_proj"
+    )
+    assert key_map[up_key] == "experts.base_layer"
+
+
+def test_expert_lora_vllm_key_map_raises_on_unknown_parameter():
+    class _Mystery(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.mystery = nn.Parameter(torch.randn(NUM_EXPERTS, 6, HIDDEN))
+
+        def forward(self, x):
+            return x
+
+    model = nn.Sequential()
+    model.blk = _Mystery()
+    model = inject_adapter_in_model(
+        _lora_config(["blk.mystery"]), model, adapter_name="actor"
+    )
+    with pytest.raises(ValueError, match="No vLLM fused-MoE LoRA mapping"):
+        expert_lora_vllm_key_map(model)
+
+
+def _tiny_granite_hybrid():
+    from transformers import GraniteMoeHybridConfig, GraniteMoeHybridForCausalLM
+
+    config = GraniteMoeHybridConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        layer_types=["mamba", "attention"],
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        shared_intermediate_size=32,
+        mamba_n_heads=4,
+        mamba_d_head=16,
+        mamba_n_groups=1,
+        mamba_d_state=8,
+        mamba_d_conv=2,
+        mamba_expand=2,
+        max_position_embeddings=64,
+    )
+    return GraniteMoeHybridForCausalLM(config).float()
+
+
+def _tiny_qwen3_moe():
+    from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+    config = Qwen3MoeConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=32,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_experts=4,
+        num_experts_per_tok=2,
+        decoder_sparse_step=1,
+        max_position_embeddings=64,
+        head_dim=16,
+    )
+    return Qwen3MoeForCausalLM(config).float()
+
+
+@pytest.mark.parametrize(
+    ("build", "expected_targets"),
+    [
+        (
+            # transformers >= 5.13 packs granite experts in the standard routed
+            # convention; the sorted ParallelExperts convention stays covered by
+            # the synthetic tests above.
+            _tiny_granite_hybrid,
+            [
+                "block_sparse_moe.experts.down_proj",
+                "block_sparse_moe.experts.gate_up_proj",
+            ],
+        ),
+        (
+            _tiny_qwen3_moe,
+            ["mlp.experts.down_proj", "mlp.experts.gate_up_proj"],
+        ),
+    ],
+    ids=["granite_hybrid", "qwen3_moe"],
+)
+def test_transformers_integration_parity(build, expected_targets):
+    from peft import get_peft_model
+
+    torch.manual_seed(0)
+    base = build()
+    assert moe_expert_target_parameters(base) == expected_targets
+
+    lora_config = LoraConfig(
+        r=4,
+        lora_alpha=8,
+        lora_dropout=0.0,
+        target_modules=["q_proj", "v_proj"],
+        target_parameters=expected_targets,
+        init_lora_weights=False,
+        task_type="CAUSAL_LM",
+    )
+    reference = get_peft_model(copy.deepcopy(base), lora_config, adapter_name="actor")
+    upgraded = get_peft_model(copy.deepcopy(base), lora_config, adapter_name="actor")
+    upgraded.load_state_dict(reference.state_dict())
+    assert upgrade_moe_param_wrappers(upgraded) > 0
+    assert any(type(m) is RoutedExpertsLoraWrapper for m in upgraded.modules())
+
+    ids = torch.randint(0, 64, (2, 10))
+    ref_out = reference(input_ids=ids).logits
+    up_out = upgraded(input_ids=ids).logits
+    assert torch.allclose(ref_out, up_out, atol=5e-5)
+
+    ref_out.square().mean().backward()
+    up_out.square().mean().backward()
+    _assert_grad_parity(reference, upgraded, atol=5e-4)
+
+    key_map = expert_lora_vllm_key_map(upgraded)
+    assert len(key_map) == 4  # two wrapped parameters in each of two MoE layers
+    for vllm_key in key_map.values():
+        assert vllm_key.endswith((".experts", ".experts.base_layer"))
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="grouped-GEMM path is CUDA-only"
+)
+def test_grouped_mm_fast_path_matches_loop_on_cuda():
+    from agilerl.algorithms.core.llm_ops import moe_lora
+
+    torch.manual_seed(0)
+    reference = inject_adapter_in_model(
+        _lora_config(["experts.gate_up_proj", "experts.down_proj"]),
+        _RoutedMoeBlock(),
+        adapter_name="actor",
+    )
+    torch.manual_seed(0)
+    fast = inject_adapter_in_model(
+        _lora_config(["experts.gate_up_proj", "experts.down_proj"]),
+        _RoutedMoeBlock(),
+        adapter_name="actor",
+    )
+    upgrade_moe_param_wrappers(reference)
+    upgrade_moe_param_wrappers(fast)
+    reference.cuda()
+    fast.cuda()
+
+    x = torch.randn(64, HIDDEN, device="cuda")
+    fast_out = fast(x)
+    if not moe_lora._use_grouped_mm(x):
+        pytest.skip("torch._grouped_mm unsupported on this GPU")
+    with pytest.MonkeyPatch.context() as mp:
+        # Force the loop path on the reference copy.
+        mp.setattr(moe_lora, "_use_grouped_mm", lambda _x: False)
+        ref_out = reference(x)
+    assert torch.allclose(ref_out, fast_out, atol=1e-5)
+
+    ref_out.square().mean().backward()
+    fast_out.square().mean().backward()
+    _assert_grad_parity(reference, fast, atol=1e-4)

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -239,6 +239,29 @@ class TestFinetuningNetworkSpec:
         assert spec.lora_config.r == 8
 
     @pytest.mark.skipif(not HAS_LLM_DEPENDENCIES, reason="LLM deps not installed")
+    def test_target_parameters_round_trip(self):
+        """Manifest target_parameters resolves to and from PEFT LoraConfig."""
+        experts = [
+            "block_sparse_moe.experts.down_proj",
+            "block_sparse_moe.experts.gate_up_proj",
+        ]
+        spec = FinetuningNetworkSpec(
+            pretrained_model_name_or_path="gpt2",
+            max_context_length=512,
+            lora_config={
+                "lora_r": 8,
+                "target_modules": ["q_proj", "v_proj"],
+                "target_parameters": experts,
+                "lora_dropout": 0.0,
+            },
+        )
+        assert spec.lora_config is not None
+        assert list(spec.lora_config.target_parameters) == experts
+
+        dumped = spec.model_dump(mode="json")
+        assert dumped["lora_config"]["target_parameters"] == experts
+
+    @pytest.mark.skipif(not HAS_LLM_DEPENDENCIES, reason="LLM deps not installed")
     def test_coerce_peft_lora_none_target_modules(self):
         """PEFT LoraConfig with target_modules=None maps to all-linear."""
         from peft import LoraConfig, TaskType


### PR DESCRIPTION
## USER GUIDE

LoRA can now target packed MoE expert weights (stacked 3D `nn.Parameter`s) from a manifest. One new field, two constraints:

**`lora_config.target_parameters`** *(list[str], default null — new)* — parameter-path suffixes of the packed expert weights to adapt:

| Model family | target_parameters |
|---|---|
| Granite-4.0 hybrid (transformers ≥ 5.13) | `block_sparse_moe.experts.gate_up_proj`, `block_sparse_moe.experts.down_proj` |
| Qwen3-MoE | `mlp.experts.gate_up_proj`, `mlp.experts.down_proj` |
| Nemotron 3 / NemotronH MoE (ungated experts) | `mixer.experts.up_proj`, `mixer.experts.down_proj` |
| anything else | `moe_expert_target_parameters(model)` from `agilerl.algorithms.core.llm_ops.moe_lora` derives them |

**`lora_config.lora_dropout`** — must be `0.0` when `target_parameters` is set (PEFT cannot factor dropout out of parameter-level LoRA; init raises otherwise).

**`lora_config.target_modules`** — set explicitly (e.g. attention projections). Avoid `all-linear` with MoE models: it also wraps the router gate, which should stay frozen.

Algorithm constraints (validated at init): single adapter only — `use_separate_reference_adapter: false`, no value head.

Example — granite-4.0-h-tiny:

```yaml
lora_config:
  lora_r: 16
  lora_alpha: 32
  lora_dropout: 0.0
  target_modules: [q_proj, k_proj, v_proj, o_proj]
  target_parameters:
    - block_sparse_moe.experts.gate_up_proj
    - block_sparse_moe.experts.down_proj
```

Example — Nemotron 3 Nano 30B-A3B (ungated experts; note `up_proj`, not `gate_up_proj`, and the shared expert stays reachable via `target_modules`):

```yaml
lora_config:
  lora_r: 16
  lora_alpha: 32
  lora_dropout: 0.0
  target_modules: [q_proj, k_proj, v_proj, o_proj]
  target_parameters:
    - mixer.experts.up_proj
    - mixer.experts.down_proj
```

Everything else is automatic: split low-rank execution (no full-rank delta materialization), `torch._grouped_mm` fast path where the GPU supports it, and vLLM rollout sync of the expert adapters.

Hybrid-SSM trainer speed: install `causal-conv1d` and `mamba-ssm>=2.3` manually on GPU boxes (deliberately **not** dependencies — they compile CUDA extensions at install time); transformers picks them up automatically, roughly halving granite step time.

---

LoRA on stacked-3D MoE expert weights via PEFT `target_parameters`, executed split (tokens grouped per expert, `torch._grouped_mm` fast path) instead of PEFT's full-rank delta materialization. Gated (`act(gate) * up`) and ungated (NemotronH-style `act(up)`) expert conventions are both recognized structurally. Adapters export in the nested format vLLM's fused-MoE loader parses.

Validated on an A100: forward/grad parity vs PEFT's reference path, vLLM adapter round-trip, and a 96-step granite-4.0-h-tiny GRPO run (32s/step vs 59s/step naive, peak 35.8GiB/40GB, expert adapters training).
