### PR TITLE
Run check-extras through uv run so it needs no shell python

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ clean-dist:
 
 # Fail publish if the arena pin drifts, or the all extra misses an extra.
 check-extras:
-    python scripts/check-extras.py
+    uv run python scripts/check-extras.py
 
 build: clean-dist
     uv build --package agilerl-arena


### PR DESCRIPTION
The `check-extras` recipe invoked bare `python`, which fails with exit 127 on shells that only expose `python3` (stock macOS) — hit during the v2.9.0 `just publish`. Route it through `uv run` like the other justfile recipes so the project venv interpreter is always used, which also guarantees `tomli` is importable on 3.10.

Verified: `uv run python scripts/check-extras.py` → "OK: arena extra pins agilerl-arena==0.1.3; all unions every extra".