### PR TITLE
Drop dead enable_lora kwarg from VLLMConfig docs

### DIFF
--- a/docs/llm_finetuning/quantization.rst
+++ b/docs/llm_finetuning/quantization.rst
@@ -80,10 +80,9 @@ When you train with QLoRA and a colocated vLLM rollout, the trainer and the
 rollout engine each hold their own copy of the (quantized) base on the same
 GPU and take turns using it (see :ref:`colocated_native_sleep` below). Every
 training step only the small LoRA adapter weights are exported from the trainer
-and loaded into vLLM (see :class:`~agilerl.utils.algo_utils.VLLMConfig` with
-``enable_lora=True``, the default). The quantized base weights stay frozen in
-4-bit; they are never dequantized, merged, or re-uploaded. This keeps the
-per-step sync cheap.
+and loaded into vLLM; a colocated engine always serves LoRA, so there is
+nothing to enable. The quantized base weights stay frozen in 4-bit; they are
+never dequantized, merged, or re-uploaded. This keeps the per-step sync cheap.
 
 .. _colocated_native_sleep:
 
@@ -247,7 +246,6 @@ for colocated QLoRA rollouts:
         gpu_memory_utilization=0.3,
         quantization="bitsandbytes",   # AgileRL-validated path
         dtype="bfloat16",
-        enable_lora=True,              # sync adapters only (default)
         max_lora_rank=16,              # >= trainer lora_config.r
     )
 
@@ -265,7 +263,6 @@ paths typically need a pre-quantized checkpoint, set separately via
     vllm_config = VLLMConfig(
         quantization="awq",
         vllm_model_name_or_path="my-org/Qwen2.5-7B-AWQ",
-        enable_lora=True,
     )
 
 ``vllm_model_name_or_path`` lets the rollout load a different checkpoint from
@@ -329,7 +326,6 @@ A typical memory-constrained QLoRA + colocated-vLLM setup on A100:
         gpu_memory_utilization=0.3,
         quantization="bitsandbytes",
         dtype="bfloat16",
-        enable_lora=True,
         max_lora_rank=16,
     )
 


### PR DESCRIPTION
Backend changes strip `enable_lora`, `weight_sharing` and `weight_sharing_multimodal` out of 12 training manifests because none of them are `VLLMConfig` fields.

## What was actually dead here

Of the three names, only `enable_lora` had any trace in this repo, and only in `docs/llm_finetuning/quantization.rst`. `weight_sharing` and `weight_sharing_multimodal` have never appeared anywhere in the history of this branch — `git log -S` returns nothing for either. They only ever lived on unmerged branches, so there is nothing to remove.

`VLLMConfig` has never had an `enable_lora` field either. It went into the quantization docs with #522 and was wrong on the first commit; the dataclass rejects it:

```
TypeError: VLLMConfig.__init__() got an unexpected keyword argument 'enable_lora'
```

So all three code examples in that page were uncopyable. This removes the kwarg from each, and rewrites the one prose reference — colocated vLLM always serves LoRA (`build_vllm_engine_kwargs` hardcodes `enable_lora=True` because the trainer syncs only the adapter), so there is no user-facing toggle to point at.

## What stays

- `agilerl/utils/llm_utils.py:2131` — `kwargs["enable_lora"] = True`, the real vLLM engine kwarg.
- `docs/tutorials/llm_finetuning/grpo_finetuning.rst:415` and `grpo_hpo.rst:553` — direct `vllm.LLM(...)` calls, where `enable_lora` is a genuine vLLM parameter.

## Verification

`pre-commit` clean on the changed file except the `ty` hook, which reports 5 diagnostics in `agilerl/algorithms/core/llm_ops/vllm_colocate.py` and `agilerl/training/train_bandits.py`. Those reproduce on clean `origin/nightly` with a freshly `uv sync`ed venv and are unrelated — this PR touches no Python.