### PR TITLE
Mask zero-advantage samples instead of dropping them under data parallelism

### DIFF
--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -337,7 +337,9 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
         advantages before loss computation, defaults to None.
     :type adv_clip_range: float | None, optional
     :param filter_zero_adv: If ``True``, drop samples whose absolute
-        advantage is below ``adv_filter_eps``, defaults to False.
+        advantage is below ``adv_filter_eps``. Under multi-process training
+        the samples are kept with zeroed advantages instead, so every rank
+        runs the same collective schedule. Defaults to False.
     :type filter_zero_adv: bool, optional
     :param adv_filter_eps: Threshold used with
         ``filter_zero_adv``; samples with ``|advantage| <= eps`` are
@@ -1185,6 +1187,13 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
 
         if active_adv_mask is None:
             return advantages, np.arange(num_samples)
+        if self.accelerator is not None and self.accelerator.num_processes > 1:
+            # Dropping samples desyncs per-rank collective schedules under data
+            # parallelism; zeroed advantages keep the schedule with the same gradient.
+            keep = active_adv_mask.to(advantages.dtype).reshape(
+                num_samples, *([1] * (advantages.dim() - 1))
+            )
+            return advantages * keep, np.arange(num_samples)
         return advantages, np.where(active_adv_mask.detach().cpu().numpy())[0]
 
     def _assert_batch_divisible_by_group(self, num_samples: int) -> None:

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -3574,9 +3574,7 @@ class TestGRPOLearn:
             [[0.0], [2.0], [-2.0], [0.0]], dtype=torch.float32
         )
         grpo.accelerator = MagicMock(num_processes=2)
-        with patch.object(
-            grpo, "_trajectory_advantages", return_value=fake_advantages
-        ):
+        with patch.object(grpo, "_trajectory_advantages", return_value=fake_advantages):
             advantages, batch_idxs = grpo._calculate_advantages(
                 rewards, completion_ids, action_masks, None
             )
@@ -3599,9 +3597,7 @@ class TestGRPOLearn:
         fake_advantages = torch.tensor(
             [[0.0], [2.0], [-2.0], [0.0]], dtype=torch.float32
         )
-        with patch.object(
-            grpo, "_trajectory_advantages", return_value=fake_advantages
-        ):
+        with patch.object(grpo, "_trajectory_advantages", return_value=fake_advantages):
             advantages, batch_idxs = grpo._calculate_advantages(
                 rewards, completion_ids, action_masks, None
             )

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -3562,6 +3562,52 @@ class TestGRPOLearn:
         assert metrics["kl"] == pytest.approx(0.1)
         grpo.clean_up()
 
+    def test_filter_zero_adv_masks_instead_of_dropping_under_dp(self):
+        grpo = _make_cpu_grpo_for_branch_tests(
+            group_size=2,
+            filter_zero_adv=True,
+            adv_filter_eps=0.05,
+        )
+        completion_ids, action_masks = _build_branch_experiences(batch_size=4)
+        rewards = torch.tensor([1.0, 1.0, -1.0, 2.0], dtype=torch.float32)
+        fake_advantages = torch.tensor(
+            [[0.0], [2.0], [-2.0], [0.0]], dtype=torch.float32
+        )
+        grpo.accelerator = MagicMock(num_processes=2)
+        with patch.object(
+            grpo, "_trajectory_advantages", return_value=fake_advantages
+        ):
+            advantages, batch_idxs = grpo._calculate_advantages(
+                rewards, completion_ids, action_masks, None
+            )
+        assert list(batch_idxs) == [0, 1, 2, 3]
+        assert advantages[0].item() == 0.0
+        assert advantages[3].item() == 0.0
+        assert advantages[1].item() == pytest.approx(2.0)
+        assert advantages[2].item() == pytest.approx(-2.0)
+        grpo.accelerator = None
+        grpo.clean_up()
+
+    def test_filter_zero_adv_drops_samples_single_process(self):
+        grpo = _make_cpu_grpo_for_branch_tests(
+            group_size=2,
+            filter_zero_adv=True,
+            adv_filter_eps=0.05,
+        )
+        completion_ids, action_masks = _build_branch_experiences(batch_size=4)
+        rewards = torch.tensor([1.0, 1.0, -1.0, 2.0], dtype=torch.float32)
+        fake_advantages = torch.tensor(
+            [[0.0], [2.0], [-2.0], [0.0]], dtype=torch.float32
+        )
+        with patch.object(
+            grpo, "_trajectory_advantages", return_value=fake_advantages
+        ):
+            advantages, batch_idxs = grpo._calculate_advantages(
+                rewards, completion_ids, action_masks, None
+            )
+        assert list(batch_idxs) == [1, 2]
+        grpo.clean_up()
+
     def test_learn_records_the_window_action_tokens_of_active_samples(self):
         grpo = _make_cpu_grpo_for_branch_tests(
             group_size=2,


### PR DESCRIPTION
**What**
`filter_zero_adv` now masks (zeroes) sub-threshold advantages instead of dropping samples when `accelerator.num_processes > 1`. Single-process behaviour is unchanged.

**Why**
Per-rank sample dropping is unsound under data parallelism: it changes each rank's micro-batch count (desynchronizing ZeRO-3's per-micro-batch gather schedules), and a rank whose entire batch is filtered takes the all-filtered skip path — parking at `wait_for_everyone` — while peers with surviving samples enter the update's collectives. Observed as a 900 s NCCL watchdog deadlock on a 1-element ALLREDUCE at DP=2 with learner-sharded rollout groups and mostly-uniform cold-start rewards (Nemotron-3.5 sudoku, ray-dev-training-3174, 2026-08-11).

**How**
In `_calculate_advantages`, the multi-process path returns all sample indices with `|advantage| <= adv_filter_eps` entries zeroed — identical collective schedule on every rank, identical gradient to dropping. Tests cover the DP masking path, the unchanged single-process drop, and `num_processes == 1` with an accelerator present.