### PR TITLE
Update the LLM rollout ordering test to the current collect_rollouts_llm API

### DIFF
--- a/tests/test_rollouts/test_on_policy.py
+++ b/tests/test_rollouts/test_on_policy.py
@@ -110,6 +110,10 @@ class TestCollectRolloutsLlm:
         agent.clean_up()
         env.close()
 
+
+class TestCollectRolloutsLlmOrdering:
+    """Pure-double ordering checks; needs neither deepspeed nor vllm."""
+
     def test_collect_rollouts_llm_preserves_batch_group_ordering_batch_size_4(
         self,
     ) -> None:
@@ -212,7 +216,6 @@ class TestCollectRolloutsLlm:
                 env=env,
                 n_steps=1,
                 batch_size=4,
-                group_size=2,
                 group_seed=123,
             )
         )


### PR DESCRIPTION
Fixes the one pre-existing Linux CI failure on `feat/openenv`: `test_collect_rollouts_llm_preserves_batch_group_ordering_batch_size_4` still passed `group_size=` to `collect_rollouts_llm`, which dropped that parameter (the env carries the group split) — a call-time `TypeError` on every run.

Two changes:

- Drop the stale kwarg. The remaining assertions already match the current API (`next_group_seed = group_seed + batch_size` → 127; 8 envs × 1 turn → `steps == 8`).
- Move the test out from under the class-level deepspeed+vllm skip gate into an ungated `TestCollectRolloutsLlmOrdering` class. It uses only in-file doubles (`_OrderingEnv`, `_EchoAgent`), so the gate was over-broad — and it's exactly why the rot was invisible locally (macOS skipped it). Running it everywhere prevents this hiding again.

Verified locally on macOS (now that it runs there): the test passes, and the full `test_on_policy.py` file is 12 passed / 6 skipped.