### PR TITLE
Add mini_batch_size for explicit optimizer-step sizing

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -2542,10 +2542,6 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
     # Adapter exported to vLLM for rollout — always the actor (also the
     # ``LoRARequest`` name the llm_utils helpers default to).
     _vllm_rollout_adapter = "actor"
-    # Resolution of ``mini_batch_size=None`` when a micro-batch is configured:
-    # ``"micro_batch"`` steps the optimizer once per micro-batch (the RL rollout
-    # algorithms), ``"batch"`` accumulates the whole per-rank batch into one
-    # optimizer step (the supervised/preference algorithms).
     _mini_batch_size_default: ClassVar[Literal["micro_batch", "batch"]] = "batch"
 
     # Runtime handles that cross HF/PEFT/DeepSpeed/vLLM wrapper boundaries;

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -2459,14 +2459,10 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
     :param micro_batch_size_per_gpu: Samples per backward pass on one rank (the
         memory knob). Optimizer-step cadence comes from ``mini_batch_size``.
     :type micro_batch_size_per_gpu: int | None
-    :param mini_batch_size: Per-rank samples covered by one optimizer step.
-        DeepSpeed's ``gradient_accumulation_steps`` is set to ``mini_batch_size
-        / micro_batch_size_per_gpu`` (validated for divisibility). ``None``
-        resolves per algorithm family: the RL rollout algorithms use
-        ``micro_batch_size_per_gpu`` (one optimizer step per micro-batch), the
-        supervised/preference algorithms use the per-rank batch (one step per
-        batch). Without DeepSpeed every micro-batch steps the optimizer, so a
-        value other than the micro-batch is rejected.
+    :param mini_batch_size: Per-rank samples covered by one optimizer step;
+        DeepSpeed's ``gradient_accumulation_steps`` = ``mini_batch_size /
+        micro_batch_size_per_gpu``. ``None`` uses the micro-batch (RL rollout
+        algorithms) or the per-rank batch (SFT/DPO).
     :type mini_batch_size: int | None, optional
     :param cosine_lr_schedule_config: The cosine LR schedule config.
     :type cosine_lr_schedule_config: CosineLRScheduleConfig | None

--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Generic,
     Literal,
     NoReturn,
@@ -2455,8 +2456,18 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
     :type model_name: str | None
     :param actor_network: The actor network.
     :type actor_network: PreTrainedModelProtocol | None
-    :param micro_batch_size_per_gpu: The micro batch size per GPU.
+    :param micro_batch_size_per_gpu: Samples per backward pass on one rank (the
+        memory knob). Optimizer-step cadence comes from ``mini_batch_size``.
     :type micro_batch_size_per_gpu: int | None
+    :param mini_batch_size: Per-rank samples covered by one optimizer step.
+        DeepSpeed's ``gradient_accumulation_steps`` is set to ``mini_batch_size
+        / micro_batch_size_per_gpu`` (validated for divisibility). ``None``
+        resolves per algorithm family: the RL rollout algorithms use
+        ``micro_batch_size_per_gpu`` (one optimizer step per micro-batch), the
+        supervised/preference algorithms use the per-rank batch (one step per
+        batch). Without DeepSpeed every micro-batch steps the optimizer, so a
+        value other than the micro-batch is rejected.
+    :type mini_batch_size: int | None, optional
     :param cosine_lr_schedule_config: The cosine LR schedule config.
     :type cosine_lr_schedule_config: CosineLRScheduleConfig | None
     :param hp_config: The hyperparameter configuration.
@@ -2535,6 +2546,11 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
     # Adapter exported to vLLM for rollout — always the actor (also the
     # ``LoRARequest`` name the llm_utils helpers default to).
     _vllm_rollout_adapter = "actor"
+    # Resolution of ``mini_batch_size=None`` when a micro-batch is configured:
+    # ``"micro_batch"`` steps the optimizer once per micro-batch (the RL rollout
+    # algorithms), ``"batch"`` accumulates the whole per-rank batch into one
+    # optimizer step (the supervised/preference algorithms).
+    _mini_batch_size_default: ClassVar[Literal["micro_batch", "batch"]] = "batch"
 
     # Runtime handles that cross HF/PEFT/DeepSpeed/vLLM wrapper boundaries;
     # their concrete types depend on the launch configuration (Accelerate
@@ -2576,6 +2592,7 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
         model_name: str | None = None,
         actor_network: PreTrainedModelProtocol | None = None,
         micro_batch_size_per_gpu: int | None = None,
+        mini_batch_size: int | None = None,
         cosine_lr_schedule_config: CosineLRScheduleConfig | None = None,
         hp_config: HyperparameterConfig | None = None,
         use_memory_efficient_params: bool = True,
@@ -2698,6 +2715,7 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
         self._configure_batch_size_per_process(
             batch_size,
             micro_batch_size_per_gpu,
+            mini_batch_size,
         )
         self.batch_size = batch_size
         self.lr = align_deepspeed_lr(float(lr), self.accelerator)
@@ -5867,13 +5885,30 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
         self,
         batch_size: int,
         micro_batch_size_per_gpu: int | None,
+        mini_batch_size: int | None,
     ) -> None:
+        if mini_batch_size is not None and mini_batch_size < 1:
+            msg = f"mini_batch_size must be a positive integer; got {mini_batch_size}."
+            raise ValueError(msg)
         if self.accelerator is None:
             self.batch_size_per_process = batch_size
             if micro_batch_size_per_gpu is not None:
                 self.micro_batch_size_per_gpu = int(micro_batch_size_per_gpu)
             else:
                 self.micro_batch_size_per_gpu = batch_size
+            if (
+                mini_batch_size is not None
+                and int(mini_batch_size) != self.micro_batch_size_per_gpu
+            ):
+                msg = (
+                    f"mini_batch_size ({mini_batch_size}) requires a DeepSpeed "
+                    "engine to accumulate gradients across micro-batches; "
+                    "without one every micro-batch of "
+                    f"{self.micro_batch_size_per_gpu} takes its own optimizer "
+                    "step."
+                )
+                raise ValueError(msg)
+            self.mini_batch_size = self.micro_batch_size_per_gpu
             return
 
         ds_plugin = self.accelerator.state.deepspeed_plugin
