### PR TITLE
Attach expert LoRA under ZeRO-3 without gathering the packed experts

### DIFF
--- a/agilerl/algorithms/core/base.py
+++ b/agilerl/algorithms/core/base.py
@@ -189,6 +189,7 @@ if TYPE_CHECKING or HAS_LLM_DEPENDENCIES:
         offload_colocated_trainer_from_gpu,
         save_peft_adapter_for_vllm_rollout,
         stitch_completion_after_windowed_vllm_generate,
+        zero3_full_shape_views,
     )
     from agilerl.utils.zero3_patches import install_zero3_patches
 
@@ -4459,9 +4460,11 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                     )
                     raise ValueError(msg)
             keep_adapter_base_dtype = self.zero_stage == 3 and not quantized_base
-            # PEFT reads the targeted parameters' shapes when attaching expert
-            # wrappers; under zero.Init they are partitioned placeholders, so
-            # gather them for the duration of the attach.
+            # PEFT reads only the targeted parameters' shapes when attaching
+            # expert wrappers; under zero.Init they are partitioned
+            # placeholders, so expose zero-storage full-shape views rather
+            # than all-gathering the experts, whose full set can exceed
+            # device memory on large MoEs.
             expert_params: list[torch.Tensor] = []
             attach_ctx: AbstractContextManager[Any] = nullcontext()
             if expert_target_parameters and self.zero_stage == 3:
@@ -4470,7 +4473,7 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
                     for name, param in peft_target.named_parameters()
                     if any(name.endswith(target) for target in expert_target_parameters)
                 ]
