### PR TITLE
Reject stale step results in BatchRolloutEnv.step_episode

### DIFF
--- a/agilerl/llm_envs/rollout_env.py
+++ b/agilerl/llm_envs/rollout_env.py
@@ -679,7 +679,9 @@ class BatchRolloutEnv:
     single-caller) or per-episode (``reset_episode``/``step_episode``/
     ``finalize_episode``, the async path — a slot is held from reset to finalize).
     The per-episode methods are synchronous and thread-safe; asyncio callers
-    offload them via ``asyncio.to_thread``.
+    offload them via ``asyncio.to_thread``. A ``step_episode`` whose episode is
+    finalized while its env round-trip is in flight raises rather than applying
+    the stale result to the slot's next episode.
     """
 
     def __init__(
@@ -741,6 +743,9 @@ class BatchRolloutEnv:
         self._assignment: list[tuple[int | None, int | None]] | None = None
         self._free_slots: queue.Queue[int] | None = None
         self._episode_to_slot: dict[str, int] = {}
+        # Monotonic per-slot activation tokens: bumped each time a slot is
+        # (re)assigned, so a step that outlives its episode is detectable.
+        self._slot_activations: list[int] = [0] * self.num_envs
         # Guards the slot queue + episode map (mutated from many caller threads);
         # re-entrant because a failed _ensure_slots calls close() while holding it.
         self._slot_lock = threading.RLock()
@@ -1082,14 +1087,27 @@ class BatchRolloutEnv:
                 raise IndexError(msg)
             return self._assignment[int(logical_slot)]
 
-    def _slot_for(self, episode_id: str) -> int:
-        """The slot ``episode_id`` holds; ``KeyError`` when it is not active."""
+    def _slot_and_activation(self, episode_id: str) -> tuple[int, int]:
+        """The ``(slot, activation)`` ``episode_id`` holds; ``KeyError`` when it is not active."""
         with self._slot_lock:
             slot = self._episode_to_slot.get(episode_id)
-        if slot is None:
-            msg = f"Episode {episode_id!r} is not active."
-            raise KeyError(msg)
-        return slot
+            if slot is None:
+                msg = f"Episode {episode_id!r} is not active."
+                raise KeyError(msg)
+            return slot, self._slot_activations[slot]
+
+    def _require_current(self, episode_id: str, slot: int, activation: int) -> None:
+        """Raise unless ``episode_id`` still holds ``slot`` on the same activation."""
+        with self._slot_lock:
+            current_slot = self._episode_to_slot.get(episode_id)
+            current_activation = self._slot_activations[slot]
+        if current_slot != slot or current_activation != activation:
+            msg = (
+                f"Episode {episode_id!r} no longer owns its env slot: it was "
+                "finalized (and the slot possibly reused) while this step was "
+                "in flight."
+            )
+            raise RuntimeError(msg)
 
     def reset_episode(
         self,
@@ -1133,6 +1151,7 @@ class BatchRolloutEnv:
                     msg = f"Episode {episode_id!r} is already active."
                     raise RuntimeError(msg)
                 self._episode_to_slot[episode_id] = slot
+                self._slot_activations[slot] += 1
             acquired = True
             return prompts, info
         finally:
@@ -1155,12 +1174,18 @@ class BatchRolloutEnv:
         :param completion_ids: This turn's full completion tensor.
         :param sampling_logps: This turn's vLLM sampling logprobs, or ``None``.
         :return: The :meth:`RolloutEnv.step` 5-tuple.
+        :raises RuntimeError: If the episode was finalized (and its slot possibly
+            reused) while the step was in flight — the stale result is never
+            applied to the slot's successor episode.
         """
-        env = self.envs[self._slot_for(episode_id)]
+        slot, activation = self._slot_and_activation(episode_id)
+        env = self.envs[slot]
         with self._tokenizer_lock:
+            self._require_current(episode_id, slot, activation)
             gen_text = env._step_prepare(completion_ids, sampling_logps=sampling_logps)
         env_result = env._step_env(gen_text)
         with self._tokenizer_lock:
