### PR TITLE
Update agilerl version to 2.8.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.9.0.dev1"
+version = "2.8.5"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.9.0.dev1"
+version = "2.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Version bump for the v2.8.5 release (nightly → main, #652): `2.9.0.dev1` → `2.8.5` in `pyproject.toml` and `uv.lock`. Minimal two-line edit; `uv lock --check` passes.