-                attach_ctx = gather_if_zero3(self.zero_stage, expert_params)
+                attach_ctx = zero3_full_shape_views(expert_params)
             with attach_ctx:
                 peft_target = get_peft_model(
                     peft_target,
@@ -4510,8 +4513,8 @@ class LLMAlgorithm(EvolvableAlgorithm[ExperiencesT], ABC, Generic[ExperiencesT])
 
             if expert_target_parameters:
                 # The upgrade's convention checks read the packed weights'
-                # shapes, so gather the shards again under ZeRO-3.
-                with gather_if_zero3(self.zero_stage, expert_params):
+                # shapes; the same zero-storage views serve them under ZeRO-3.
+                with zero3_full_shape_views(expert_params):
                     n_expert_lora = upgrade_moe_param_wrappers(peft_target)
                 logger.info(
                     "Split expert-LoRA execution enabled on %d packed-experts modules.",

--- a/agilerl/utils/llm_utils.py
+++ b/agilerl/utils/llm_utils.py
@@ -662,6 +662,45 @@ def gather_if_zero3(
 
 
 @contextmanager
+def zero3_full_shape_views(
+    params: list[torch.Tensor],
+) -> Generator[None, None, None]:
+    """Expose full ``ds_shape`` views on partitioned ZeRO-3 params for shape-only reads.
+
+    Each partitioned param temporarily swaps its placeholder ``data`` for a
+    zero-storage view (a scalar expanded to ``ds_shape``), so shape, dtype and
+    device reads inside the block see the full tensor without an all-gather.
+    Values must not be read inside the block; the placeholder is restored on
+    exit. Params without ``ds_shape``, or already ``AVAILABLE``, pass through
+    untouched.
+
+    :param params: Candidate parameters; only partitioned ZeRO-3 params get views.
+    :type params: list[torch.Tensor]
+    """
+    saved: list[tuple[torch.Tensor, torch.Tensor]] = []
+    seen: set[int] = set()
+    try:
+        for param in params:
+            if id(param) in seen:
+                continue
+            ds_shape = getattr(param, "ds_shape", None)
+            if ds_shape is None:
+                continue
+            status = getattr(param, "ds_status", None)
+            if getattr(status, "name", None) == "AVAILABLE":
+                continue
+            seen.add(id(param))
+            saved.append((param, param.data))
+            param.data = torch.empty((), dtype=param.dtype, device=param.device).expand(
+                tuple(ds_shape)
+            )
+        yield
+    finally:
+        for param, data in saved:
+            param.data = data
+
+
+@contextmanager
 def gather_if_ds_param(
     *tensors: torch.Tensor | None,
     modifier_rank: int | None = 0,

--- a/agilerl/utils/zero3_patches.py
+++ b/agilerl/utils/zero3_patches.py
@@ -12,6 +12,9 @@ dispatched from here by family.
   replaying a submodule order the current step never produced.
 * :func:`patch_zero3_param_persistence` keeps small ZeRO-3 parameters
   replicated on every rank by setting ``zero.Init`` persistence thresholds.
+* :func:`patch_zero3_persistent_release` keeps parameters already marked
+  persistent resident when a submodule releases under an incomplete fetch
+  trace, so persistence holds on models that fetch on demand every step.
 
 Resolution and idempotence primitives live in :mod:`agilerl.utils.patching`,
 below both this module and the per-family patch modules.
@@ -44,6 +47,7 @@ __all__ = [
     "install_zero3_patches",
     "patch_zero3_fetch_trace",
     "patch_zero3_param_persistence",
+    "patch_zero3_persistent_release",
 ]
 
 ZERO3_COORDINATOR_MODULE = "deepspeed.runtime.zero.partitioned_param_coordinator"
@@ -53,6 +57,7 @@ MANGLE_PREFIX = "_PartitionedParameterCoordinator"
 SNAPSHOT_ATTR = "_agilerl_zero3_trace_snapshot"
 
 TRACE_PATCHED_FLAG = "_agilerl_zero3_trace_patched"
+PERSIST_RELEASE_PATCHED_FLAG = "_agilerl_zero3_persist_release_patched"
 
 TRACE_ATTRS = (
     "__trace_mode",
@@ -69,10 +74,10 @@ def install_zero3_patches(
 ) -> None:
     """Install the ZeRO-3 patches that apply to this run.
 
-    Always installs the fetch-trace workaround, then the patches every family
-    detected in *model_name_or_path* needs. Parameter persistence installs
-    when the config declares ``stage3_param_persistence_threshold``. Call
-    before the model is built.
+    Always installs the fetch-trace workaround and the persistent-release
+    guard, then the patches every family detected in *model_name_or_path*
+    needs. Parameter persistence installs when the config declares
+    ``stage3_param_persistence_threshold``. Call before the model is built.
 
     :param deepspeed_config: Resolved DeepSpeed config, or None.
     :type deepspeed_config: Mapping[str, Any] | None
@@ -84,6 +89,7 @@ def install_zero3_patches(
     :rtype: None
     """
     patch_zero3_fetch_trace(deepspeed_config)
+    patch_zero3_persistent_release()
     install_family_zero3_patches(model_name_or_path)
 
     if not isinstance(deepspeed_config, Mapping):
@@ -133,6 +139,42 @@ def _resolve_zero3_targets() -> tuple[type | None, type | None]:
         )
         raise RuntimeError(message)
     return coordinator, trace_mode
+
+
+def _resolve_zero3_release_targets() -> tuple[
+    type | None, Callable[..., Any] | None, Callable[[Any], bool] | None
+]:
+    """Resolve the ZeRO-3 coordinator class and its param-iteration helpers.
+
+    All None when deepspeed is absent. A loaded module that lacks any symbol
+    is version skew and raises.
+
+    :return: ``(coordinator_cls, iter_params, z3_leaf_module)``, or all None.
+    :rtype: tuple[type | None, Callable | None, Callable | None]
+    """
+    module = try_import(ZERO3_COORDINATOR_MODULE)
+    if module is None:
+        return None, None, None
+    coordinator = getattr(module, "PartitionedParameterCoordinator", None)
+    iter_params = getattr(module, "iter_params", None)
+    z3_leaf_module = getattr(module, "z3_leaf_module", None)
+    missing = [
+        name
+        for name, value in (
+            ("PartitionedParameterCoordinator", coordinator),
+            ("iter_params", iter_params),
+            ("z3_leaf_module", z3_leaf_module),
+        )
+        if value is None
+    ]
+    if missing:
+        message = (
+            "[zero3-persist-release] "
+            f"{ZERO3_COORDINATOR_MODULE} is present but missing "
+            f"{', '.join(missing)}"
+        )
+        raise RuntimeError(message)
+    return coordinator, iter_params, z3_leaf_module
 
 
 def _resolve_zero3_init() -> type | None:
@@ -342,6 +384,96 @@ def patch_zero3_fetch_trace(
         "[zero3-trace] reset_step patched; no-grad forwards preserve %d trace "
         "identity attributes",
         len(TRACE_ATTRS),
+    )
+
+
+def _make_patched_release_sub_module(
+    original_release_sub_module: Callable[..., None],
+    iter_params: Callable[..., Any],
+    z3_leaf_module: Callable[[Any], bool],
+) -> Callable[..., None]:
+    """Build the ``release_sub_module`` wrapper that pins persistent params.
+
+    :param original_release_sub_module: Unbound ``release_sub_module`` to call
+        through to.
+    :type original_release_sub_module: Callable[..., None]
+    :param iter_params: deepspeed's parameter iterator for a submodule.
+    :type iter_params: Callable[..., Any]
+    :param z3_leaf_module: Predicate for deepspeed leaf modules.
+    :type z3_leaf_module: Callable[[Any], bool]
+    :return: Replacement ``release_sub_module``.
+    :rtype: Callable[..., None]
+    """
+
+    @functools.wraps(original_release_sub_module)
+    def patched_release_sub_module(
+        self: object, submodule: object, *args: Any, **kwargs: Any
+    ) -> None:
+        pinned = [
+            (param, getattr(param, "is_external_param", False))
+            for param in iter_params(submodule, recurse=z3_leaf_module(submodule))
+            if getattr(param, "ds_persist", False)
+        ]
+        for param, _ in pinned:
+            param.is_external_param = True
+        try:
+            original_release_sub_module(self, submodule, *args, **kwargs)
+        finally:
+            for param, was_external in pinned:
+                param.is_external_param = was_external
+
+    return patched_release_sub_module
+
+
+def patch_zero3_persistent_release(*, enabled: bool = True) -> None:
+    """Keep persistent ZeRO-3 parameters resident when a submodule releases.
+
+    ``release_sub_module`` excludes persistent parameters from release only
+    when its recorded fetch trace is complete; while the trace is recording or
+    invalid — every step, for a model that picks submodules from the data — it
+    releases them like any other parameter, and each one is re-gathered on its
+    next use. The wrapper flags the submodule's persistent parameters as
+    external for the duration of each call, which every guard in the release
+    loop honours (both the partition call and the leaf-module data swap), then
+    restores the flags. Whole-model releases (``release_and_reset_all``)
+    ignore the external flag, so optimizer-step and teardown partitioning
+    still cover every parameter. A no-op when deepspeed is unavailable.
+
+    :param enabled: Install the patch, defaults to True.
+    :type enabled: bool, optional
+    :return: None
+    :rtype: None
+    """
+    if not enabled:
+        logger.info(
+            "[zero3-persist-release] disabled by caller; "
+            "release_sub_module left unpatched",
+        )
+        return
+
+    coordinator_cls, iter_params, z3_leaf_module = _resolve_zero3_release_targets()
+    if coordinator_cls is None or iter_params is None or z3_leaf_module is None:
+        logger.warning(
+            "[zero3-persist-release] deepspeed ZeRO-3 coordinator unavailable; "
+            "release_sub_module left unpatched",
+        )
+        return
+    if class_is_patched(coordinator_cls, PERSIST_RELEASE_PATCHED_FLAG):
+        return
+
+    original_release_sub_module = getattr(coordinator_cls, "release_sub_module", None)
+    if original_release_sub_module is None:
+        message = "[zero3-persist-release] coordinator lacks release_sub_module"
+        raise RuntimeError(message)
+
+    coordinator_target: Any = coordinator_cls
+    coordinator_target.release_sub_module = _make_patched_release_sub_module(
+        original_release_sub_module, iter_params, z3_leaf_module
+    )
+    setattr(coordinator_cls, PERSIST_RELEASE_PATCHED_FLAG, True)
+    logger.info(
+        "[zero3-persist-release] release_sub_module patched; persistent "
+        "parameters stay resident while the fetch trace is incomplete",
     )
 
 

--- a/tests/test_algorithms/test_core_base.py
+++ b/tests/test_algorithms/test_core_base.py
@@ -7229,10 +7229,6 @@ class TestLLMInitializeActorsExpertLoraGuards:
                 "agilerl.algorithms.core.base.mark_expert_wrappers_as_zero3_leaves",
                 mark,
             ),
-            patch(
-                "agilerl.algorithms.core.base.gather_if_zero3",
-                return_value=nullcontext(),
-            ),
             patch.object(agent, "use_adapter"),
         ):
             LLMAlgorithm._initialize_actors(agent, base_model, add_adapters=True)
@@ -7274,15 +7270,118 @@ class TestLLMInitializeActorsExpertLoraGuards:
                 "agilerl.algorithms.core.base.mark_expert_wrappers_as_zero3_leaves",
                 mark,
             ),
-            patch(
-                "agilerl.algorithms.core.base.gather_if_zero3",
-                return_value=nullcontext(),
-            ),
             patch.object(agent, "use_adapter"),
         ):
             LLMAlgorithm._initialize_actors(agent, base_model, add_adapters=True)
 
         mark.assert_not_called()
