### PR TITLE
v2.9.0: ZeRO-3 training 🔱 Nemotron support 🤖 Multi-Frequency Population-Based Training 🧬

### DIFF
--- a/agilerl-arena/pyproject.toml
+++ b/agilerl-arena/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl-arena"
-version = "0.1.2"
+version = "0.1.3"
 description = "Arena Platform Client Library and CLI."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agilerl"
-version = "2.8.5"
+version = "2.9.0"
 description = "AgileRL is a deep reinforcement learning library focused on improving RL development through RLOps."
 authors = [{ name = "Nick Ustaran-Anderegg", email = "dev@agilerl.com" }]
 license = "Apache-2.0"
@@ -58,7 +58,7 @@ llm = [
     "vllm>=0.24; sys_platform == 'linux'",
 ]
 arena = [
-    "agilerl-arena==0.1.2",
+    "agilerl-arena==0.1.3",
 ]
 all = [
     "agilerl[box2d,llm,arena]",

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "agilerl"
-version = "2.8.5"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -222,7 +222,7 @@ docs = [
 
 [[package]]
 name = "agilerl-arena"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "agilerl-arena" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## **Features**

- **DeepSpeed ZeRO-3 training**: LLM post-training now runs under ZeRO-3, enabling LoRA fine-tuning of ~30B-parameter models with LoRA-scoped gathers, fused/Liger loss support, and robust checkpoint resume (#621).
- **Nemotron support**: new `agilerl.architectures` package with Nemotron-H hybrid Mamba and Liger kernel support (#621).
- **Expert LoRA for MoE models**: LoRA can now target packed 3D expert weights via PEFT `target_parameters`, including under ZeRO-3 (#621).
- **Multi-Frequency Population-Based Training**: new `MultiFrequencySelection` operator (MF-PBT, Doulazmi et al.) as a drop-in alternative to tournament selection, with manifest wiring, docs, and a tutorial (#611).
- **`mini_batch_size`**: explicit optimizer-step sizing for LLM algorithms, plus a new batch-sizing docs page (#621).

## **Optimizations**

- LoRA inputs skip PEFT's fp32 cast under bf16 autocast, cutting gradient-step peak memory by ~20–24% with bitwise-identical gradients (#623).
- Fused classic-RL hot paths (Polyak updates, CUDA Adam, batched double-Q) and a vectorized DQN curriculum tutorial: lesson-2 wall time 12.75 h → 2.48 h (#620).
- Colocated rollouts pay offload synchronization once per engine wake instead of once per turn (#638).

## **Fixes**

- Manifest plumbing: `chunk_rows`, `micro_batch_size_per_gpu`, `max_wall_seconds`, and wandb run naming all flow through correctly, and unrecognized keys are reported with their dotted paths (#638).
- Fixed flex-decoding `NoValidChoicesError` on SM90+ GPUs (#621).
- `VLLMConfig` docs examples updated — colocated vLLM always serves LoRA (#640).
- CI now guards that the `all` extra matches the union of every other extra (#641).
- `agilerl-arena` 0.1.3 released alongside, carrying the `selection_strategy` manifest support; the `arena` extra pins it (#654).

## **Breaking Changes**

- Unrecognized manifest keys now raise a `ValueError` at startup; use `chunk_rows` in place of the former `fused_*_chunk_rows` fields (#638).
- `tournament_selection_and_mutation` is deprecated in favour of `run_selection_and_mutation` (#611).

## What's Changed
* perf: fuse algorithm hot paths and vectorize the DQN curriculum tutorial by @micdoh in https://github.com/AgileRL/AgileRL/pull/620
* Stop paying for PEFT's fp32 LoRA input cast under autocast by @micdoh in https://github.com/AgileRL/AgileRL/pull/623
* Multiple-Frequencies Population-Based Training (MF-PBT) by @sgarcia56 in https://github.com/AgileRL/AgileRL/pull/611
* Chore(deps): Bump hydra-core from 1.3.2 to 1.3.4 by @dependabot in https://github.com/AgileRL/AgileRL/pull/625
* Chore(deps): Bump datasets from 5.0.0 to 5.0.1 by @dependabot in https://github.com/AgileRL/AgileRL/pull/627
* Fix manifest plumbing bugs and colocated rollout overhead by @micdoh in https://github.com/AgileRL/AgileRL/pull/638
* Chore(deps): Bump deepspeed from 0.19.2 to 0.19.3 by @dependabot in https://github.com/AgileRL/AgileRL/pull/629
* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/AgileRL/AgileRL/pull/634
* Chore(deps-dev): Bump pytest from 9.0.3 to 9.1.1 by @dependabot in https://github.com/AgileRL/AgileRL/pull/628
* Drop dead enable_lora kwarg from VLLMConfig docs by @micdoh in https://github.com/AgileRL/AgileRL/pull/640
* Guard the all extra alongside the arena dep pin by @micdoh in https://github.com/AgileRL/AgileRL/pull/641
* Chore(deps): Bump pettingzoo from 1.24.4 to 1.26.1 by @dependabot in https://github.com/AgileRL/AgileRL/pull/626
* Chore(deps): Bump redis from 8.0.1 to 8.1.0 by @dependabot in https://github.com/AgileRL/AgileRL/pull/644
* Chore(deps): Bump sphinx-toolbox from 4.2.0 to 4.3.0 by @dependabot in https://github.com/AgileRL/AgileRL/pull/647
* Chore(deps): Bump python-keycloak from 5.12.0 to 7.1.1 by @dependabot in https://github.com/AgileRL/AgileRL/pull/645
* Chore(deps): Bump click from 8.4.1 to 8.4.2 by @dependabot in https://github.com/AgileRL/AgileRL/pull/646
* Chore(deps): Bump pymunk from 7.2.0 to 7.3.0 by @dependabot in https://github.com/AgileRL/AgileRL/pull/648
* Scope ZeRO-3 gathers to LoRA params and fix adapter copy writes by @mikepratt1 in https://github.com/AgileRL/AgileRL/pull/621
* Update agilerl version to 2.8.5 by @micdoh in https://github.com/AgileRL/AgileRL/pull/653
* Update agilerl to 2.9.0 and agilerl-arena to 0.1.3 by @micdoh in https://github.com/AgileRL/AgileRL/pull/654

## New Contributors
* @sgarcia56 made their first contribution in https://github.com/AgileRL/AgileRL/pull/611

**Full Changelog**: https://github.com/AgileRL/AgileRL/compare/v2.8.4...v2.9.0