@@ -5891,7 +5926,7 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
 
         self.batch_size_per_process = int(batch_size / self.accelerator.num_processes)
 
-        if micro_batch_size_per_gpu is None:
+        if micro_batch_size_per_gpu is None and mini_batch_size is None:
             if (
                 self.batch_size_per_process
                 % ds_config.get("gradient_accumulation_steps", 1)
@@ -5910,6 +5945,9 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
             )
             self.micro_batch_size_per_gpu = (
                 self.batch_size_per_process // gradient_accumulation_steps
+            )
+            self.mini_batch_size = (
+                self.micro_batch_size_per_gpu * gradient_accumulation_steps
             )
 
             prev_micro = ds_config.get("train_micro_batch_size_per_gpu")
@@ -5931,16 +5969,36 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
             )
             raise ValueError(msg)
 
-        self.micro_batch_size_per_gpu = int(micro_batch_size_per_gpu)
-        if (
-            batch_size
-            % (self.micro_batch_size_per_gpu * self.accelerator.num_processes)
-            != 0
-        ):
-            msg = f"When specifying micro_batch_size_per_gpu, batch_size ({batch_size}) must be divisible by the product of the number of processes ({self.accelerator.num_processes}) and micro_batch_size_per_gpu ({self.micro_batch_size_per_gpu})."
-            raise ValueError(
-                msg,
+        if micro_batch_size_per_gpu is not None:
+            self.micro_batch_size_per_gpu = int(micro_batch_size_per_gpu)
+            if (
+                batch_size
+                % (self.micro_batch_size_per_gpu * self.accelerator.num_processes)
+                != 0
+            ):
+                msg = f"When specifying micro_batch_size_per_gpu, batch_size ({batch_size}) must be divisible by the product of the number of processes ({self.accelerator.num_processes}) and micro_batch_size_per_gpu ({self.micro_batch_size_per_gpu})."
+                raise ValueError(
+                    msg,
+                )
+        elif mini_batch_size is not None:
+            self.micro_batch_size_per_gpu = int(mini_batch_size)
+
+        if mini_batch_size is not None:
+            self.mini_batch_size = int(mini_batch_size)
+        elif self._mini_batch_size_default == "micro_batch":
+            self.mini_batch_size = self.micro_batch_size_per_gpu
+        else:
+            self.mini_batch_size = self.batch_size_per_process
+        if self.mini_batch_size % self.micro_batch_size_per_gpu != 0:
+            msg = (
+                f"mini_batch_size ({self.mini_batch_size}) must be divisible by "
+                f"micro_batch_size_per_gpu ({self.micro_batch_size_per_gpu}): "
+                "gradient_accumulation_steps = mini_batch_size / "
+                "micro_batch_size_per_gpu must be a whole number of backward "
+                "passes."
             )
+            raise ValueError(msg)
+
         prev_micro = ds_config.get("train_micro_batch_size_per_gpu")
         if prev_micro is not None:
             warnings.warn(
@@ -5950,13 +6008,21 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
             )
         ds_config["train_micro_batch_size_per_gpu"] = self.micro_batch_size_per_gpu
         gradient_accumulation_steps = (
-            batch_size / self.accelerator.num_processes / self.micro_batch_size_per_gpu
+            self.mini_batch_size // self.micro_batch_size_per_gpu
         )
-        warnings.warn(
-            f"Overwriting deepspeed config gradient accumulation steps from {ds_config.get('gradient_accumulation_steps', 'auto')} to {gradient_accumulation_steps}",
-            stacklevel=2,
-        )
-        ds_config["gradient_accumulation_steps"] = int(gradient_accumulation_steps)
+        prev_accumulation = ds_config.get("gradient_accumulation_steps")
+        if (
+            prev_accumulation not in (None, "auto")
+            and int(prev_accumulation) != gradient_accumulation_steps
+        ):
+            warnings.warn(
+                "Overwriting DeepSpeed config gradient_accumulation_steps from "
+                f"{prev_accumulation!r} to {gradient_accumulation_steps} "
+                f"(mini_batch_size={self.mini_batch_size} // "
+                f"micro_batch_size_per_gpu={self.micro_batch_size_per_gpu}).",
+                stacklevel=2,
+            )
+        ds_config["gradient_accumulation_steps"] = gradient_accumulation_steps
         return
 
     def recompile(self) -> None:

--- a/agilerl/algorithms/dpo.py
+++ b/agilerl/algorithms/dpo.py
@@ -71,6 +71,12 @@ class DPO(LLMAlgorithm[PreferencePrompts]):
     :type calc_position_embeddings: bool, optional
     :param micro_batch_size_per_gpu: Micro batch size per GPU, defaults to None
     :type micro_batch_size_per_gpu: int, optional
+    :param mini_batch_size: Per-rank rows covered by one optimizer step;
+        DeepSpeed's gradient_accumulation_steps is set to
+        ``mini_batch_size / micro_batch_size_per_gpu``. Defaults to None,
+        which resolves to the per-rank batch (one optimizer step per
+        batch).
+    :type mini_batch_size: int | None, optional
     :param device: Device to train on. Ignored when an accelerator is given (each rank
         owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str, optional
@@ -145,6 +151,7 @@ class DPO(LLMAlgorithm[PreferencePrompts]):
         update_epochs: int = 1,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
+        mini_batch_size: int | None = None,
         device: str | torch.device | None = None,
         lora_config: LoraConfig | None = None,
         accelerator: Accelerator | None = None,
@@ -180,6 +187,7 @@ class DPO(LLMAlgorithm[PreferencePrompts]):
             actor_network=actor_network,
             model_config=model_config,
             micro_batch_size_per_gpu=micro_batch_size_per_gpu,
+            mini_batch_size=mini_batch_size,
             cosine_lr_schedule_config=None,
             hp_config=hp_config,
             wrap=wrap,

--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -789,8 +789,6 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
                         self._record_window_action_tokens(action_masks, window_idxs)
                     for start in range(0, len(window_idxs), batch_size):
                         minibatch_idxs = window_idxs[start : start + batch_size]
-                        if len(minibatch_idxs) == 0:
-                            continue
                         loss, aux = self._loss(
                             batch_size,
                             minibatch_idxs,

--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -215,10 +215,19 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
     :type min_p: float, optional
     :param calc_position_embeddings: Flag indicating whether to calculate position embeddings, defaults to True
     :type calc_position_embeddings: bool, optional
-    :param micro_batch_size_per_gpu: If specified, gradient_accumulation_steps will be
-        calculated to achieve the target batch_size. If None, uses existing
-        gradient_accumulation_steps from DeepSpeed config, defaults to None
+    :param micro_batch_size_per_gpu: Trajectories per backward pass on one rank
+        (the memory knob). Optimizer-step cadence comes from
+        ``mini_batch_size``. If None, derived from the DeepSpeed config's
+        gradient_accumulation_steps, defaults to None
     :type micro_batch_size_per_gpu: int, optional
+    :param mini_batch_size: Per-rank trajectories covered by one optimizer
+        step. DeepSpeed's gradient_accumulation_steps is set to
+        ``mini_batch_size / micro_batch_size_per_gpu`` (validated for
+        divisibility). Defaults to None, which resolves to
+        ``micro_batch_size_per_gpu`` — one optimizer step per micro-batch. Set
+        it to the per-rank rollout batch (``batch_size / num_processes x
+        group_size``) to accumulate the whole batch into a single step.
+    :type mini_batch_size: int, optional
     :param max_output_tokens: Max number of answer tokens, defaults to None
     :type max_output_tokens: int, optional
     :param min_output_tokens: Minimum output tokens, defaults to 0
@@ -394,6 +403,8 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
     _window_action_tokens: int | None = None
     """Action tokens of this rank's samples entering the optimizer step in progress."""
 
+    _mini_batch_size_default = "micro_batch"
+
     def __init__(
         self,
         pad_token_id: int,
@@ -418,6 +429,7 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
         use_memory_efficient_params: bool = True,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
+        mini_batch_size: int | None = None,
         max_output_tokens: int | None = None,
         min_output_tokens: int | None = None,
         max_model_len: int | None = 1024,
@@ -478,6 +490,7 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
             actor_network=actor_network,
             model_config=model_config,
             micro_batch_size_per_gpu=micro_batch_size_per_gpu,
+            mini_batch_size=mini_batch_size,
             cosine_lr_schedule_config=cosine_lr_schedule_config,
             wrap=wrap,
             hp_config=hp_config,
@@ -725,8 +738,6 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
             advantages, batch_idxs = self._calculate_advantages(
                 rewards, completion_ids, action_masks, turn_ids
             )
-            if self.loss_norm == "accumulation_window":
-                self._record_window_action_tokens(action_masks, batch_idxs)
             aux_metric = self.aux_metric_name
             effective_num_samples = len(batch_idxs)
             if effective_num_samples == 0:
@@ -763,31 +774,40 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
 
             # Ensure batch_size is not larger than the number of active samples
             batch_size = min(batch_size, effective_num_samples)
+            self._warn_if_micro_batches_straddle_optimizer_steps(
+                effective_num_samples, batch_size
+            )
+            if self.loss_norm == "accumulation_window":
+                window_size = batch_size * self._accumulation_steps()
+            else:
+                window_size = effective_num_samples
             for _ in range(self.update_epochs):
                 self.rng.shuffle(batch_idxs)
-                for start in range(0, effective_num_samples, batch_size):
-                    minibatch_idxs = batch_idxs[
-                        start : min((start + batch_size), effective_num_samples)
-                    ]
-                    if len(minibatch_idxs) == 0:
-                        continue
-                    loss, aux = self._loss(
-                        batch_size,
-                        minibatch_idxs,
-                        completion_ids,
-                        action_masks,
-                        advantages,
-                        old_log_probs,
-                        reference_log_probs,
-                        turn_ids=is_turn_ids,
-                        sampling_log_probs=sampling_log_probs,
-                    )
-                    self._raise_if_loss_not_finite_on_any_rank(loss)
+                for window_start in range(0, effective_num_samples, window_size):
+                    window_idxs = batch_idxs[window_start : window_start + window_size]
+                    if self.loss_norm == "accumulation_window":
+                        self._record_window_action_tokens(action_masks, window_idxs)
+                    for start in range(0, len(window_idxs), batch_size):
+                        minibatch_idxs = window_idxs[start : start + batch_size]
+                        if len(minibatch_idxs) == 0:
+                            continue
+                        loss, aux = self._loss(
+                            batch_size,
+                            minibatch_idxs,
+                            completion_ids,
+                            action_masks,
+                            advantages,
+                            old_log_probs,
+                            reference_log_probs,
+                            turn_ids=is_turn_ids,
+                            sampling_log_probs=sampling_log_probs,
+                        )
+                        self._raise_if_loss_not_finite_on_any_rank(loss)
 
-                    self._backward_pass(loss)
-                    learn_metrics["loss"] += loss.item()
-                    learn_metrics[aux_metric] += aux.item()
-                    updates += 1
+                        self._backward_pass(loss)
+                        learn_metrics["loss"] += loss.item()
+                        learn_metrics[aux_metric] += aux.item()
+                        updates += 1
         result = {
             metric: value / max(updates, 1) for metric, value in learn_metrics.items()
         }
@@ -1488,6 +1508,44 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
         :rtype: None
         """
         self._window_action_tokens = int(action_masks[batch_idxs].sum().item())
+
+    def _warn_if_micro_batches_straddle_optimizer_steps(
+        self,
+        effective_num_samples: int,
+        micro_batch_size: int,
+    ) -> None:
+        """Warn when an epoch's micro-batches do not fill whole optimizer steps.
+
+        Reads the engine accumulation width leniently so mocked or non-DeepSpeed
+        actors never fail here; the strict accessor guards the loss path.
+
+        :param effective_num_samples: Trajectories entering this update.
+        :type effective_num_samples: int
+        :param micro_batch_size: Trajectories per backward pass.
+        :type micro_batch_size: int
+        :return: None
+        :rtype: None
+        """
+        if not self._uses_deepspeed:
+            return
+        accessor = getattr(self.actor, "gradient_accumulation_steps", None)
+        if not callable(accessor):
+            return
+        steps = accessor()
+        if not isinstance(steps, int) or isinstance(steps, bool) or steps <= 1:
+            return
+        micro_batches = -(-effective_num_samples // micro_batch_size)
+        if micro_batches % steps == 0:
+            return
+        warnings.warn(
+            f"The DeepSpeed engine folds {steps} micro-batches into one "
+            f"optimizer step, but this update runs {micro_batches} "
+            f"micro-batches per epoch, so the trailing {micro_batches % steps} "
+            "micro-batch(es) only reach the optimizer during a later epoch or "
+            "learn call. Choose mini_batch_size and micro_batch_size_per_gpu "
+            "so the per-rank batch splits into whole optimizer steps.",
+            stacklevel=3,
+        )
 
     def _accumulation_steps_without_deepspeed(self) -> int:
         """Micro-batches one optimizer step spans with no DeepSpeed engine.

--- a/agilerl/algorithms/ppo_llm.py
+++ b/agilerl/algorithms/ppo_llm.py
@@ -123,6 +123,12 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
     :type calc_position_embeddings: bool, optional
     :param micro_batch_size_per_gpu: Optional target micro-batch size per GPU.
     :type micro_batch_size_per_gpu: int | None, optional
+    :param mini_batch_size: Per-rank trajectories covered by one optimizer
+        step; DeepSpeed's gradient_accumulation_steps is set to
+        ``mini_batch_size / micro_batch_size_per_gpu``. Defaults to None,
+        which resolves to ``micro_batch_size_per_gpu`` (one optimizer step
+        per micro-batch).
+    :type mini_batch_size: int | None, optional
     :param max_output_tokens: Maximum newly generated tokens per completion.
     :type max_output_tokens: int | None, optional
     :param min_output_tokens: Minimum newly generated tokens per completion.
@@ -253,6 +259,8 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
     :type lora_target_scope: str | None, optional
     """
 
+    _mini_batch_size_default = "micro_batch"
+
     def __init__(
         self,
         pad_token_id: int,
@@ -280,6 +288,7 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
         use_separate_reference_adapter: bool = True,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
+        mini_batch_size: int | None = None,
         max_output_tokens: int | None = None,
         min_output_tokens: int | None = None,
         max_model_len: int = 1024,
@@ -339,6 +348,7 @@ class PPO(LLMAlgorithm[LLMRolloutExperiences]):
             actor_network=actor_network,
             model_config=model_config,
             micro_batch_size_per_gpu=micro_batch_size_per_gpu,
+            mini_batch_size=mini_batch_size,
             cosine_lr_schedule_config=cosine_lr_schedule_config,
             hp_config=hp_config,
             use_memory_efficient_params=use_memory_efficient_params,

--- a/agilerl/algorithms/reinforce_llm.py
+++ b/agilerl/algorithms/reinforce_llm.py
@@ -119,6 +119,12 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
     :type calc_position_embeddings: bool
     :param micro_batch_size_per_gpu: Micro-batch size for gradient accumulation.
     :type micro_batch_size_per_gpu: int | None
+    :param mini_batch_size: Per-rank trajectories covered by one optimizer
+        step; DeepSpeed's gradient_accumulation_steps is set to
+        ``mini_batch_size / micro_batch_size_per_gpu``. Defaults to None,
+        which resolves to ``micro_batch_size_per_gpu`` (one optimizer step
+        per micro-batch).
+    :type mini_batch_size: int | None, optional
     :param max_output_tokens: Maximum new tokens per generation.
     :type max_output_tokens: int | None
     :param min_output_tokens: Minimum new tokens per generation.
@@ -235,6 +241,8 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
     :type lora_target_scope: str | None, optional
     """
 
+    _mini_batch_size_default = "micro_batch"
+
     def __init__(
         self,
         pad_token_id: int,
@@ -260,6 +268,7 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
         use_separate_reference_adapter: bool = True,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
+        mini_batch_size: int | None = None,
         max_output_tokens: int | None = None,
         min_output_tokens: int | None = None,
         max_model_len: int = 1024,
@@ -313,6 +322,7 @@ class REINFORCE(LLMAlgorithm[LLMRolloutExperiences]):
             actor_network=actor_network,
             model_config=model_config,
             micro_batch_size_per_gpu=micro_batch_size_per_gpu,
+            mini_batch_size=mini_batch_size,
             cosine_lr_schedule_config=cosine_lr_schedule_config,
             hp_config=hp_config,
             wrap=wrap,

--- a/agilerl/algorithms/sft.py
+++ b/agilerl/algorithms/sft.py
@@ -79,6 +79,12 @@ class SFT(LLMAlgorithm[SFTPrompts]):
     :param micro_batch_size_per_gpu: Micro-batch size for gradient accumulation.
         When None the full batch is used in a single forward pass.
     :type micro_batch_size_per_gpu: int, optional
+    :param mini_batch_size: Per-rank rows covered by one optimizer step;
+        DeepSpeed's gradient_accumulation_steps is set to
+        ``mini_batch_size / micro_batch_size_per_gpu``. Defaults to None,
+        which resolves to the per-rank batch (one optimizer step per
+        batch).
+    :type mini_batch_size: int | None, optional
     :param device: Device to train on. Ignored when an accelerator is given (each rank
         owns its own GPU); ``None`` auto-detects CUDA/MPS/CPU.
     :type device: str, optional
@@ -148,6 +154,7 @@ class SFT(LLMAlgorithm[SFTPrompts]):
         update_epochs: int = 1,
         calc_position_embeddings: bool = True,
         micro_batch_size_per_gpu: int | None = None,
+        mini_batch_size: int | None = None,
         device: str | torch.device | None = None,
         lora_config: LoraConfig | None = None,
         accelerator: Accelerator | None = None,
@@ -182,6 +189,7 @@ class SFT(LLMAlgorithm[SFTPrompts]):
             actor_network=actor_network,
             model_config=model_config,
             micro_batch_size_per_gpu=micro_batch_size_per_gpu,
+            mini_batch_size=mini_batch_size,
             cosine_lr_schedule_config=None,
             hp_config=hp_config,
             wrap=wrap,

--- a/agilerl/models/algo.py
+++ b/agilerl/models/algo.py
@@ -545,6 +545,7 @@ class LLMAlgorithmSpec(AlgorithmSpec):
     lora_target_scope: str | None = Field(default=None)
     chunk_rows: int | None = Field(default=None, ge=1)
     micro_batch_size_per_gpu: int | None = Field(default=None, ge=1)
+    mini_batch_size: int | None = Field(default=None, ge=1)
     vllm_importance_sampling_correction: bool = Field(default=True)
     vllm_importance_sampling_cap: float = Field(default=2.0, ge=0.0)
     attn_implementation: str | None = Field(default=None)

--- a/docs/llm_finetuning/batch_sizing.rst
+++ b/docs/llm_finetuning/batch_sizing.rst
@@ -1,0 +1,156 @@
+.. _llm_batch_sizing:
+
+Batch sizes and optimizer steps
+===============================
+
+Three separate numbers control one LLM training update, and conflating them is
+the easiest way to get a run that trains far more slowly than it should. This
+page explains what each one means, how they combine, and what AgileRL does when
+you leave them unset.
+
+A few terms
+-----------
+
+* **Trajectory**: one completion produced during rollout — a single episode, or
+  a single sampled answer to a prompt. It is the unit all three batch sizes
+  count.
+* **Rollout batch**: every trajectory collected before the policy is updated.
+  For the GRPO family this is ``batch_size * group_size``, since each prompt is
+  answered ``group_size`` times.
+* **Backward pass**: one forward-and-backward through the model, producing
+  gradients. Its size is what determines peak GPU memory.
+* **Optimizer step**: the moment the optimizer (Adam) actually changes the
+  weights. Gradients from one or more backward passes are summed first.
+* **Gradient accumulation**: running several backward passes and adding their
+  gradients together before taking a single optimizer step. Lets you train at a
+  large effective batch size without holding it in memory at once.
+
+The three sizes
+---------------
+
+.. list-table::
+   :widths: 26 20 54
+   :header-rows: 1
+
+   * - Size
+     - Argument
+     - What it controls
+   * - Rollout batch
+     - ``batch_size`` x ``group_size``
+     - How much experience is collected before the policy is updated.
+   * - Mini-batch
+     - ``mini_batch_size``
+     - How many trajectories one **optimizer step** covers, per rank.
+   * - Micro-batch
+     - ``micro_batch_size_per_gpu``
+     - How many trajectories go through one **backward pass**, per rank.
+
+They are related by a single rule, which AgileRL applies to the DeepSpeed engine
+for you:
+
+.. code-block:: text
+
+    gradient_accumulation_steps = mini_batch_size / micro_batch_size_per_gpu
+
+``mini_batch_size`` must be a whole multiple of ``micro_batch_size_per_gpu``, and
+the trajectories a rank holds must divide evenly into mini-batches. AgileRL
+validates both and raises rather than silently rounding.
+
+The useful consequence is that the two knobs are independent:
+``micro_batch_size_per_gpu`` is now purely a **memory** knob, and
+``mini_batch_size`` is purely a **learning-cadence** knob. Lowering the
+micro-batch to fit a longer sequence into memory no longer changes how often the
+optimizer steps.
+
+Defaults
+--------
+
+Leaving ``mini_batch_size`` unset is fine, and what it resolves to depends on the
+algorithm:
+
+* **RL rollout algorithms** (:ref:`GRPO<grpo>`, :ref:`GSPO<gspo>`,
+  :ref:`CISPO<cispo>`, :ref:`LLM PPO<llmppo>`, :ref:`LLM REINFORCE<llmreinforce>`)
+  default to ``micro_batch_size_per_gpu`` — one optimizer step per backward pass.
+* **SFT and DPO** default to the rank's whole batch — one optimizer step per
+  batch, the usual supervised cadence.
+
+Why the cadence matters
+-----------------------
+
+It is tempting to treat gradient accumulation as free: the same trajectories are
+seen either way, so surely the model learns the same amount? It does not. Adam's
+progress is dominated by the *number of steps it takes*, not by the magnitude of
+any single gradient. Averaging ten micro-batches into one step moves the weights
+roughly as far as one step, not ten.
+
+Two runs over identical data can therefore differ by an order of magnitude in how
+much the policy actually moves per update, purely from this setting. If a run
+looks like it is barely learning while the loss and rewards look reasonable,
+check the optimizer step count before anything else.
+
+A worked example
+----------------
+
+Take ``batch_size: 2``, ``group_size: 5``, on two data-parallel trainer ranks,
+with ``micro_batch_size_per_gpu: 1``:
+
+* The rollout batch is ``2 * 5 = 10`` trajectories.
+* Split across 2 ranks, each rank holds **5 trajectories**.
+* With the micro-batch at 1, each rank runs **5 backward passes**.
+
+Now the cadence is yours to choose:
+
+.. list-table::
+   :widths: 30 20 50
+   :header-rows: 1
+
+   * - ``mini_batch_size``
+     - Accumulation
+     - Optimizer steps per rank, per update
+   * - unset (defaults to 1)
+     - 1
+     - 5 — one per backward pass
+   * - 5
+     - 5
+     - 1 — the whole rank batch in a single step
+   * - 3
+     - --
+     - rejected: 5 trajectories do not divide into mini-batches of 3
+
+Setting it
+----------
+
+In Python, pass it to the constructor alongside the micro-batch:
+
+.. code-block:: python
+
+    from agilerl.algorithms import GRPO
+
+    agent = GRPO(
+        pad_token_id=tokenizer.pad_token_id,
+        pad_token=tokenizer.pad_token,
+        model_name="Qwen/Qwen2.5-3B",
+        batch_size=2,
+        group_size=5,
+        micro_batch_size_per_gpu=1,  # memory
+        mini_batch_size=5,           # cadence: one step per rank per update
+        accelerator=accelerator,
+    )
+
+Or in the ``algorithm`` section of a training manifest:
+
+.. code-block:: yaml
+
+    algorithm:
+        name: GRPO
+        batch_size: 2
+        group_size: 5
+        micro_batch_size_per_gpu: 1
+        mini_batch_size: 5
+
+.. note::
+
+    Under data parallelism every rank derives the same accumulation width and so
+    takes the same number of optimizer steps per update. This is required, not
+    incidental: ranks that stepped at different times would desynchronise the
+    ZeRO collectives.

--- a/docs/llm_finetuning/index.rst
+++ b/docs/llm_finetuning/index.rst
@@ -66,11 +66,15 @@ This example demonstrates how to use the GRPO algorithm to fine-tune a LLM on a 
 .. toctree::
    :hidden:
 
+   batch_sizing
    fused_logprobs
    quantization
    llm_checkpoints
 
 .. seealso::
+
+   :doc:`batch_sizing`
+      Rollout, mini- and micro-batch sizes, and how often the optimizer steps.
 
    :doc:`fused_logprobs`
       Fused linear log-probability computation for memory-efficient training.

--- a/tests/test_algorithms/test_core_base.py
+++ b/tests/test_algorithms/test_core_base.py
@@ -1697,6 +1697,8 @@ def _make_llm_agent(
     batch_size=4,
     use_separate_reference_adapter=False,
     *,
+    mini_batch_size=None,
+    algo_cls=None,
     reduce_memory_peak: bool = False,
     use_vllm: bool = False,
     use_memory_efficient_params: bool = True,
@@ -1704,6 +1706,8 @@ def _make_llm_agent(
     """Helper to create a _StubLLMAlgorithm with heavily mocked internals."""
     if not HAS_LLM_DEPENDENCIES:
         pytest.skip("LLM dependencies not installed")
+    if algo_cls is None:
+        algo_cls = _StubLLMAlgorithm
     if actor_network is None:
         actor_network = _make_mock_peft_actor()
 
@@ -1721,7 +1725,7 @@ def _make_llm_agent(
             side_effect=lambda obj_list, from_process=0: list(obj_list),
         ),
     ):
-        agent = _StubLLMAlgorithm(
+        agent = algo_cls(
             index=0,
             batch_size=batch_size,
             lr=1e-4,
@@ -1735,6 +1739,7 @@ def _make_llm_agent(
             lora_config=lora_config if lora_config is not None else MagicMock(),
             actor_network=actor_network,
             micro_batch_size_per_gpu=micro_batch_size_per_gpu,
+            mini_batch_size=mini_batch_size,
             cosine_lr_schedule_config=cosine_lr_schedule_config,
             accelerator=accelerator,
             device="cpu",
@@ -2940,6 +2945,133 @@ class TestLLMConfigureBatchSize:
         )
         with pytest.raises(ValueError, match="gradient accumulation"):
             _make_llm_agent(accelerator=acc, clone=False)
+
+
+class _MicroDefaultStubLLMAlgorithm(_StubLLMAlgorithm):
+    """Stub with the RL-family mini-batch default."""
+
+    _mini_batch_size_default = "micro_batch"
+
+
+@_LLM_DEPS_SKIP
+class TestLLMConfigureMiniBatchSize:
+    @staticmethod
+    def _accelerator(ds_config=None, num_processes=1):
+        return _make_mock_accelerator(
+            ds_config=ds_config
+            or {
+                "zero_optimization": {"stage": 0},
+                "train_micro_batch_size_per_gpu": "auto",
+            },
+            num_processes=num_processes,
+        )
+
+    def test_explicit_mini_batch_sets_accumulation_steps(self):
+        acc = self._accelerator()
+        agent = _make_llm_agent(
+            accelerator=acc,
+            clone=False,
+            micro_batch_size_per_gpu=1,
+            mini_batch_size=2,
+        )
+        ds_config = acc.state.deepspeed_plugin.deepspeed_config
+        assert agent.micro_batch_size_per_gpu == 1
+        assert agent.mini_batch_size == 2
+        assert ds_config["gradient_accumulation_steps"] == 2
+        assert ds_config["train_micro_batch_size_per_gpu"] == 1
+
+    def test_default_mini_batch_micro_policy_steps_every_micro_batch(self):
+        acc = self._accelerator()
+        agent = _make_llm_agent(
+            accelerator=acc,
+            clone=False,
+            micro_batch_size_per_gpu=2,
+            algo_cls=_MicroDefaultStubLLMAlgorithm,
+        )
+        ds_config = acc.state.deepspeed_plugin.deepspeed_config
+        assert agent.mini_batch_size == 2
+        assert ds_config["gradient_accumulation_steps"] == 1
+
+    def test_default_mini_batch_batch_policy_accumulates_whole_batch(self):
+        acc = self._accelerator()
+        agent = _make_llm_agent(
+            accelerator=acc,
+            clone=False,
+            micro_batch_size_per_gpu=2,
+            batch_size=4,
+        )
+        ds_config = acc.state.deepspeed_plugin.deepspeed_config
+        assert agent.mini_batch_size == 4
+        assert ds_config["gradient_accumulation_steps"] == 2
+
+    def test_mini_batch_not_divisible_by_micro_raises(self):
+        acc = self._accelerator()
+        with pytest.raises(ValueError, match="must be divisible by"):
+            _make_llm_agent(
+                accelerator=acc,
+                clone=False,
+                micro_batch_size_per_gpu=2,
+                mini_batch_size=3,
+                batch_size=4,
+            )
+
+    def test_mini_batch_without_micro_batch_takes_one_backward_per_step(self):
+        acc = self._accelerator()
+        agent = _make_llm_agent(
+            accelerator=acc,
+            clone=False,
+            mini_batch_size=2,
+            batch_size=4,
+        )
+        ds_config = acc.state.deepspeed_plugin.deepspeed_config
+        assert agent.micro_batch_size_per_gpu == 2
+        assert agent.mini_batch_size == 2
+        assert ds_config["gradient_accumulation_steps"] == 1
+
+    def test_mini_batch_without_deepspeed_mismatch_raises(self):
+        with pytest.raises(ValueError, match="requires a DeepSpeed engine"):
+            _make_llm_agent(
+                clone=False,
+                micro_batch_size_per_gpu=1,
+                mini_batch_size=2,
+            )
+
+    def test_mini_batch_nonpositive_raises(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            _make_llm_agent(clone=False, mini_batch_size=0)
+
+    def test_legacy_config_accumulation_records_mini_batch(self):
+        acc = self._accelerator(
+            ds_config={
+                "zero_optimization": {"stage": 0},
+                "gradient_accumulation_steps": 2,
+                "train_micro_batch_size_per_gpu": "auto",
+            },
+            num_processes=2,
+        )
+        agent = _make_llm_agent(accelerator=acc, clone=False, batch_size=4)
+        assert agent.micro_batch_size_per_gpu == 1
+        assert agent.mini_batch_size == 2
+
+    def test_overriding_config_accumulation_warns(self):
+        acc = self._accelerator(
+            ds_config={
+                "zero_optimization": {"stage": 0},
+                "gradient_accumulation_steps": 4,
+            },
+        )
+        with pytest.warns(
+            UserWarning, match="Overwriting DeepSpeed config gradient_accumulation"
+        ):
+            agent = _make_llm_agent(
+                accelerator=acc,
+                clone=False,
+                micro_batch_size_per_gpu=1,
+                mini_batch_size=2,
+            )
+        ds_config = acc.state.deepspeed_plugin.deepspeed_config
+        assert ds_config["gradient_accumulation_steps"] == 2
+        assert agent.mini_batch_size == 2
 
 
 @_LLM_DEPS_SKIP

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -3600,6 +3600,80 @@ class TestGRPOLearn:
         assert grpo._window_action_tokens == 18
         grpo.clean_up()
 
+    def test_learn_records_window_tokens_per_optimizer_step(self):
+        grpo = _make_cpu_grpo_for_branch_tests(loss_norm="accumulation_window")
+        completion_ids, action_masks = _build_branch_experiences(batch_size=4)
+        rewards = torch.tensor([1.0, 0.0, -1.0, 2.0], dtype=torch.float32)
+
+        def fake_fused_forward(ids, batch_size):
+            shape = (ids.shape[0], ids.shape[1] - 1)
+            zeros = torch.zeros(shape, dtype=torch.float32, device=ids.device)
+            return zeros, zeros, None
+
+        grpo._uses_deepspeed = True
+        grpo.micro_batch_size_per_gpu = 1
+        grpo.actor.gradient_accumulation_steps = lambda: 2
+        original_record = GRPO._record_window_action_tokens
+        window_sizes: list[int] = []
+
+        def record_spy(masks, idxs):
+            window_sizes.append(len(idxs))
+            original_record(grpo, masks, idxs)
+
+        with (
+            patch.object(
+                grpo, "_fused_forward_no_grad", side_effect=fake_fused_forward
+            ),
+            patch.object(
+                grpo,
+                "_loss",
+                return_value=(
+                    torch.tensor(1.0, dtype=torch.float32),
+                    torch.tensor(0.1, dtype=torch.float32),
+                ),
+            ) as mock_loss,
+            patch.object(grpo, "_backward_pass", return_value=None),
+            patch.object(grpo, "_record_window_action_tokens", side_effect=record_spy),
+        ):
+            grpo.learn((completion_ids, action_masks, rewards))
+        # Four micro-batches of one sample fold into two optimizer steps, so
+        # the window normalizer is recorded once per step over two samples.
+        assert window_sizes == [2, 2]
+        assert grpo._window_action_tokens == 18
+        assert mock_loss.call_count == 4
+        grpo.clean_up()
+
+    def test_learn_warns_when_micro_batches_straddle_optimizer_steps(self):
+        grpo = _make_cpu_grpo_for_branch_tests(group_size=3)
+        completion_ids, action_masks = _build_branch_experiences(batch_size=3)
+        rewards = torch.tensor([1.0, 0.0, -1.0], dtype=torch.float32)
+
+        def fake_fused_forward(ids, batch_size):
+            shape = (ids.shape[0], ids.shape[1] - 1)
+            zeros = torch.zeros(shape, dtype=torch.float32, device=ids.device)
+            return zeros, zeros, None
+
+        grpo._uses_deepspeed = True
+        grpo.micro_batch_size_per_gpu = 1
+        grpo.actor.gradient_accumulation_steps = lambda: 2
+        with (
+            patch.object(
+                grpo, "_fused_forward_no_grad", side_effect=fake_fused_forward
+            ),
+            patch.object(
+                grpo,
+                "_loss",
+                return_value=(
+                    torch.tensor(1.0, dtype=torch.float32),
+                    torch.tensor(0.1, dtype=torch.float32),
+                ),
+            ),
+            patch.object(grpo, "_backward_pass", return_value=None),
+            pytest.warns(UserWarning, match="whole optimizer steps"),
+        ):
+            grpo.learn((completion_ids, action_masks, rewards))
+        grpo.clean_up()
+
     def test_learn_warns_and_returns_zeros_when_all_filtered(self):
         grpo = _make_cpu_grpo_for_branch_tests(
             group_size=2,

--- a/tests/test_algorithms/test_llms/test_grpo_loss_norm.py
+++ b/tests/test_algorithms/test_llms/test_grpo_loss_norm.py
@@ -12,6 +12,7 @@ kernel is a stand-in mirroring liger's signature and both of its reductions.
 from __future__ import annotations
 
 import inspect
+import warnings
 from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any
@@ -217,6 +218,9 @@ class _Stub:
     _record_window_action_tokens = GRPO._record_window_action_tokens
     _reduce_masked_loss = GRPO._reduce_masked_loss
     _resolve_loss_window = GRPO._resolve_loss_window
+    _warn_if_micro_batches_straddle_optimizer_steps = (
+        GRPO._warn_if_micro_batches_straddle_optimizer_steps
+    )
 
     def _get_lm_head(self) -> torch.nn.Linear:
         return self.lm_head
@@ -535,6 +539,40 @@ class TestAccumulationSteps:
         algo.actor = SimpleNamespace(gradient_accumulation_steps=lambda: 0)
         with pytest.raises(RuntimeError, match="returned 0"):
             algo._accumulation_steps()
+
+
+class TestStraddleWarning:
+    """A trailing micro-batch is worth warning about; a full window is not."""
+
+    @staticmethod
+    def _emitted(algo: _Stub, samples: int, micro_batch_size: int) -> list:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            algo._warn_if_micro_batches_straddle_optimizer_steps(
+                samples, micro_batch_size
+            )
+        return caught
+
+    def test_a_trailing_micro_batch_warns(self) -> None:
+        algo = _Stub(accumulation_steps=2)
+        with pytest.warns(UserWarning, match="whole optimizer steps"):
+            algo._warn_if_micro_batches_straddle_optimizer_steps(3, 1)
+
+    def test_micro_batches_filling_whole_steps_stay_silent(self) -> None:
+        assert self._emitted(_Stub(accumulation_steps=2), 4, 1) == []
+
+    def test_an_engine_without_the_accessor_stays_silent(self) -> None:
+        """A stand-in actor carries no accumulation width to compare against."""
+        algo = _Stub()
+        algo.actor = SimpleNamespace()
+        assert self._emitted(algo, 3, 2) == []
+
+    def test_a_single_step_window_stays_silent(self) -> None:
+        """Every micro-batch takes its own step, so none can straddle one."""
+        assert self._emitted(_Stub(accumulation_steps=1), 3, 2) == []
+
+    def test_without_deepspeed_no_engine_owns_the_window(self) -> None:
+        assert self._emitted(_Stub(uses_deepspeed=False), 3, 2) == []
 
 
 class TestWindowActionTokenRecording:

--- a/tests/test_algorithms/test_llms/test_grpo_metric_naming.py
+++ b/tests/test_algorithms/test_llms/test_grpo_metric_naming.py
@@ -74,6 +74,7 @@ class _Stub:
         self.vllm_importance_sampling_cap = 2.0
         self.filter_zero_adv = filter_zero_adv
         self.loss_norm = "micro_batch"
+        self._uses_deepspeed = False
         self.pad_token_id = PAD_TOKEN_ID
         self.update_epochs = 1
         self.micro_batch_size_per_gpu = 2
@@ -100,6 +101,9 @@ class _Stub:
     _record_window_action_tokens = GRPO._record_window_action_tokens
     _sampling_mismatch_metrics = GRPO._sampling_mismatch_metrics
     _use_liger_path = GRPO._use_liger_path
+    _warn_if_micro_batches_straddle_optimizer_steps = (
+        GRPO._warn_if_micro_batches_straddle_optimizer_steps
+    )
     _warn_liger_non_token_is = LLMAlgorithm._warn_liger_non_token_is
     _warn_liger_path_bypassed = GRPO._warn_liger_path_bypassed
 

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -1073,6 +1073,49 @@ class TestTrainingManifestArenaBridgeWithoutDeps:
 
 
 @pytest.mark.skipif(not HAS_LLM_DEPENDENCIES, reason="LLM deps not installed")
+class TestManifestBatchSizing:
+    """Both batch-sizing knobs reach the algorithm from the manifest.
+
+    An unknown algorithm key is rejected outright, so a manifest cannot set an
+    optimizer-step size the spec does not carry.
+    """
+
+    @staticmethod
+    def _manifest(**algo_overrides):
+        return _make_manifest(
+            algo={
+                "name": "GRPO",
+                "batch_size": 8,
+                "group_size": 4,
+                **algo_overrides,
+            },
+            env={"env_type": "reasoning", "dataset": "d.parquet"},
+            network={
+                "pretrained_model_name_or_path": "net-model",
+                "max_context_length": 256,
+                "lora_config": {
+                    "lora_r": 8,
+                    "lora_alpha": 16,
+                    "target_modules": ["q_proj", "v_proj"],
+                },
+            },
+        )
+
+    def test_both_batch_knobs_survive_the_manifest(self):
+        manifest = TrainingManifest.get_validated(
+            self._manifest(micro_batch_size_per_gpu=2, mini_batch_size=4),
+            mode="python",
+        )
+        assert manifest.algorithm.micro_batch_size_per_gpu == 2
+        assert manifest.algorithm.mini_batch_size == 4
+
+    def test_an_unset_mini_batch_size_stays_none(self):
+        """``None`` lets the algorithm apply its own family default."""
+        manifest = TrainingManifest.get_validated(self._manifest(), mode="python")
+        assert manifest.algorithm.mini_batch_size is None
+
+
+@pytest.mark.skipif(not HAS_LLM_DEPENDENCIES, reason="LLM deps not installed")
 class TestTrainerGetValidatedManifestLLMNetwork:
     """``network`` fills or overrides LLM algorithm model fields after manifest parse."""
 


### PR DESCRIPTION
Adds a third explicit batch-size tier for LLM training, mirroring verl's `ppo_mini_batch_size` / `ppo_micro_batch_size_per_gpu` split:

- rollout batch — trajectories collected per update (existing `batch_size` x `group_size`)
- `mini_batch_size` (new) — per-rank samples covered by one optimizer step
- `micro_batch_size_per_gpu` — samples per backward pass; now purely a memory knob

The DeepSpeed engine's `gradient_accumulation_steps` is set explicitly to `mini_batch_size / micro_batch_size_per_gpu` (validated for divisibility) instead of being inherited from the launch accelerate config, or silently derived as whole-batch accumulation whenever a micro-batch was passed.

**Defaults.** For the RL rollout algorithms (GRPO, GSPO, CISPO, PPO, REINFORCE) an unset `mini_batch_size` resolves to `micro_batch_size_per_gpu` — one optimizer step per micro-batch. That is the cadence the gemma-4 Sudoku CISPO benchmarks actually ran (GAS=1 out of `bench_accelerate_config.yaml`, since none of the bench paths pass the micro-batch through the constructor) and the regime empirically shown to drive learning; the old explicit-micro branch set GAS = `batch/(num_processes*micro)`, which nothing exercised. SFT and DPO keep whole-batch accumulation — one step per batch is the expected supervised cadence. Whole-batch accumulation stays available for RL by setting `mini_batch_size` to the per-rank rollout batch.

Details:

- The knob is per-rank, so every DP rank derives the same accumulation width and executes the same number of optimizer steps per learn (ZeRO collectives stay in lockstep).
- `loss_norm="accumulation_window"` now records its action-token normalizer once per optimizer-step window rather than once per learn, so it composes with any accumulation width (the engine's own 1/GAS loss scaling is unchanged).
- `GRPO.learn` warns when an epoch's micro-batches do not fill whole optimizer steps, since the trailing window would otherwise spill into the next learn call.
- Without DeepSpeed every micro-batch steps the optimizer, so a `mini_batch_size` wider than the micro-batch is rejected.

Background: distributed launches that commit whole-rollout-batch accumulation to the engine (one Adam step per update) learn far slower than these benchmarks stepping per micro-batch; that 10x step-count difference was measured to be the entire gap on the CISPO gemma-4 Sudoku benchmark (adapter-delta fingerprints; forcing GAS=1 reproduced the benchmark learning curve exactly).

Tested: `tests/test_algorithms/test_core_base.py` and `test_grpo_loss_norm.py` locally (394 passed) plus new coverage for the knob resolution, the per-window normalizer, and the straddle warning; the vllm-gated `test_grpo.py` additions run in CI (macOS cannot install vllm).