+
+
+class _PackedExperts(torch.nn.Module):
+    """NemotronH-style self-routing packed experts with stacked 3D weights."""
+
+    def __init__(self, num_experts: int, hidden: int, intermediate: int) -> None:
+        super().__init__()
+        self.num_experts = num_experts
+        self.up_proj = torch.nn.Parameter(
+            torch.randn(num_experts, intermediate, hidden) * 0.1
+        )
+        self.down_proj = torch.nn.Parameter(
+            torch.randn(num_experts, hidden, intermediate) * 0.1
+        )
+        self.act_fn = F.silu
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        return hidden_states
+
+
+class _PackedMoeModel(torch.nn.Module):
+    """Two-layer stack of packed-experts blocks under a ``mixer`` path."""
+
+    def __init__(self, num_experts: int = 4, hidden: int = 8) -> None:
+        super().__init__()
+        self.layers = torch.nn.ModuleList()
+        for _ in range(2):
+            block = torch.nn.Module()
+            block.mixer = torch.nn.Module()
+            block.mixer.experts = _PackedExperts(num_experts, hidden, 6)
+            self.layers.append(block)
+
+
+@_LLM_DEPS_SKIP
+class TestLLMInitializeActorsExpertLoraZero3Memory:
+    """Expert-LoRA attach under ZeRO-3 must not need the experts resident."""
+
+    def test_zero3_attach_succeeds_on_partitioned_placeholders(self) -> None:
+        """Attach works while every expert param is an empty ZeRO-3 placeholder.
+
+        The fake partitioned params carry only ``ds_shape``/``ds_status``, so
+        no DeepSpeed gather can materialize them: the attach can only succeed
+        by reading shapes without touching data, and any regression to
+        gathering the packed experts fails this test.
+        """
+        from peft.tuners.lora.layer import ParamWrapper
+
+        from agilerl.algorithms.core.llm_ops.moe_lora import (
+            RoutedExpertsLoraWrapper,
+        )
+
+        num_experts, hidden = 4, 8
+        lora = LoraConfig(
+            r=4,
+            lora_alpha=8,
+            lora_dropout=0.0,
+            target_modules=[],
+            target_parameters=["experts.up_proj", "experts.down_proj"],
+        )
+        agent = _make_llm_agent(lora_config=lora)
+        agent.selected_adapters = ("actor",)
+        agent.zero_stage = 3
+        base_model = _PackedMoeModel(num_experts=num_experts, hidden=hidden)
+        expert_params = [
+            param
+            for name, param in base_model.named_parameters()
+            if name.endswith(("up_proj", "down_proj"))
+        ]
+        assert len(expert_params) == 4
+        for param in expert_params:
+            param.ds_shape = tuple(param.shape)
+            param.ds_status = SimpleNamespace(name="NOT_AVAILABLE")
+            param.data = torch.empty(0)
+
+        mark = MagicMock()
+        with (
+            patch(
+                "agilerl.algorithms.core.base.adapt_lora_config_for_model",
+                side_effect=lambda _model, cfg, **kw: cfg,
+            ),
+            patch(
+                "agilerl.algorithms.core.base.patch_lora_for_fused_forward",
+                create=True,
+            ),
+            patch("agilerl.algorithms.core.base.HAS_LIGER_KERNEL", False),
+            patch(
+                "agilerl.algorithms.core.base.mark_expert_wrappers_as_zero3_leaves",
+                mark,
+            ),
+            patch.object(agent, "use_adapter"),
+        ):
+            LLMAlgorithm._initialize_actors(agent, base_model, add_adapters=True)
+
+        assert all(param.numel() == 0 for param in expert_params)
+        wrappers = [
+            module
+            for module in agent.actor.modules()
+            if isinstance(module, ParamWrapper)
+        ]
+        assert len(wrappers) == 4
+        upgraded = [w for w in wrappers if isinstance(w, RoutedExpertsLoraWrapper)]
+        assert len(upgraded) == 2
+        for wrapper in wrappers:
+            assert wrapper.num_experts == num_experts
+            lora_a = wrapper.lora_A["actor"].weight
+            assert lora_a.shape[0] == 4 * num_experts
+        mark.assert_called_once()
 
 
 @_LLM_DEPS_SKIP

