### PR TITLE
ZeRO-3 support for split expert LoRA

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -154,7 +154,10 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
         set_fused_adapter_routing,
         unset_fused_adapter_routing,
     )
-    from agilerl.algorithms.core.llm_ops.moe_lora import upgrade_moe_param_wrappers
+    from agilerl.algorithms.core.llm_ops.moe_lora import (
+        mark_expert_wrappers_as_zero3_leaves,
+        upgrade_moe_param_wrappers,
+    )
     from agilerl.algorithms.core.llm_ops.vllm_colocate import (
         patch_vllm_3d_moe_lora_flag,
         patch_vllm_lora_keep_resident,
@@ -4394,12 +4397,25 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                     )
                     raise ValueError(msg)
             keep_adapter_base_dtype = self.zero_stage == 3 and not quantized_base
-            peft_target = get_peft_model(
-                peft_target,
-                lora_config,
-                adapter_name="actor",
-                autocast_adapter_dtype=not keep_adapter_base_dtype,
-            )
+            # PEFT reads the targeted parameters' shapes when attaching expert
+            # wrappers; under zero.Init they are partitioned placeholders, so
+            # gather them for the duration of the attach.
+            expert_params: list[torch.Tensor] = []
+            attach_ctx: AbstractContextManager[Any] = nullcontext()
+            if expert_target_parameters and self.zero_stage == 3:
+                expert_params = [
+                    param
+                    for name, param in peft_target.named_parameters()
+                    if any(name.endswith(target) for target in expert_target_parameters)
+                ]
+                attach_ctx = gather_if_zero3(self.zero_stage, expert_params)
+            with attach_ctx:
+                peft_target = get_peft_model(
+                    peft_target,
+                    lora_config,
+                    adapter_name="actor",
+                    autocast_adapter_dtype=not keep_adapter_base_dtype,
+                )
 
             # Add every adapter listed in ``selected_adapters`` beyond ``actor`` as a fresh
             # LoRA initialised from ``self.lora_config``. Downstream loads can overwrite
@@ -4431,11 +4447,16 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                         param.data = param.data.to(torch.bfloat16)
 
             if expert_target_parameters:
-                n_expert_lora = upgrade_moe_param_wrappers(peft_target)
+                # The upgrade's convention checks read the packed weights'
+                # shapes, so gather the shards again under ZeRO-3.
+                with gather_if_zero3(self.zero_stage, expert_params):
+                    n_expert_lora = upgrade_moe_param_wrappers(peft_target)
                 logger.info(
                     "Split expert-LoRA execution enabled on %d packed-experts modules.",
                     n_expert_lora,
                 )
+                if n_expert_lora and self.zero_stage == 3:
+                    mark_expert_wrappers_as_zero3_leaves(peft_target)
 
             # Apply Liger Kernel optimizations (fused RMSNorm, RoPE, SwiGLU,
             # CrossEntropy) to the inner causal-LM *after* PEFT wrapping.

--- a/agilerl/algorithms/core/llm_ops/moe_lora.py
+++ b/agilerl/algorithms/core/llm_ops/moe_lora.py
@@ -95,8 +95,19 @@ def _dims_aligned(itemsize: int, *dims: int) -> bool:
 
 
 def _is_partitioned(*tensors: torch.Tensor) -> bool:
-    """Whether any tensor is a DeepSpeed ZeRO-3 partitioned parameter."""
-    return any(hasattr(t, "ds_id") for t in tensors)
+    """Whether any tensor is a ZeRO-3 shard that is not currently gathered.
+
+    Inside a ZeRO-3 leaf module's forward (see
+    :func:`mark_expert_wrappers_as_zero3_leaves`) partitioned parameters are
+    gathered and report ``ds_status`` AVAILABLE, so raw reads see full data.
+    """
+    for tensor in tensors:
+        if not hasattr(tensor, "ds_id"):
+            continue
+        status = getattr(tensor, "ds_status", None)
+        if getattr(status, "name", None) != "AVAILABLE":
+            return True
+    return False
 
 
 def _grouped_linear(
@@ -328,9 +339,11 @@ class RoutedExpertsLoraWrapper(ParamWrapper):
         assert not isinstance(act_fn, torch.Tensor)
         if _is_partitioned(up_weight, down_weight):
             msg = (
-                "Split expert LoRA cannot read ZeRO-3 partitioned expert "
-                "weights outside their owning module's forward. Use ZeRO "
-                "stage <= 2 with expert LoRA on this architecture."
+                "Split expert LoRA found ZeRO-3 partitioned expert weights "
+                "that are not gathered. The expert wrappers must be ZeRO-3 "
+                "leaf modules (mark_expert_wrappers_as_zero3_leaves; applied "
+                "automatically at algorithm init) so the subtree gathers "
+                "before this forward reads the packed weights."
             )
             raise RuntimeError(msg)
 
@@ -363,6 +376,24 @@ class RoutedExpertsLoraWrapper(ParamWrapper):
         result = torch.zeros_like(hidden_states)
         result.index_add_(0, token_idx, (down * routed_weights).to(result.dtype))
         return result
+
+
+def mark_expert_wrappers_as_zero3_leaves(model: nn.Module) -> int:
+    """Mark upgraded expert wrappers as DeepSpeed ZeRO-3 leaf modules, returning how many.
+
+    A leaf module's whole parameter subtree — adapter Linears and the packed
+    expert weights beneath the wrapper — is gathered at its pre-forward, so
+    the split forward's raw weight reads see full tensors (and MoE avoids
+    per-parameter gather storms). Call before ``deepspeed.initialize``.
+    """
+    wrapper_classes = (SortedExpertsLoraWrapper, RoutedExpertsLoraWrapper)
+    count = sum(isinstance(m, wrapper_classes) for m in model.modules())
+    if not count:
+        return 0
+    from deepspeed.utils import set_z3_leaf_modules
+
+    set_z3_leaf_modules(model, list(wrapper_classes))
+    return count
 
 
 def upgrade_moe_param_wrappers(model: nn.Module) -> int:

--- a/agilerl/algorithms/core/llm_ops/vllm_colocate.py
+++ b/agilerl/algorithms/core/llm_ops/vllm_colocate.py
@@ -143,17 +143,14 @@ def patch_vllm_3d_moe_lora_flag(model_name_or_path: str) -> bool:
         from vllm.model_executor.models.registry import ModelRegistry
 
         architecture = AutoConfig.from_pretrained(model_name_or_path).architectures[0]
-        entry = getattr(ModelRegistry, "models", {}).get(architecture)
-        if entry is not None:
-            model_cls = entry.load_model_cls()
-        else:
-            # Older vLLM without the lazy-entry mapping.
-            model_cls, _ = ModelRegistry.resolve_model_cls(architecture)
+        model_cls = ModelRegistry.models[architecture].load_model_cls()
     except Exception:
         return False
     if getattr(model_cls, "is_3d_moe_weight", False):
         return False
-    model_cls.is_3d_moe_weight = True
+    # setattr: the attribute is undeclared on model classes predating the
+    # flag, so plain assignment is a type error.
+    setattr(model_cls, "is_3d_moe_weight", True)  # noqa: B010
     return True
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ include = ["agilerl", "agilerl/arena"]
 include = [
     "agilerl/algorithms/core/base.py",
     "agilerl/algorithms/core/llm_ops/fused_loss.py",
+    "agilerl/algorithms/core/llm_ops/moe_lora.py",
     "agilerl/algorithms/core/llm_ops/vllm_colocate.py",
     "agilerl/algorithms/grpo.py",
     "agilerl/algorithms/sft.py",

--- a/tests/test_algorithms/test_llm_ops/test_moe_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_moe_lora.py
@@ -596,3 +596,45 @@ def test_grouped_mm_fast_path_matches_loop_on_cuda():
     ref_out.square().mean().backward()
     fast_out.square().mean().backward()
     _assert_grad_parity(reference, fast, atol=1e-4)
+
+
+class _FakeDsStatus:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def _mark_ds(param, status=None):
+    param.ds_id = 1
+    if status is not None:
+        param.ds_status = _FakeDsStatus(status)
+
+
+def test_zero3_gathered_base_weights_run_split_forward():
+    reference, upgraded = _routed_pair()
+    experts = _wrappers(upgraded)[0].get_base_layer()
+    # Leaf-gathered ZeRO-3 params report AVAILABLE; raw reads see full data.
+    _mark_ds(experts.gate_up_proj, "AVAILABLE")
+    _mark_ds(experts.down_proj, "AVAILABLE")
+    x = torch.randn(10, HIDDEN)
+    assert torch.allclose(reference(x), upgraded(x), atol=1e-5)
+
+
+def test_zero3_gathered_adapters_use_fast_path():
+    reference, upgraded = _sorted_pair()
+    for module in _wrappers(upgraded):
+        for adapter in module.lora_A:
+            _mark_ds(module.lora_A[adapter].weight, "AVAILABLE")
+            _mark_ds(module.lora_B[adapter].weight, "AVAILABLE")
+    x = torch.randn(10, HIDDEN)
+    assert torch.allclose(reference(x), upgraded(x), atol=1e-5)
+
+
+def test_mark_expert_wrappers_as_zero3_leaves():
+    pytest.importorskip("deepspeed")
+    from agilerl.algorithms.core.llm_ops.moe_lora import (
+        mark_expert_wrappers_as_zero3_leaves,
+    )
+
+    _, upgraded = _routed_pair()
+    assert mark_expert_wrappers_as_zero3_leaves(upgraded) == 1
+    assert mark_expert_wrappers_as_zero3_leaves(nn.Linear(2, 2)) == 0


### PR DESCRIPTION
Expert LoRA now works under ZeRO-3: the PEFT attach and convention detection gather the packed expert shards, the wrappers become DeepSpeed z3 leaf modules so their subtree gathers before the split forward, and the partitioned-weights guard only blocks ungathered shards. Also fixes two Linux-only ty diagnostics in the vLLM 3D-flag patch.