+            self._require_current(episode_id, slot, activation)
             return env._step_apply(env_result)
 
     def get_episode_data(

--- a/tests/test_wrappers/test_rollout_env.py
+++ b/tests/test_wrappers/test_rollout_env.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import re
+import threading
 from typing import ClassVar
 
 import pytest
@@ -1197,6 +1198,16 @@ class _FailingFirstResetEnv(_SyncStubEnv):
         return super().reset(seed=seed)
 
 
+class _BlockingStepEnv(_SyncStubEnv):
+    step_entered: ClassVar[threading.Event]
+    release_step: ClassVar[threading.Event]
+
+    def _step_env(self, gen_text: str):
+        type(self).step_entered.set()
+        assert type(self).release_step.wait(timeout=10.0), "step was never released"
+        return super()._step_env(gen_text)
+
+
 class TestBatchRolloutEnvPerEpisode:
     def _collector(self, **kwargs) -> BatchRolloutEnv:
         defaults: dict = {
@@ -1315,3 +1326,69 @@ class TestBatchRolloutEnvPerEpisode:
         assert len(results) == 4
         assert vec_env.active_episode_count() == 0
         assert all(r[0].shape == (1, 4) for r in results)
+
+    def _blocked_step_thread(
+        self, vec_env: BatchRolloutEnv, episode_id: str
+    ) -> tuple[threading.Thread, list[Exception]]:
+        caught: list[Exception] = []
+
+        def drive() -> None:
+            try:
+                vec_env.step_episode(episode_id, torch.ones(1, 5, dtype=torch.long))
+            except Exception as exc:
+                caught.append(exc)
+
+        thread = threading.Thread(target=drive, daemon=True)
+        thread.start()
+        assert _BlockingStepEnv.step_entered.wait(timeout=10.0)
+        return thread, caught
+
+    def test_stale_step_never_lands_on_a_reused_slot(self) -> None:
+        _BlockingStepEnv.step_entered = threading.Event()
+        _BlockingStepEnv.release_step = threading.Event()
+        vec_env = self._collector(
+            env_factory=_BlockingStepEnv, batch_size=1, group_size=1
+        )
+        vec_env.reset_episode("ep-old", logical_slot=0)
+        thread, caught = self._blocked_step_thread(vec_env, "ep-old")
+
+        assert vec_env.finalize_episode("ep-old") is not None
+        vec_env.reset_episode("ep-new", logical_slot=0)
+        _BlockingStepEnv.release_step.set()
+        thread.join(timeout=10.0)
+        assert not thread.is_alive()
+
+        assert len(caught) == 1
+        assert isinstance(caught[0], RuntimeError)
+        assert "no longer owns its env slot" in str(caught[0])
+        # The successor episode saw no phantom turn and still steps normally.
+        env = vec_env.envs[0]
+        assert env.turn_boundaries == []
+        _prompt, reward, terminated, _trunc, _info = vec_env.step_episode(
+            "ep-new", torch.ones(1, 5, dtype=torch.long)
+        )
+        assert reward == 1.0
+        assert terminated
+        assert env.turn_boundaries == [1]
+
+    def test_stale_step_is_rejected_when_the_episode_id_is_reused(self) -> None:
+        _BlockingStepEnv.step_entered = threading.Event()
+        _BlockingStepEnv.release_step = threading.Event()
+        vec_env = self._collector(
+            env_factory=_BlockingStepEnv, batch_size=1, group_size=1
+        )
+        vec_env.reset_episode("ep", logical_slot=0)
+        thread, caught = self._blocked_step_thread(vec_env, "ep")
+
+        vec_env.finalize_episode("ep")
+        vec_env.reset_episode("ep", logical_slot=0)
+        _BlockingStepEnv.release_step.set()
+        thread.join(timeout=10.0)
+        assert not thread.is_alive()
+
+        # Identity alone cannot catch this: the reused id maps to the same slot,
+        # so only the bumped activation token distinguishes the new episode.
+        assert len(caught) == 1
+        assert isinstance(caught[0], RuntimeError)
+        assert "no longer owns its env slot" in str(caught[0])
+        assert vec_env.envs[0].turn_boundaries == []


### PR DESCRIPTION
## Problem

A `step_episode` whose caller gave up (cancelled offload, timed-out driver) keeps running its env round-trip. If the episode is finalized meanwhile and the slot reset for a successor episode, the late `_step_apply` silently appends a phantom turn/reward onto the fresh episode's state. The async consumer now defends on its side (tracking in-flight calls before finalizing), but the env should not depend on caller discipline for its own state integrity.

## Fix

- `BatchRolloutEnv` keeps a monotonic per-slot **activation token**, bumped atomically with the episode-map insert in `reset_episode`.
- `step_episode` snapshots `(slot, activation)` at entry and re-verifies both before each state mutation (`_step_prepare` and `_step_apply`), raising `RuntimeError` when the episode no longer owns its slot on the same activation.
- Identity alone would miss callers that reuse episode ids across windows (same id, same slot, new episode) — that's what the token is for.
- Rechecks run under the tokenizer lock, the same lock every `_reset_apply`/`_step_apply` mutation takes, so a verified step cannot interleave with a successor's reset. Slot-lock acquisition now nests inside the tokenizer lock; no path nests the reverse order.
- The token list is allocated once in `__init__` (the slot pool is fixed at construction) and survives `close()`/rebuild, so tokens never restart from zero.

## Tests

Two regression tests drive a blocking-step env double from a background thread: finalize + reuse the slot while the step is mid-round-trip, then release it.

- `test_stale_step_never_lands_on_a_reused_slot` — different successor id (caught by the identity check); also confirms the successor episode still steps normally with no phantom turn.
- `test_stale_step_is_rejected_when_the_episode_id_is_reused` — same id re-reset onto the same slot (caught only by the activation token).

Both fail on the previous code with the stale step returning **successfully** (the silent-corruption case). Full `test_rollout_env.py` (65), `test_on_policy.py`, `test_llm_envs.py`, and `test_openenv.py` (122) pass; ty diagnostics unchanged vs branch tip.