--- a/tests/test_algorithms/test_llm_ops/test_moe_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_moe_lora.py
@@ -844,3 +844,108 @@ class TestMoeLoraFallbackBranches:
 
         assert out is sentinel
         base_forward.assert_called_once()
+
+
+@pytest.mark.gpu
+class TestZero3ExpertAttachMemory:
+    """Expert-LoRA attach on a zero.Init model must not gather the experts."""
+
+    def test_attach_peak_allocation_far_below_summed_expert_size(self) -> None:
+        import math
+        import os
+
+        if not torch.cuda.is_available():
+            pytest.skip("requires CUDA")
+        deepspeed = pytest.importorskip("deepspeed")
+        from peft import LoraConfig, get_peft_model
+
+        from agilerl.utils.llm_utils import zero3_full_shape_views
+
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("LOCAL_RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29531")
+        deepspeed.init_distributed(dist_backend="nccl")
+
+        num_layers, num_experts, hidden, intermediate = 4, 8, 1024, 2816
+
+        class BigExperts(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.num_experts = num_experts
+                self.up_proj = nn.Parameter(
+                    torch.empty(num_experts, intermediate, hidden)
+                )
+                self.down_proj = nn.Parameter(
+                    torch.empty(num_experts, hidden, intermediate)
+                )
+                self.act_fn = F.silu
+
+            def forward(self, hidden_states, top_k_index, top_k_weights):
+                return hidden_states
+
+        class BigMoeModel(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layers = nn.ModuleList()
+                for _ in range(num_layers):
+                    block = nn.Module()
+                    block.experts = BigExperts()
+                    self.layers.append(block)
+
+        # remote_device=cpu keeps the single-rank gather from aliasing the
+        # local shard, so a regression to gathering the packed experts
+        # re-allocates their full summed size on the GPU and trips the bound.
+        with deepspeed.zero.Init(
+            remote_device="cpu",
+            config_dict_or_path={
+                "train_batch_size": 1,
+                "train_micro_batch_size_per_gpu": 1,
+                "zero_optimization": {
+                    "stage": 3,
+                    "offload_param": {"device": "cpu"},
+                },
+            },
+        ):
+            model = BigMoeModel()
+
+        expert_params = [
+            param
+            for name, param in model.named_parameters()
+            if name.endswith(("up_proj", "down_proj"))
+        ]
+        assert len(expert_params) == 2 * num_layers
+        assert all(param.numel() == 0 for param in expert_params)
+        summed_expert_bytes = sum(
+            math.prod(param.ds_shape) * param.element_size() for param in expert_params
+        )
+
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        base_allocated = torch.cuda.memory_allocated()
+
+        config = LoraConfig(
+            r=8,
+            lora_alpha=16,
+            lora_dropout=0.0,
+            target_modules=[],
+            target_parameters=["experts.up_proj", "experts.down_proj"],
+        )
+        with zero3_full_shape_views(expert_params):
+            peft_model = get_peft_model(
+                model, config, adapter_name="actor", autocast_adapter_dtype=False
+            )
+        with zero3_full_shape_views(expert_params):
+            upgraded = upgrade_moe_param_wrappers(peft_model)
+
+        torch.cuda.synchronize()
+        peak_delta = torch.cuda.max_memory_allocated() - base_allocated
+
+        assert upgraded == num_layers
+        assert all(param.numel() == 0 for param in expert_params)
+        assert peak_delta < summed_expert_bytes // 10, (
+            f"attach peak delta {peak_delta / 2**20:.0f} MiB vs summed experts "
+            f"{summed_expert_bytes / 2**20:.0f} MiB"
+        )

--- a/tests/test_algorithms/test_llm_ops/test_moe_lora.py
+++ b/tests/test_algorithms/test_llm_ops/test_moe_lora.py
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import json
+import os
+import socket
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -850,28 +857,31 @@ class TestMoeLoraFallbackBranches:
 class TestZero3ExpertAttachMemory:
     """Expert-LoRA attach on a zero.Init model must not gather the experts."""
 
-    def test_attach_peak_allocation_far_below_summed_expert_size(self) -> None:
+    # deepspeed.init_distributed and zero.Init leave process-global state (a
+    # default process group, patched module construction), so the scenario
+    # runs in a subprocess to keep it out of other tests' processes.
+    _SCRIPT = textwrap.dedent(
+        """
+        import json
         import math
-        import os
 
-        if not torch.cuda.is_available():
-            pytest.skip("requires CUDA")
-        deepspeed = pytest.importorskip("deepspeed")
+        import deepspeed
+        import torch
+        import torch.nn as nn
+        import torch.nn.functional as F
         from peft import LoraConfig, get_peft_model
 
+        from agilerl.algorithms.core.llm_ops.moe_lora import (
+            upgrade_moe_param_wrappers,
+        )
         from agilerl.utils.llm_utils import zero3_full_shape_views
 
-        os.environ.setdefault("RANK", "0")
-        os.environ.setdefault("LOCAL_RANK", "0")
-        os.environ.setdefault("WORLD_SIZE", "1")
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", "29531")
         deepspeed.init_distributed(dist_backend="nccl")
-
         num_layers, num_experts, hidden, intermediate = 4, 8, 1024, 2816
 
+
         class BigExperts(nn.Module):
-            def __init__(self) -> None:
+            def __init__(self):
                 super().__init__()
                 self.num_experts = num_experts
                 self.up_proj = nn.Parameter(
@@ -885,14 +895,16 @@ class TestZero3ExpertAttachMemory:
             def forward(self, hidden_states, top_k_index, top_k_weights):
                 return hidden_states
 
+
         class BigMoeModel(nn.Module):
-            def __init__(self) -> None:
+            def __init__(self):
                 super().__init__()
                 self.layers = nn.ModuleList()
                 for _ in range(num_layers):
                     block = nn.Module()
                     block.experts = BigExperts()
                     self.layers.append(block)
+
 
         # remote_device=cpu keeps the single-rank gather from aliasing the
         # local shard, so a regression to gathering the packed experts
@@ -917,14 +929,15 @@ class TestZero3ExpertAttachMemory:
         ]
         assert len(expert_params) == 2 * num_layers
         assert all(param.numel() == 0 for param in expert_params)
-        summed_expert_bytes = sum(
-            math.prod(param.ds_shape) * param.element_size() for param in expert_params
+        summed = sum(
+            math.prod(param.ds_shape) * param.element_size()
+            for param in expert_params
         )
 
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
         torch.cuda.reset_peak_memory_stats()
-        base_allocated = torch.cuda.memory_allocated()
+        base = torch.cuda.memory_allocated()
 
         config = LoraConfig(
             r=8,
@@ -941,11 +954,52 @@ class TestZero3ExpertAttachMemory:
             upgraded = upgrade_moe_param_wrappers(peft_model)
 
         torch.cuda.synchronize()
-        peak_delta = torch.cuda.max_memory_allocated() - base_allocated
+        result = {
+            "peak_delta": torch.cuda.max_memory_allocated() - base,
+            "summed": summed,
+            "upgraded": upgraded,
+            "placeholders_empty": all(
+                param.numel() == 0 for param in expert_params
+            ),
+        }
+        print("RESULT " + json.dumps(result))
+        """
+    )
 
-        assert upgraded == num_layers
-        assert all(param.numel() == 0 for param in expert_params)
-        assert peak_delta < summed_expert_bytes // 10, (
-            f"attach peak delta {peak_delta / 2**20:.0f} MiB vs summed experts "
-            f"{summed_expert_bytes / 2**20:.0f} MiB"
+    def test_attach_peak_allocation_far_below_summed_expert_size(self) -> None:
+        if not torch.cuda.is_available():
+            pytest.skip("requires CUDA")
+        pytest.importorskip("deepspeed")
+
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        repo_root = Path(__file__).resolve().parents[3]
+        env = os.environ | {
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "WORLD_SIZE": "1",
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": str(port),
+            "PYTHONPATH": os.pathsep.join(
+                [str(repo_root), os.environ.get("PYTHONPATH", "")]
+            ).rstrip(os.pathsep),
+        }
+        proc = subprocess.run(
+            [sys.executable, "-c", self._SCRIPT],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
         )
+        assert proc.returncode == 0, (
+            f"attach subprocess failed\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+        result_line = next(
+            line for line in proc.stdout.splitlines() if line.startswith("RESULT ")
+        )
+        result = json.loads(result_line.removeprefix("RESULT "))
+        assert result["upgraded"] == 4
+        assert result["placeholders_empty"] is True
+        assert result["peak_delta"] < result["summed"] // 10, result

--- a/tests/test_utils/test_llm_utils.py
+++ b/tests/test_utils/test_llm_utils.py
@@ -86,6 +86,7 @@ from agilerl.utils.llm_utils import (
     stitch_completion_after_windowed_hf_generate,
     stitch_completion_after_windowed_vllm_generate,
     validate_importance_sampling_level,
+    zero3_full_shape_views,
 )
 from tests import TINY_LLM_FIXTURE_PATH
 
@@ -1066,6 +1067,61 @@ def test_adapter_checkpoint_params_covers_every_peft_adapter_checkpoint_key():
     assert len(gathered) == len(saved)
     for key, tensor in saved.items():
         assert tensor.data_ptr() in gathered_storage, key
+
+
+class TestZero3FullShapeViews:
+    @staticmethod
+    def _partitioned_param(shape, dtype=torch.float32):
+        param = nn.Parameter(torch.empty(0, dtype=dtype))
+        param.ds_shape = shape
+        param.ds_status = SimpleNamespace(name="NOT_AVAILABLE")
+        return param
+
+    def test_partitioned_param_exposes_full_shape_without_storage(self):
+        param = self._partitioned_param((4, 6, 3))
+        with zero3_full_shape_views([param, param]):
+            assert tuple(param.shape) == (4, 6, 3)
+            assert param.ndim == 3
+            assert param.data.untyped_storage().nbytes() <= param.element_size()
+        assert param.shape == torch.Size([0])
+        assert param.numel() == 0
+
+    def test_dtype_and_device_preserved(self):
+        param = self._partitioned_param((3, 4), dtype=torch.bfloat16)
+        with zero3_full_shape_views([param]):
+            assert param.dtype == torch.bfloat16
+            assert param.device == torch.device("cpu")
+
+    def test_non_ds_param_passes_through(self):
+        plain = nn.Parameter(torch.randn(2, 2))
+        original = plain.clone()
+        with zero3_full_shape_views([plain]):
+            assert torch.equal(plain, original)
+        assert torch.equal(plain, original)
+
+    def test_available_param_passes_through(self):
+        available = nn.Parameter(torch.randn(3))
+        available.ds_shape = (3,)
+        available.ds_status = SimpleNamespace(name="AVAILABLE")
+        original = available.clone()
+        with zero3_full_shape_views([available]):
+            assert torch.equal(available, original)
+        assert torch.equal(available, original)
+
+    def test_restores_placeholder_on_error(self):
+        param = self._partitioned_param((2, 5))
+
+        def read_shape_then_fail() -> None:
+            assert param.ndim == 2
+            error = RuntimeError("boom")
+            raise error
+
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            zero3_full_shape_views([param]),
+        ):
+            read_shape_then_fail()
+        assert param.shape == torch.Size([0])
 
 
 def _make_tokenizer(vocab_size: int = 100, prompt_len: int = 3) -> MagicMock:

