### PR TITLE
Update agilerl to 2.9.0 and agilerl-arena to 0.1.3

### DIFF
--- a/agilerl-arena/pyproject.toml
+++ b/agilerl-arena/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl-arena"
-version = "0.1.2"
+version = "0.1.3"
 description = "Arena Platform Client Library and CLI."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.5"
+version = "2.9.0"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"
@@ -58,7 +58,7 @@ llm = [
     "vllm>=0.24; sys_platform == 'linux'",
 ]
 arena = [
-    "agilerl-arena==0.1.2",
+    "agilerl-arena==0.1.3",
 ]
 all = [
     "agilerl[box2d,llm,arena]",

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.5"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -222,7 +222,7 @@ docs = [
 
 [[package]]
 name = "agilerl-arena"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "agilerl-arena" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Corrects the release versioning: the feature set shipped as v2.8.5 (ZeRO-3, Nemotron, MF-PBT, expert LoRA) warrants a minor release, and nightly was already on `2.9.0.dev1` before the 2.8.5 bump. Also releases the agilerl-arena changes made since 0.1.2 (the `selection_strategy` manifest aliasing and the python-keycloak constraint widening) as 0.1.3, with the arena pin aligned.

- `agilerl`: 2.8.5 → **2.9.0**
- `agilerl-arena`: 0.1.2 → **0.1.3**
- `agilerl[arena]` pin: `agilerl-arena==0.1.3`
- `uv.lock` updated to match; `uv lock --check` and `scripts/check-extras.py` pass

Nothing was published to PyPI as 2.8.5; the v2.8.5 tag/release will be replaced by v2.9.0 after this lands via the usual nightly → main release PR.