### PR TITLE
Fix manifest plumbing bugs and colocated rollout overhead

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -6249,9 +6249,9 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
 
     def _prepare_vllm_for_generation(self) -> None:
         assert self.vllm_config is not None  # _configure_vllm guarantees a config
-        if self.use_memory_efficient_params and not self._vllm_awake:
-            move_params_to_cpu(self._get_unwrapped_actor())
-            if self.accelerator is None or self.accelerator.is_main_process:
+        if self.use_memory_efficient_params:
+            moved = move_params_to_cpu(self._get_unwrapped_actor())
+            if moved and (self.accelerator is None or self.accelerator.is_main_process):
                 log_cuda_memory_snapshot(
                     "trainer base offloaded to CPU (before vLLM wake)"
                 )

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -6250,12 +6250,6 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
     def _prepare_vllm_for_generation(self) -> None:
         assert self.vllm_config is not None  # _configure_vllm guarantees a config
         if self.use_memory_efficient_params and not self._vllm_awake:
-            # Colocated: park the trainer's own base on CPU *before* waking vLLM
-            # so the rollout engine owns the GPU and the two bases never coexist
-            # on-device. The training step brings it back via
-            # ``memory_efficient_params_context``. While the engine is already
-            # awake (mid-rollout turns) the base is still parked, so the offload
-            # and its log are skipped alongside the wake below.
             move_params_to_cpu(self._get_unwrapped_actor())
             if self.accelerator is None or self.accelerator.is_main_process:
                 log_cuda_memory_snapshot(

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -6249,11 +6249,13 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
 
     def _prepare_vllm_for_generation(self) -> None:
         assert self.vllm_config is not None  # _configure_vllm guarantees a config
-        if self.use_memory_efficient_params:
+        if self.use_memory_efficient_params and not self._vllm_awake:
             # Colocated: park the trainer's own base on CPU *before* waking vLLM
             # so the rollout engine owns the GPU and the two bases never coexist
             # on-device. The training step brings it back via
-            # ``memory_efficient_params_context``.
+            # ``memory_efficient_params_context``. While the engine is already
+            # awake (mid-rollout turns) the base is still parked, so the offload
+            # and its log are skipped alongside the wake below.
             move_params_to_cpu(self._get_unwrapped_actor())
             if self.accelerator is None or self.accelerator.is_main_process:
                 log_cuda_memory_snapshot(

--- a/agilerl/models/algo.py
+++ b/agilerl/models/algo.py
@@ -538,8 +538,8 @@ class LLMAlgorithmSpec(AlgorithmSpec):
     activation_offload: bool = Field(default=False)
     use_sequence_packing: bool = Field(default=False)
     lora_target_scope: str | None = Field(default=None)
-    fused_logprobs_chunk_rows: int | None = Field(default=None)
-    fused_loss_chunk_rows: int | None = Field(default=None)
+    chunk_rows: int | None = Field(default=None, ge=1)
+    micro_batch_size_per_gpu: int | None = Field(default=None, ge=1)
     vllm_importance_sampling_correction: bool = Field(default=True)
     vllm_importance_sampling_cap: float = Field(default=2.0, ge=0.0)
     attn_implementation: str | None = Field(default=None)
@@ -595,12 +595,6 @@ class LLMAlgorithmSpec(AlgorithmSpec):
             msg = "LLMAlgorithmSpec.build_algorithm requires a tokenizer."
             raise ValueError(msg)
 
-        micro_batch_size_per_gpu = None
-        if accelerator is not None:
-            micro_batch_size_per_gpu = max(
-                self.batch_size // accelerator.num_processes, 1
-            )
-
         use_vllm = getattr(self, "use_vllm", False)
         if not use_vllm and hasattr(self, "vllm_config"):
             self.vllm_config = None
@@ -643,7 +637,6 @@ class LLMAlgorithmSpec(AlgorithmSpec):
             pad_token=tokenizer.eos_token,
             accelerator=accelerator,
             index=index,
-            micro_batch_size_per_gpu=micro_batch_size_per_gpu,
             device=device,
             actor_network=actor_network,
             **kwargs,

--- a/agilerl/models/hpo.py
+++ b/agilerl/models/hpo.py
@@ -87,7 +87,7 @@ class TournamentSelectionSpec(BaseModel):
     """
 
     strategy: Literal["tournament"] = "tournament"
-    tournament_size: int = Field(default=2, ge=2)
+    tournament_size: int = Field(default=2, ge=1)
     elitism: bool = True
 
 

--- a/agilerl/models/manifest.py
+++ b/agilerl/models/manifest.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, get_args, overload
@@ -42,8 +41,6 @@ from agilerl.models.networks import (
     normalize_manifest_network,
 )
 from agilerl.models.training import ReplayBufferSpec, TrainingSpec
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from agilerl.arena.models import TrainingManifest as ArenaTrainingManifest
@@ -617,7 +614,11 @@ class TrainingManifest(BaseModel):
         unknown = _collect_unknown_fields(raw_snapshot, validated)
         if unknown:
             formatted = "[" + ", ".join(f'"{name}"' for name in unknown) + "]"
-            logger.warning("Ignoring unrecognized manifest field(s): %s", formatted)
+            msg = (
+                f"Unrecognized manifest field(s): {formatted}. Manifest keys "
+                "must match spec fields exactly; remove or rename them."
+            )
+            raise ValueError(msg)
 
         if mode == "json":
             return validated.model_dump(mode="json", exclude_none=True)

--- a/agilerl/models/training.py
+++ b/agilerl/models/training.py
@@ -182,6 +182,8 @@ class TrainingSpec(BaseModel):
     :type evaluation_interval: int
     :param num_epochs: Number of epochs to train for.
     :type num_epochs: int | None
+    :param max_wall_seconds: Wall-clock limit for multi-turn LLM fine-tuning runs.
+    :type max_wall_seconds: float | None
     :param episode_steps: Number of steps to train for each episode (only applicable for bandits).
     :type episode_steps: int
     :param sum_scores: Whether to sum sub-agent scores (only applicable for multi-agent).
@@ -222,6 +224,7 @@ class TrainingSpec(BaseModel):
     # LLM-specific training parameters
     evaluation_interval: int = Field(default=10, ge=1)
     num_epochs: int | None = Field(default=None, ge=1)
+    max_wall_seconds: float | None = Field(default=None, gt=0)
 
     # Bandit-specific training parameters
     episode_steps: int = Field(default=500, ge=1)

--- a/agilerl/training/llm/multiturn.py
+++ b/agilerl/training/llm/multiturn.py
@@ -164,7 +164,7 @@ def finetune_llm_multiturn(
     pbar = default_progress_bar(max_steps, accelerator)
 
     loggers = init_loggers(
-        algo=init_hp.get("ALGO", "LLMPPO"),
+        algo=init_hp.get("ALGO", pop[0].algo),
         env_name=env_name,
         pbar=pbar,
         verbose=verbose,

--- a/agilerl/training/llm/preference.py
+++ b/agilerl/training/llm/preference.py
@@ -149,7 +149,7 @@ def finetune_llm_preference(
     pbar = default_progress_bar(max_steps, accelerator)
 
     loggers = init_loggers(
-        algo=init_hp.get("ALGO", "DPO"),
+        algo=init_hp.get("ALGO", pop[0].algo),
         env_name=envs[0].name,
         pbar=pbar,
         verbose=verbose,

--- a/agilerl/training/llm/reasoning.py
+++ b/agilerl/training/llm/reasoning.py
@@ -161,7 +161,7 @@ def finetune_llm_reasoning(
 
     # Initialize loggers and Population wrapper
     loggers = init_loggers(
-        algo=init_hp.get("ALGO", "GRPO"),
+        algo=init_hp.get("ALGO", pop[0].algo),
         env_name=envs[0].name,
         pbar=pbar,
         verbose=verbose,

--- a/agilerl/training/llm/sft.py
+++ b/agilerl/training/llm/sft.py
@@ -141,7 +141,7 @@ def finetune_llm_sft(
 
     # Initialize loggers and Population wrapper
     loggers = init_loggers(
-        algo=init_hp.get("ALGO", "SFT"),
+        algo=init_hp.get("ALGO", pop[0].algo),
         env_name=env.name,
         pbar=pbar,
         verbose=verbose,

--- a/agilerl/training/trainer.py
+++ b/agilerl/training/trainer.py
@@ -827,8 +827,18 @@ class LocalTrainer(Trainer):
             assert isinstance(self.env_spec, LLMEnvSpec)
             kwargs["env_factory"] = self.env_factory
             kwargs["max_turns"] = self.env_spec.max_turns
+            manifest["env_name"] = self.env_spec.name
+            if self.training_spec.max_wall_seconds is not None:
+                kwargs["max_wall_seconds"] = self.training_spec.max_wall_seconds
         else:
             kwargs["env"] = self.env
+            if self.training_spec.max_wall_seconds is not None:
+                warnings.warn(
+                    "max_wall_seconds is only supported by multi-turn LLM "
+                    "fine-tuning and will be ignored.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         # Add checkpointing arguments to the training spec
         self.training_spec.checkpoint_steps = checkpoint_steps

--- a/agilerl/utils/llm_utils.py
+++ b/agilerl/utils/llm_utils.py
@@ -1620,7 +1620,7 @@ def move_params_to_cpu(unwrapped_model: torch.nn.Module) -> None:
     :return: None
     :rtype: None
     """
-    if next(unwrapped_model.parameters()).device != "cpu":
+    if next(unwrapped_model.parameters()).device.type != "cpu":
         unwrapped_model.to("cpu", non_blocking=True)
         torch.cuda.synchronize()
         torch.cuda.empty_cache()

--- a/agilerl/utils/llm_utils.py
+++ b/agilerl/utils/llm_utils.py
@@ -1612,18 +1612,14 @@ def move_params_to_gpu(unwrapped_model: torch.nn.Module, device: torch.device) -
         torch.cuda.synchronize()
 
 
-def move_params_to_cpu(unwrapped_model: torch.nn.Module) -> None:
-    """Move params to CPU.
-
-    :param agent: Distributed agent
-    :type agent: DistributedLLMAgent
-    :return: None
-    :rtype: None
-    """
+def move_params_to_cpu(unwrapped_model: torch.nn.Module) -> bool:
+    """Move params to CPU, returning True when a device transfer was needed."""
     if next(unwrapped_model.parameters()).device.type != "cpu":
         unwrapped_model.to("cpu", non_blocking=True)
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
+        return True
+    return False
 
 
 def stitch_completion_after_windowed_hf_generate(

--- a/agilerl/utils/utils.py
+++ b/agilerl/utils/utils.py
@@ -1474,12 +1474,15 @@ def init_wandb(
     kwargs: dict[str, Any] = {
         "config": config_dict,
         "project": project,  # wandb project where this run will be logged
-        "name": "{}-EvoHPO-{}-{}".format(
+    }
+    # A WANDB_NAME environment override wins; only generate a default run name
+    # when it is unset, since passing name explicitly would silently ignore it.
+    if not os.environ.get("WANDB_NAME"):
+        kwargs["name"] = "{}-EvoHPO-{}-{}".format(
             env_name,
             algo,
             datetime.now().strftime("%m%d%Y%H%M%S"),
-        ),
-    }
+        )
 
     if addl_args is not None:
         kwargs.update(addl_args)

--- a/docs/llm_finetuning/fused_logprobs.rst
+++ b/docs/llm_finetuning/fused_logprobs.rst
@@ -91,7 +91,7 @@ How many positions go in each chunk (``chunk_rows``) is chosen automatically fro
 the vocabulary size, so that one ``(chunk_rows, V)`` slab stays near a fixed
 memory budget (about 256 MB by default): models with bigger vocabularies get
 fewer rows per chunk, smaller ones more. Override it with the
-``fused_logprobs_chunk_rows`` constructor argument if you want manual control.
+``chunk_rows`` constructor argument if you want manual control.
 
 Optional: the fused Liger loss
 ------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.9.0.dev0"
+version = "2.9.0.dev1"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/tests/test_algorithms/test_llms/test_quantization.py
+++ b/tests/test_algorithms/test_llms/test_quantization.py
@@ -647,6 +647,44 @@ class TestColocatedInitOrdering:
         offload.assert_not_called()
 
 
+class TestPrepareVllmForGenerationOffloadGuard:
+    """The trainer-base offload (and its log) fire once per wake, not per turn."""
+
+    @staticmethod
+    def _stub_agent() -> LLMAlgorithm:
+        agent = TestColocatedInitOrdering._stub_agent()
+        agent.use_memory_efficient_params = True
+        agent._vllm_awake = False
+        agent._vllm_moved = False
+        agent.llm = mock.MagicMock()
+        return agent
+
+    def test_offload_and_log_skipped_while_engine_is_awake(self):
+        agent = self._stub_agent()
+        with (
+            mock.patch(
+                "agilerl.algorithms.core.base.move_params_to_cpu"
+            ) as move_to_cpu,
+            mock.patch(
+                "agilerl.algorithms.core.base.log_cuda_memory_snapshot"
+            ) as log_snapshot,
+            mock.patch("torch.cuda.empty_cache"),
+            mock.patch.object(agent, "_get_unwrapped_actor"),
+            mock.patch.object(agent, "_sync_actor_to_vllm"),
+        ):
+            agent._prepare_vllm_for_generation()
+            assert move_to_cpu.call_count == 1
+            assert log_snapshot.call_count == 2  # offload + wake snapshots
+            assert agent._vllm_awake is True
+
+            # Mid-rollout turns: engine already awake, nothing to offload/log.
+            agent._prepare_vllm_for_generation()
+            agent._prepare_vllm_for_generation()
+            assert move_to_cpu.call_count == 1
+            assert log_snapshot.call_count == 2
+            agent.llm.wake_up.assert_called_once()
+
+
 class TestAdaptLoraConfigForClippableLinear:
     @staticmethod
     def _gemma4_style_block():

--- a/tests/test_algorithms/test_llms/test_quantization.py
+++ b/tests/test_algorithms/test_llms/test_quantization.py
@@ -647,19 +647,24 @@ class TestColocatedInitOrdering:
         offload.assert_not_called()
 
 
-class TestPrepareVllmForGenerationOffloadGuard:
-    """The trainer-base offload (and its log) fire once per wake, not per turn."""
+class TestPrepareVllmForGenerationOffload:
+    """The trainer-base offload runs every call, but its snapshot log (and the
+    synchronize/empty_cache inside ``move_params_to_cpu``) fire only when the
+    base actually moved — once per engine wake in practice, not once per turn.
+    """
 
     @staticmethod
-    def _stub_agent() -> LLMAlgorithm:
-        agent = TestColocatedInitOrdering._stub_agent()
+    def _stub_agent(sleep_mode: bool = True) -> LLMAlgorithm:
+        agent = TestColocatedInitOrdering._stub_agent(
+            vllm_config=VLLMConfig(sleep_mode=sleep_mode)
+        )
         agent.use_memory_efficient_params = True
-        agent._vllm_awake = False
+        agent._vllm_awake = not sleep_mode
         agent._vllm_moved = False
         agent.llm = mock.MagicMock()
         return agent
 
-    def test_offload_and_log_skipped_while_engine_is_awake(self):
+    def test_log_fires_only_when_base_actually_moves(self):
         agent = self._stub_agent()
         with (
             mock.patch(
@@ -672,17 +677,38 @@ class TestPrepareVllmForGenerationOffloadGuard:
             mock.patch.object(agent, "_get_unwrapped_actor"),
             mock.patch.object(agent, "_sync_actor_to_vllm"),
         ):
+            move_to_cpu.side_effect = [True, False, False]
             agent._prepare_vllm_for_generation()
-            assert move_to_cpu.call_count == 1
             assert log_snapshot.call_count == 2  # offload + wake snapshots
             assert agent._vllm_awake is True
 
-            # Mid-rollout turns: engine already awake, nothing to offload/log.
+            # Mid-rollout turns: base already parked, so no further logs.
             agent._prepare_vllm_for_generation()
             agent._prepare_vllm_for_generation()
-            assert move_to_cpu.call_count == 1
+            assert move_to_cpu.call_count == 3
             assert log_snapshot.call_count == 2
             agent.llm.wake_up.assert_called_once()
+
+    def test_offload_still_runs_with_sleep_mode_off(self):
+        # sleep_mode off initializes _vllm_awake=True; the trainer base must
+        # still be parked before the first rollout.
+        agent = self._stub_agent(sleep_mode=False)
+        with (
+            mock.patch(
+                "agilerl.algorithms.core.base.move_params_to_cpu",
+                return_value=True,
+            ) as move_to_cpu,
+            mock.patch(
+                "agilerl.algorithms.core.base.log_cuda_memory_snapshot"
+            ) as log_snapshot,
+            mock.patch.object(agent, "_get_unwrapped_actor"),
+            mock.patch.object(agent, "_sync_actor_to_vllm"),
+        ):
+            agent._prepare_vllm_for_generation()
+
+        move_to_cpu.assert_called_once()
+        assert log_snapshot.call_count == 1
+        agent.llm.wake_up.assert_not_called()
 
 
 class TestAdaptLoraConfigForClippableLinear:

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -115,64 +115,54 @@ def test_get_validated_json_omits_unset_optional_sections() -> None:
     assert "network" not in out
 
 
-def test_get_validated_warns_on_unknown_algorithm_field() -> None:
-    with patch("agilerl.models.manifest.logger") as mock_logger:
+def test_get_validated_raises_on_unknown_algorithm_field() -> None:
+    with pytest.raises(ValueError, match=r"algorithm\.bogus_algo_field"):
         TrainingManifest.get_validated(
             _make_manifest(
                 {"name": "DQN", "lr": 3e-4, "bogus_algo_field": 1},
                 env={"name": "CartPole-v1"},
             )
         )
-    mock_logger.warning.assert_called_once()
-    template, formatted = mock_logger.warning.call_args.args
-    assert "unrecognized manifest field" in template
-    assert "algorithm.bogus_algo_field" in formatted
 
 
-def test_get_validated_warns_on_unknown_top_level_field() -> None:
-    with patch("agilerl.models.manifest.logger") as mock_logger:
+def test_get_validated_raises_on_unknown_top_level_field() -> None:
+    with pytest.raises(ValueError, match="bogus_top_level"):
         TrainingManifest.get_validated(
             _make_manifest(
                 {"name": "DQN"}, env={"name": "CartPole-v1"}, bogus_top_level=123
             )
         )
-    mock_logger.warning.assert_called_once()
-    assert "bogus_top_level" in mock_logger.warning.call_args.args[1]
 
 
-def test_get_validated_no_warning_for_known_aliased_or_excluded_fields() -> None:
+def test_get_validated_accepts_known_aliased_or_excluded_fields() -> None:
     # `cudagraphs` is declared-but-excluded, and population_size / metrics_interval
     # / memory_size are validation aliases: none are unknown.
-    with patch("agilerl.models.manifest.logger") as mock_logger:
-        TrainingManifest.get_validated(
-            _make_manifest(
-                {"name": "DQN", "lr": 3e-4, "cudagraphs": True},
-                env={"name": "CartPole-v1"},
-                training={
-                    "population_size": 4,
-                    "metrics_interval": 123,
-                    "max_steps": 1000,
-                },
-                replay_buffer={"memory_size": 4096},
-            )
+    TrainingManifest.get_validated(
+        _make_manifest(
+            {"name": "DQN", "lr": 3e-4, "cudagraphs": True},
+            env={"name": "CartPole-v1"},
+            training={
+                "population_size": 4,
+                "metrics_interval": 123,
+                "max_steps": 1000,
+            },
+            replay_buffer={"memory_size": 4096},
         )
-    mock_logger.warning.assert_not_called()
+    )
 
 
-def test_get_validated_no_warning_for_legacy_selection_key() -> None:
-    with patch("agilerl.models.manifest.logger") as mock_logger:
-        TrainingManifest.get_validated(
-            _make_manifest(
-                {"name": "DQN"},
-                env={"name": "CartPole-v1"},
-                tournament_selection={"tournament_size": 3},
-            )
+def test_get_validated_accepts_the_legacy_selection_key() -> None:
+    TrainingManifest.get_validated(
+        _make_manifest(
+            {"name": "DQN"},
+            env={"name": "CartPole-v1"},
+            tournament_selection={"tournament_size": 3},
         )
-    mock_logger.warning.assert_not_called()
+    )
 
 
 def test_get_validated_reports_unknown_keys_under_the_legacy_selection_key() -> None:
-    with patch("agilerl.models.manifest.logger") as mock_logger:
+    with pytest.raises(ValueError, match=r"tournament_selection\.bogus_key"):
         TrainingManifest.get_validated(
             _make_manifest(
                 {"name": "DQN"},
@@ -180,12 +170,10 @@ def test_get_validated_reports_unknown_keys_under_the_legacy_selection_key() -> 
                 tournament_selection={"tournament_size": 3, "bogus_key": 1},
             )
         )
-    mock_logger.warning.assert_called_once()
-    assert "tournament_selection.bogus_key" in mock_logger.warning.call_args.args[1]
 
 
 def test_get_validated_reports_unknown_keys_under_the_current_selection_key() -> None:
-    with patch("agilerl.models.manifest.logger") as mock_logger:
+    with pytest.raises(ValueError, match=r"selection_strategy\.bogus_key"):
         TrainingManifest.get_validated(
             _make_manifest(
                 {"name": "DQN"},
@@ -193,8 +181,6 @@ def test_get_validated_reports_unknown_keys_under_the_current_selection_key() ->
                 selection_strategy={"tournament_size": 3, "bogus_key": 1},
             )
         )
-    mock_logger.warning.assert_called_once()
-    assert "selection_strategy.bogus_key" in mock_logger.warning.call_args.args[1]
 
 
 def test_get_validated_json_writes_the_current_selection_key() -> None:
@@ -1497,6 +1483,28 @@ class TestFromConfigFiles:
 
         assert isinstance(trainer.algorithm_spec, expected_algo_cls)
         assert isinstance(trainer.env_spec, PzEnvSpec)
+
+    @pytest.mark.skipif(not HAS_LLM_DEPENDENCIES, reason="LLM deps not installed")
+    @pytest.mark.parametrize(
+        ("rel_path", "expected_chunk_rows"),
+        [
+            ("llm_finetuning/cispo_quant_bench.yaml", 128),
+            ("llm_finetuning/cispo_quant_bench_qwen.yaml", 64),
+        ],
+        ids=["cispo-gemma", "cispo-qwen"],
+    )
+    def test_llm_quant_bench_configs_validate_strictly(
+        self, rel_path, expected_chunk_rows
+    ):
+        """Shipped configs pass strict manifest validation, and their
+        ``chunk_rows`` knob is a real spec field that survives the round trip.
+        """
+        config_path = CONFIGS_DIR / rel_path
+        if not config_path.exists():
+            pytest.skip(f"Config not found: {config_path}")
+
+        out = TrainingManifest.get_validated(config_path)
+        assert out["algorithm"]["chunk_rows"] == expected_chunk_rows
 
     @pytest.mark.skipif(not HAS_LLM_DEPENDENCIES, reason="LLM deps not installed")
     @pytest.mark.parametrize(

--- a/tests/test_models/test_pydantic_models.py
+++ b/tests/test_models/test_pydantic_models.py
@@ -831,8 +831,8 @@ class TestBuildAlgorithmForwardsOnlySetFields:
 class TestLLMAlgorithmSpecBuild:
     """Lines 531-533, 554 in algo.py."""
 
-    def test_micro_batch_size_per_gpu_integer_split(self):
-        """Per-GPU micro batch is the integer per-process share, floored at 1."""
+    def test_micro_batch_size_per_gpu_forwarded_only_when_set(self):
+        """Explicit micro batch reaches the constructor; unset leaves the algorithm's default."""
         from agilerl.models.algorithms.grpo import GRPOSpec
 
         mock_tokenizer = MagicMock()
@@ -842,25 +842,45 @@ class TestLLMAlgorithmSpecBuild:
         accelerator.num_processes = 2
 
         spec = GRPOSpec(
-            pretrained_model_name_or_path="gpt2", group_size=4, batch_size=8
+            pretrained_model_name_or_path="gpt2",
+            group_size=4,
+            batch_size=8,
+            micro_batch_size_per_gpu=1,
         )
         mock_algo_cls = MagicMock()
         with patch.object(type(spec), "algo_class", return_value=mock_algo_cls):
             spec.build_algorithm(
                 tokenizer=mock_tokenizer, index=0, accelerator=accelerator
             )
-        assert mock_algo_cls.call_args.kwargs["micro_batch_size_per_gpu"] == 4
+        assert mock_algo_cls.call_args.kwargs["micro_batch_size_per_gpu"] == 1
 
-        # Never fractional or zero when batch_size < num_processes
-        small = GRPOSpec(
-            pretrained_model_name_or_path="gpt2", group_size=4, batch_size=1
+        # Unset: the algorithm derives it (e.g. from gradient accumulation),
+        # matching direct construction.
+        derived = GRPOSpec(
+            pretrained_model_name_or_path="gpt2", group_size=4, batch_size=8
         )
         mock_algo_cls.reset_mock()
-        with patch.object(type(small), "algo_class", return_value=mock_algo_cls):
-            small.build_algorithm(
+        with patch.object(type(derived), "algo_class", return_value=mock_algo_cls):
+            derived.build_algorithm(
                 tokenizer=mock_tokenizer, index=0, accelerator=accelerator
             )
-        assert mock_algo_cls.call_args.kwargs["micro_batch_size_per_gpu"] == 1
+        assert "micro_batch_size_per_gpu" not in mock_algo_cls.call_args.kwargs
+
+    def test_chunk_rows_forwarded_to_constructor(self):
+        """The manifest chunk_rows knob reaches the algorithm constructor."""
+        from agilerl.models.algorithms.grpo import GRPOSpec
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+        mock_tokenizer.eos_token = "<|endoftext|>"
+
+        spec = GRPOSpec(
+            pretrained_model_name_or_path="gpt2", group_size=4, chunk_rows=128
+        )
+        mock_algo_cls = MagicMock()
+        with patch.object(type(spec), "algo_class", return_value=mock_algo_cls):
+            spec.build_algorithm(tokenizer=mock_tokenizer, index=0)
+        assert mock_algo_cls.call_args.kwargs["chunk_rows"] == 128
 
     def test_vllm_config_dict_coerced(self):
         """build_algorithm coerces dict vllm_config."""
@@ -1058,6 +1078,21 @@ class TestTrainingSpec:
             ValueError, match="eval_steps must be greater than evaluation_interval"
         ):
             TrainingSpec(eval_steps=5, evaluation_interval=10)
+
+    def test_max_wall_seconds_accepted(self):
+        assert TrainingSpec(max_wall_seconds=3600).max_wall_seconds == 3600
+        assert TrainingSpec().max_wall_seconds is None
+        with pytest.raises(ValueError, match="greater than"):
+            TrainingSpec(max_wall_seconds=0)
+
+
+class TestTournamentSelectionSpec:
+    def test_tournament_size_of_one_is_valid(self):
+        from agilerl.models.hpo import TournamentSelectionSpec
+
+        assert TournamentSelectionSpec(tournament_size=1).tournament_size == 1
+        with pytest.raises(ValueError, match="greater than"):
+            TournamentSelectionSpec(tournament_size=0)
 
 
 class TestReplayBufferSpecNStep:

--- a/tests/test_train/test_train_llm.py
+++ b/tests/test_train/test_train_llm.py
@@ -1356,6 +1356,44 @@ class TestFinetuneLlmMultiturn:
         mock_agent.learn.assert_called_with(ANY, turn_ids=ANY)
         assert mock_save.call_count == 0
 
+    def test_finetune_llm_multiturn_labels_run_from_population(self):
+        """A manifest-style init_hp (no flat ALGO key) still names the run after
+        the actual algorithm and env, not the LLMPPO/multiturn defaults.
+        """
+        mock_agent = _make_multiturn_mock_agent(spec=GRPO)
+
+        with (
+            patch("agilerl.training.llm.multiturn.default_progress_bar"),
+            patch(
+                "agilerl.training.llm.multiturn.init_loggers", return_value=[]
+            ) as mock_init_loggers,
+            patch("agilerl.training.llm.multiturn.safe_aggregate_metrics"),
+            patch("agilerl.training.llm.multiturn.save_llm_checkpoint"),
+            patch("agilerl.training.llm.multiturn.SyncMultiTurnVecEnv"),
+            patch(
+                "agilerl.training.llm.multiturn.collect_rollouts_llm"
+            ) as mock_collect,
+            patch(
+                "agilerl.training.llm.multiturn.stack_and_pad_experiences"
+            ) as mock_stack,
+        ):
+            mock_collect.return_value = _multiturn_collect_return(batch_steps=3)
+            mock_stack.return_value = (torch.zeros(1, 8, dtype=torch.long),)
+
+            finetune_llm_multiturn(
+                pop=[mock_agent],
+                env_factory=MagicMock(),
+                max_turns=2,
+                init_hp={"env_name": "game:Sudoku-v0-hard"},
+                max_steps=3,
+                evaluation_interval=100,
+                verbose=False,
+                accelerator=None,
+            )
+
+        assert mock_init_loggers.call_args.kwargs["algo"] == "GRPO"
+        assert mock_init_loggers.call_args.kwargs["env_name"] == "game:Sudoku-v0-hard"
+
     def test_finetune_llm_multiturn_forwards_sampling_logps_to_learn(self):
         """When the rollout captures sampling logps, they're forwarded to
         ``learn(..., sampling_logps=...)`` for GRPO/PPO/REINFORCE agents.

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -584,6 +584,34 @@ class TestLocalTrainerTrain:
         mock_train_fn.assert_called_once()
         assert result == (mock_pop, [[1.0]])
 
+    @patch("agilerl.training.trainer.create_population_from_spec")
+    def test_train_warns_max_wall_seconds_ignored_for_non_multiturn(
+        self,
+        mock_create_pop,
+    ):
+        from agilerl.models.env import GymEnvSpec
+
+        env_spec = GymEnvSpec(name="CartPole-v1")
+        mock_pop = [MagicMock()]
+        mock_create_pop.return_value = mock_pop
+        mock_train_fn = MagicMock(return_value=(mock_pop, [[1.0]]))
+
+        with (
+            patch.object(PPOSpec, "get_training_fn", return_value=mock_train_fn),
+            patch.object(LocalTrainer, "_make_env", return_value=MagicMock()),
+        ):
+            trainer = LocalTrainer(
+                algorithm="PPO",
+                environment=env_spec,
+                training=TrainingSpec(
+                    max_steps=500, evo_steps=100, pop_size=2, max_wall_seconds=60
+                ),
+            )
+            with pytest.warns(UserWarning, match="max_wall_seconds"):
+                trainer.train()
+
+        assert "max_wall_seconds" not in mock_train_fn.call_args[1]
+
 
 @requires_arena
 class TestArenaTrainerConstruction:

--- a/tests/test_train/test_trainer.py
+++ b/tests/test_train/test_trainer.py
@@ -1462,7 +1462,9 @@ class TestLLMBuildAlgorithm:
 
         call_kwargs = mock_algo.call_args[1]
         assert call_kwargs["accelerator"] is mock_accel
-        assert call_kwargs["micro_batch_size_per_gpu"] is not None
+        # Unset on the spec: the algorithm derives its own micro batch size,
+        # matching direct construction.
+        assert "micro_batch_size_per_gpu" not in call_kwargs
 
 
 class TestLLMLocalTrainer:
@@ -2566,6 +2568,58 @@ class TestLocalTrainerMultiturn:
         assert call_kwargs["pop"] is mock_pop
         assert call_kwargs["max_steps"] == 100
         assert "env" not in call_kwargs
+        # The wandb run name reads the flat env_name key from init_hp.
+        assert call_kwargs["init_hp"]["env_name"] == "game:Test-v0"
+        assert "max_wall_seconds" not in call_kwargs
+
+    def test_train_forwards_max_wall_seconds(self, grpo_spec):
+        from agilerl.models.env import LLMEnvSpec, LLMEnvType
+
+        mock_pop = [MagicMock()]
+        mock_tokenizer = MagicMock(eos_token_id=0, eos_token="<eos>", pad_token_id=0)
+        mock_train_fn = MagicMock(return_value=mock_pop)
+
+        env_spec = LLMEnvSpec(
+            env_type=LLMEnvType.MULTITURN,
+            env_name="game:Test-v0",
+            max_turns=8,
+        )
+
+        with (
+            patch(
+                "agilerl.training.trainer.AutoTokenizer", create=True
+            ) as mock_auto_tok,
+            patch(
+                "agilerl.training.trainer.create_population_from_spec",
+                return_value=mock_pop,
+            ),
+            patch.object(
+                LLMEnvSpec,
+                "make_multiturn_env_factory",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                type(grpo_spec),
+                "get_training_fn",
+                return_value=mock_train_fn,
+            ),
+            patch.object(LocalTrainer, "to_manifest", return_value={}),
+            patch(
+                "agilerl.training.trainer.create_llm_accelerator",
+                return_value=MagicMock(),
+            ),
+        ):
+            mock_auto_tok.from_pretrained.return_value = mock_tokenizer
+            trainer = LocalTrainer(
+                algorithm=grpo_spec,
+                environment=env_spec,
+                training=TrainingSpec(
+                    max_steps=100, evo_steps=10, pop_size=1, max_wall_seconds=1800
+                ),
+            )
+            trainer.train()
+
+        assert mock_train_fn.call_args[1]["max_wall_seconds"] == 1800
 
 
 class TestImportGuardReload:

--- a/tests/test_utils/test_llm_utils.py
+++ b/tests/test_utils/test_llm_utils.py
@@ -1422,6 +1422,22 @@ def test_move_params_helpers_call_model_move_and_cuda_sync():
     empty_cache.assert_called_once()
 
 
+def test_move_params_to_cpu_skips_when_already_on_cpu():
+    """No move, sync, or empty_cache when the model already lives on CPU."""
+    model = MagicMock()
+    param = MagicMock()
+    param.device = torch.device("cpu")
+    model.parameters.return_value = iter([param])
+    with (
+        patch("torch.cuda.synchronize") as sync,
+        patch("torch.cuda.empty_cache") as empty_cache,
+    ):
+        move_params_to_cpu(model)
+    model.to.assert_not_called()
+    sync.assert_not_called()
+    empty_cache.assert_not_called()
+
+
 def test_get_model_name_or_path_and_align_deepspeed_lr_helpers():
     class _DirectModel:
         name_or_path = "direct_name"

--- a/tests/test_utils/test_llm_utils.py
+++ b/tests/test_utils/test_llm_utils.py
@@ -1416,7 +1416,7 @@ def test_move_params_helpers_call_model_move_and_cuda_sync():
         patch("torch.cuda.synchronize") as sync,
         patch("torch.cuda.empty_cache") as empty_cache,
     ):
-        move_params_to_cpu(model_cpu)
+        assert move_params_to_cpu(model_cpu) is True
     model_cpu.to.assert_called_once_with("cpu", non_blocking=True)
     sync.assert_called_once()
     empty_cache.assert_called_once()
@@ -1432,7 +1432,7 @@ def test_move_params_to_cpu_skips_when_already_on_cpu():
         patch("torch.cuda.synchronize") as sync,
         patch("torch.cuda.empty_cache") as empty_cache,
     ):
-        move_params_to_cpu(model)
+        assert move_params_to_cpu(model) is False
     model.to.assert_not_called()
     sync.assert_not_called()
     empty_cache.assert_not_called()

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -950,6 +950,21 @@ class TestInitWandb:
             mock_wandb.init.assert_called_once()
             assert mock_wandb.init.call_args[1].get("tags") == ["test"]
 
+    def test_default_name_generated_when_wandb_name_unset(self, monkeypatch):
+        monkeypatch.delenv("WANDB_NAME", raising=False)
+        with patch("agilerl.utils.utils.wandb") as mock_wandb:
+            mock_wandb.api = MagicMock()
+            init_wandb(algo="DQN", env_name="CartPole-v1")
+            name = mock_wandb.init.call_args.kwargs["name"]
+            assert name.startswith("CartPole-v1-EvoHPO-DQN-")
+
+    def test_wandb_name_env_var_wins(self, monkeypatch):
+        monkeypatch.setenv("WANDB_NAME", "my-run")
+        with patch("agilerl.utils.utils.wandb") as mock_wandb:
+            mock_wandb.api = MagicMock()
+            init_wandb(algo="DQN", env_name="CartPole-v1")
+            assert "name" not in mock_wandb.init.call_args.kwargs
+
     def test_no_api_warns(self, monkeypatch):
         monkeypatch.delenv("WANDB_API_KEY", raising=False)
 

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.9.0.dev0"
+version = "2.9.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Fixes the eight issues found running the CISPO quant benchmark through the manifest path (`python -m agilerl.train`) on nightly `066bc0f0`.

**Manifest / config plumbing**
- wandb runs are named after the actual algorithm and env (e.g. `CISPO` on `game:Sudoku-v0-hard`, not the `LLMPPO`/`multiturn` fallbacks): LLM loops default to `pop[0].algo`, the trainer injects the env name into `init_hp` for multiturn, and `init_wandb` respects `WANDB_NAME` when set.
- `chunk_rows` replaces the stale `fused_logprobs_chunk_rows`/`fused_loss_chunk_rows` spec fields and now reaches the constructors. The fused spellings crashed at startup; the shipped quant-bench configs' `chunk_rows` was silently dropped and now works.
- `micro_batch_size_per_gpu` is settable from a manifest. Unset defers to the algorithm's own derivation (micro = batch / procs / grad-accum), matching direct construction instead of forcing `batch_size // num_processes`, which doubled backward activation memory on single-GPU runs.
- Unknown manifest keys fail loudly: `TrainingManifest.get_validated` raises a `ValueError` listing the dotted paths (was a log warning). All shipped configs validate clean.
- `training.max_wall_seconds` added and plumbed into the multiturn loop; other loops warn and ignore it.
- `selection_strategy.tournament_size` lower bound relaxed to 1 for `pop_size: 1` benchmark runs.

**Colocated rollout overhead**
- `move_params_to_cpu` compared a `torch.device` against the string `"cpu"` (never equal), so every rollout turn paid `cuda.synchronize()` + `empty_cache()` with the model already on CPU. It compares `device.type` now and reports whether a transfer happened; the bnb mixed-placement init path still uses the unconditional `offload_colocated_trainer_from_gpu`.
- `_prepare_vllm_for_generation` still parks the trainer base on every call (a no-op device check once it's on CPU — required for `sleep_mode: false`, where the vLLM-first init relies on this offload), but the synchronize/empty_cache and the "offloaded to CPU" memory-snapshot log now happen only when the base actually moved — once per engine wake in practice instead of once per turn (measured 155 logs vs 4 wakes at `max_turns: 50`).

Ticket: https://app.notion.com/p/3b37b5dd18cb818eb959fa22d10b8a91