--- a/tests/test_utils/test_zero3_patches.py
+++ b/tests/test_utils/test_zero3_patches.py
@@ -19,6 +19,7 @@ from agilerl.utils.zero3_patches import (
     install_zero3_patches,
     patch_zero3_fetch_trace,
     patch_zero3_param_persistence,
+    patch_zero3_persistent_release,
 )
 
 _DEFAULT_PARAM_THRESHOLD = 100_000
@@ -131,6 +132,7 @@ class TestImportDoesNotPullThirdParty:
             assert not hasattr(zero3_patches, name)
         assert callable(zero3_patches._resolve_zero3_targets)
         assert callable(zero3_patches._resolve_zero3_init)
+        assert callable(zero3_patches._resolve_zero3_release_targets)
 
 
 class TestInstallZero3ThirdPartyHooks:
@@ -140,6 +142,11 @@ class TestInstallZero3ThirdPartyHooks:
             zero3_patches,
             "patch_zero3_fetch_trace",
             lambda config: calls.append("fetch"),
+        )
+        monkeypatch.setattr(
+            zero3_patches,
+            "patch_zero3_persistent_release",
+            lambda **kwargs: calls.append("release"),
         )
         monkeypatch.setattr(
             zero3_patches,
@@ -154,7 +161,7 @@ class TestInstallZero3ThirdPartyHooks:
 
         install_zero3_patches({"zero_optimization": {"stage": 3}})
 
-        assert calls == ["fetch", "families"]
+        assert calls == ["fetch", "release", "families"]
 
     def test_family_dispatch_receives_the_checkpoint_id(self, monkeypatch):
         seen: list[str | None] = []
@@ -162,6 +169,11 @@ class TestInstallZero3ThirdPartyHooks:
             zero3_patches,
             "patch_zero3_fetch_trace",
             lambda config: None,
+        )
+        monkeypatch.setattr(
+            zero3_patches,
+            "patch_zero3_persistent_release",
+            lambda **kwargs: None,
         )
         monkeypatch.setattr(
             zero3_patches,
@@ -182,6 +194,11 @@ class TestInstallZero3ThirdPartyHooks:
             zero3_patches,
             "patch_zero3_fetch_trace",
             lambda config: None,
+        )
+        monkeypatch.setattr(
+            zero3_patches,
+            "patch_zero3_persistent_release",
+            lambda **kwargs: None,
         )
         monkeypatch.setattr(
             zero3_patches,
@@ -242,13 +259,18 @@ class TestInstallZero3ThirdPartyHooks:
         )
         monkeypatch.setattr(
             zero3_patches,
+            "patch_zero3_persistent_release",
+            lambda **kwargs: calls.append("release"),
+        )
+        monkeypatch.setattr(
+            zero3_patches,
             "patch_zero3_param_persistence",
             lambda *args, **kwargs: calls.append("persist"),
         )
 
         install_zero3_patches(config)
 
-        assert calls == ["fetch"]
+        assert calls == ["fetch", "release"]
 
 
 class TestZero3Resolvers:
@@ -277,6 +299,26 @@ class TestZero3Resolvers:
         monkeypatch.setattr(zero3_patches, "try_import", lambda _path: None)
 
         assert zero3_patches._resolve_zero3_init() is None
+
+    def test_resolve_release_targets_returns_none_triple_when_import_fails(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(zero3_patches, "try_import", lambda _path: None)
+
+        assert zero3_patches._resolve_zero3_release_targets() == (None, None, None)
+
+    def test_resolve_release_targets_raises_when_symbols_missing(
+        self, monkeypatch
+    ) -> None:
+        module = type(
+            "M",
+            (),
+            {"PartitionedParameterCoordinator": type("C", (), {})},
+        )()
+        monkeypatch.setattr(zero3_patches, "try_import", lambda _path: module)
+
+        with pytest.raises(RuntimeError, match="iter_params, z3_leaf_module"):
+            zero3_patches._resolve_zero3_release_targets()
 
     def test_snapshot_skips_attributes_the_coordinator_lacks(self) -> None:
         assert zero3_patches._snapshot_trace_state(object()) == {}
@@ -609,13 +651,30 @@ class TestZero3TraceInstallation:
 
 
 class _FakeZero3Init:
-    """Fake ``zero.Init`` exposing only the persistence class attributes."""
+    """Fake ``zero.Init`` mirroring the persistence class attributes and the
+    conversion-time persistence decision of deepspeed 0.19.3.
+    """
 
     param_persistence_threshold = _DEFAULT_PARAM_THRESHOLD
     model_persistence_threshold = _DEFAULT_MODEL_THRESHOLD
     num_persisted_parameters = 0
     num_persisted_elements = 0
     apply_param_persistence = False
+
+    def _convert_to_deepspeed_param(self, param):
+        param.ds_numel = param.numel()
+        if (
+            _FakeZero3Init.apply_param_persistence
+            and param.ds_numel <= _FakeZero3Init.param_persistence_threshold
+            and _FakeZero3Init.num_persisted_elements + param.ds_numel
+            <= _FakeZero3Init.model_persistence_threshold
+        ):
+            param.ds_persist = True
+            _FakeZero3Init.num_persisted_parameters += 1
+            _FakeZero3Init.num_persisted_elements += param.ds_numel
+        else:
+            param.ds_persist = False
+        param.is_external_param = False
 
 
 @pytest.fixture
@@ -629,6 +688,8 @@ def zero3_init_cls(monkeypatch):
     _FakeZero3Init.apply_param_persistence = False
     _FakeZero3Init.param_persistence_threshold = _DEFAULT_PARAM_THRESHOLD
     _FakeZero3Init.model_persistence_threshold = _DEFAULT_MODEL_THRESHOLD
+    _FakeZero3Init.num_persisted_parameters = 0
+    _FakeZero3Init.num_persisted_elements = 0
 
 
 class TestZero3ParamPersistence:
@@ -641,6 +702,38 @@ class TestZero3ParamPersistence:
         assert any(
             "param_threshold=50000" in record.message for record in caplog.records
         )
+
+    def test_params_created_under_init_after_patching_are_persistent(
+        self, zero3_init_cls
+    ):
+        patch_zero3_param_persistence(100_000, num_partitions=2)
+
+        model = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.LayerNorm(4))
+        context = zero3_init_cls()
+        for param in model.parameters():
+            context._convert_to_deepspeed_param(param)
+
+        assert all(param.ds_persist for param in model.parameters())
+        assert zero3_init_cls.num_persisted_parameters == 4
+
+    def test_unpatched_init_marks_nothing_persistent(self, zero3_init_cls):
+        model = torch.nn.Linear(4, 4)
+        context = zero3_init_cls()
+        for param in model.parameters():
+            context._convert_to_deepspeed_param(param)
+
+        assert not any(param.ds_persist for param in model.parameters())
+
+    def test_conversion_respects_param_threshold(self, zero3_init_cls):
+        patch_zero3_param_persistence(10, num_partitions=2)
+
+        model = torch.nn.Linear(4, 4)
+        context = zero3_init_cls()
+        for param in model.parameters():
+            context._convert_to_deepspeed_param(param)
+
+        assert model.weight.ds_persist is False
+        assert model.bias.ds_persist is True
 
     def test_model_threshold_is_divided_by_num_partitions(self, zero3_init_cls):
         patch_zero3_param_persistence(
@@ -740,3 +833,207 @@ class TestZero3ParamPersistence:
         assert zero3_init_cls.param_persistence_threshold == _DEFAULT_PARAM_THRESHOLD
         assert zero3_init_cls.model_persistence_threshold == _DEFAULT_MODEL_THRESHOLD
         assert any("disabled by caller" in record.message for record in caplog.records)
+
+
+class _FakeReleaseParam:
+    def __init__(self, ds_id, ds_persist=False, is_external_param=False):
+        self.ds_id = ds_id
+        self.ds_persist = ds_persist
+        self.is_external_param = is_external_param
+        self.release_count = 0
+        self.data_cleared = False
+
+
+class _FakeReleaseSubmodule:
+    def __init__(self, params, leaf=False):
+        self.params = list(params)
+        self.leaf = leaf
+
+
+def _make_release_coordinator_class():
+    """Fresh coordinator double mirroring the release guards of deepspeed
+    0.19.3: an incomplete trace selects every parameter for release, a
+    complete trace pre-filters persistent ones, and both the partition call
+    and the leaf-module data swap skip external parameters.
+    """
+
+    class PartitionedParameterCoordinator:
+        def __init__(self, complete_trace=False):
+            self.complete_trace = complete_trace
+
+        def is_complete_trace(self):
+            return self.complete_trace
+
+        def release_sub_module(self, submodule, forward=False):
+            params = list(submodule.params)
+            if self.is_complete_trace():
+                to_release = {p.ds_id for p in params if not p.ds_persist}
+            else:
+                to_release = {p.ds_id for p in params}
+            free_data = not submodule.leaf
+            for param in params:
+                if param.ds_id in to_release and not param.is_external_param:
+                    param.release_count += 1
+                if not free_data:
+                    if param.ds_id in to_release and not param.is_external_param:
+                        param.data_cleared = True
+
+        def release_and_reset_all(self, module):
+            for param in module.params:
+                param.release_count += 1
+
+    return PartitionedParameterCoordinator
+
+
+@pytest.fixture
+def release_coordinator_cls(monkeypatch):
+    cls = _make_release_coordinator_class()
+    recurse_calls = []
+
+    def fake_iter_params(module, recurse=False):
+        recurse_calls.append(recurse)
+        return list(module.params)
+
+    monkeypatch.setattr(
+        zero3_patches,
+        "_resolve_zero3_release_targets",
+        lambda: (cls, fake_iter_params, lambda module: module.leaf),
+    )
+    cls.recurse_calls = recurse_calls
+    return cls
+
+
+class TestZero3PersistentRelease:
+    """Persistent params stay resident on every release path but teardown."""
+
+    def test_incomplete_trace_keeps_persistent_params_resident(
+        self, release_coordinator_cls
+    ):
+        patch_zero3_persistent_release()
+        persistent = _FakeReleaseParam(1, ds_persist=True)
+        transient = _FakeReleaseParam(2)
+        submodule = _FakeReleaseSubmodule([persistent, transient])
+
+        release_coordinator_cls(complete_trace=False).release_sub_module(submodule)
+
+        assert persistent.release_count == 0
+        assert transient.release_count == 1
+
+    def test_external_flags_are_restored_after_release(self, release_coordinator_cls):
+        patch_zero3_persistent_release()
+        persistent = _FakeReleaseParam(1, ds_persist=True)
+        external = _FakeReleaseParam(2, ds_persist=True, is_external_param=True)
+        submodule = _FakeReleaseSubmodule([persistent, external])
+
+        release_coordinator_cls().release_sub_module(submodule)
+
+        assert persistent.is_external_param is False
+        assert external.is_external_param is True
+
+    def test_leaf_module_data_swap_skips_persistent_params(
+        self, release_coordinator_cls
+    ):
+        patch_zero3_persistent_release()
+        persistent = _FakeReleaseParam(1, ds_persist=True)
+        transient = _FakeReleaseParam(2)
+        submodule = _FakeReleaseSubmodule([persistent, transient], leaf=True)
+
+        release_coordinator_cls().release_sub_module(submodule)
+
+        assert persistent.data_cleared is False
+        assert transient.data_cleared is True
+        assert release_coordinator_cls.recurse_calls[-1] is True
+
+    def test_complete_trace_behaviour_is_unchanged(self, release_coordinator_cls):
+        patch_zero3_persistent_release()
+        persistent = _FakeReleaseParam(1, ds_persist=True)
+        transient = _FakeReleaseParam(2)
+        submodule = _FakeReleaseSubmodule([persistent, transient])
+
+        release_coordinator_cls(complete_trace=True).release_sub_module(submodule)
+
+        assert persistent.release_count == 0
+        assert transient.release_count == 1
+
+    def test_release_and_reset_all_still_releases_persistent_params(
+        self, release_coordinator_cls
+    ):
+        patch_zero3_persistent_release()
+        persistent = _FakeReleaseParam(1, ds_persist=True)
+        submodule = _FakeReleaseSubmodule([persistent])
+
+        release_coordinator_cls().release_and_reset_all(submodule)
+
+        assert persistent.release_count == 1
+
+    def test_flags_are_restored_when_release_raises(self, monkeypatch):
+        class PartitionedParameterCoordinator:
+            def release_sub_module(self, submodule, forward=False):
+                message = "boom"
+                raise RuntimeError(message)
+
+        monkeypatch.setattr(
+            zero3_patches,
+            "_resolve_zero3_release_targets",
+            lambda: (
+                PartitionedParameterCoordinator,
+                lambda module, recurse=False: list(module.params),
+                lambda module: module.leaf,
+            ),
+        )
+        patch_zero3_persistent_release()
+        persistent = _FakeReleaseParam(1, ds_persist=True)
+        submodule = _FakeReleaseSubmodule([persistent])
+
+        with pytest.raises(RuntimeError, match="boom"):
+            PartitionedParameterCoordinator().release_sub_module(submodule)
+
+        assert persistent.is_external_param is False
+
+    def test_apply_is_idempotent(self, release_coordinator_cls):
+        patch_zero3_persistent_release()
+        patched_once = release_coordinator_cls.release_sub_module
+
+        patch_zero3_persistent_release()
+
+        assert release_coordinator_cls.release_sub_module is patched_once
+
+    def test_disabled_leaves_release_unpatched(self, release_coordinator_cls, caplog):
+        original = release_coordinator_cls.release_sub_module
+
+        with caplog.at_level(logging.INFO):
+            patch_zero3_persistent_release(enabled=False)
+
+        assert release_coordinator_cls.release_sub_module is original
+        assert any("disabled by caller" in record.message for record in caplog.records)
+
+    def test_missing_release_sub_module_raises(self, monkeypatch):
+        class PartitionedParameterCoordinator:
+            pass
+
+        monkeypatch.setattr(
+            zero3_patches,
+            "_resolve_zero3_release_targets",
+            lambda: (
+                PartitionedParameterCoordinator,
+                lambda module, recurse=False: [],
+                lambda module: False,
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="lacks release_sub_module"):
+            patch_zero3_persistent_release()
+
+    def test_missing_coordinator_class_is_a_no_op(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            zero3_patches,
+            "_resolve_zero3_release_targets",
+            lambda: (None, None, None),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            patch_zero3_persistent_release()
+
+        assert any(
+            "coordinator unavailable" in record.message for record in caplog.records
+        )


### PR DESCRIPTION
**What**
Two ZeRO-3 fixes for MoE expert LoRA: attach adapters without all-gathering the packed experts, and keep small "persistent" parameters resident on every rank.

**Why**
On Nemotron-3.5-Nano-30B the attach all-gathered ~55 GB of expert weights per rank and OOMed 80 GB A100s. Separately, persistent parameters were released and re-gathered on every use — DeepSpeed only honours persistence once its fetch trace is complete, which leaf-module MoE models never reach — and that churn let the data-parallel ranks drift into mismatched allgathers that hung training on the NCCL watchdog.

**How**
PEFT only reads shapes, dtypes and devices when attaching, so partitioned expert params temporarily expose zero-storage full-shape views (`zero3_full_shape_views`) — no communication, no allocation. `patch_zero3_persistent_release` makes DeepSpeed's release path honour `ds_persist` while the trace is incomplete, so small params stay resident. Covered by CPU and subprocess-isolated GPU (zero.Init) regression tests; verified end-to-end on a 2-rank Nemotron-30B stage-3 cluster run — attach, learn step and weight sync all clean.

**Evidence**
Cluster run on 2 A100-80GB trainer ranks + 2 vLLM rollout engines (Nemotron-3.5-Nano-30B, GRPO multiturn, `zero_stage: 3`, expert `target_parameters`): the adapter attach completed on both ranks where it previously OOMed at ~77 GiB, both engines generated rollouts, learn step 1 completed (loss 0.004, kl 0.011, reward 0.96, accuracy 0.91), and the updated adapter NCCL-synced back to both engines (`rollout_version=1`). Without the persistent-release commit the same run hung mid learn step on a 900 s NCCL watchdog timeout, twice, with mirrored divergent allgathers in the flight-recorder dumps.