### PR TITLE
Mask zero-advantage samples instead of dropping them under multi-process GRPO

### DIFF
--- a/agilerl/algorithms/grpo.py
+++ b/agilerl/algorithms/grpo.py
@@ -336,8 +336,11 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
     :param adv_clip_range: Optional symmetric clamp range applied to
         advantages before loss computation, defaults to None.
     :type adv_clip_range: float | None, optional
-    :param filter_zero_adv: If ``True``, drop samples whose absolute
-        advantage is below ``adv_filter_eps``, defaults to False.
+    :param filter_zero_adv: If ``True``, filter samples whose absolute
+        advantage is below ``adv_filter_eps``. Single-process runs drop the
+        samples from the update; multi-process runs zero their advantages
+        instead, keeping the collective schedule identical on every rank,
+        defaults to False.
     :type filter_zero_adv: bool, optional
     :param adv_filter_eps: Threshold used with
         ``filter_zero_adv``; samples with ``|advantage| <= eps`` are
@@ -741,12 +744,13 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
             aux_metric = self.aux_metric_name
             effective_num_samples = len(batch_idxs)
             if effective_num_samples == 0:
+                # Single-process only: multi-process filtering masks advantages
+                # instead of dropping samples, so every rank always enters the
+                # update loop with the same number of micro-batches.
                 warnings.warn(
                     "All samples were filtered by advantage threshold; skipping GRPO update.",
                     stacklevel=2,
                 )
-                if self.accelerator is not None and self.accelerator.num_processes > 1:
-                    self.accelerator.wait_for_everyone()
                 return {"loss": 0.0, aux_metric: 0.0}
 
             updates = 0
@@ -1159,6 +1163,10 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
         per-trajectory ``(B, 1)`` and per-turn-broadcast ``(B, T-1)``
         advantages. Returns the advantages and the indices of samples that
         survive the zero-advantage filter (all samples when it is disabled).
+        Multi-process runs apply the filter by zeroing the advantages of
+        filtered samples and returning every index: each rank keeps its full
+        batch, so all ranks run the same forward/backward collective schedule
+        regardless of how many samples each one filters.
         """
         num_samples = completion_ids.shape[0]
         if self._resolve_advantage_granularity() == "turn" and turn_ids is not None:
@@ -1184,6 +1192,9 @@ class GRPO(LLMAlgorithm[LLMRolloutExperiences]):
             advantages = advantages.clamp(-self.adv_clip_range, self.adv_clip_range)
 
         if active_adv_mask is None:
+            return advantages, np.arange(num_samples)
+        if self.accelerator is not None and self.accelerator.num_processes > 1:
+            advantages = advantages * active_adv_mask.unsqueeze(-1).to(advantages.dtype)
             return advantages, np.arange(num_samples)
         return advantages, np.where(active_adv_mask.detach().cpu().numpy())[0]
 

--- a/tests/test_algorithms/test_llms/test_grpo.py
+++ b/tests/test_algorithms/test_llms/test_grpo.py
@@ -331,6 +331,16 @@ def _patch_surviving_sample_idxs(grpo, batch_idxs):
     return patch.object(grpo, "_calculate_advantages", side_effect=_with_batch_idxs)
 
 
+def _make_two_process_accelerator_mock():
+    """Mock a two-process accelerator whose gathers are single-rank identities."""
+    acc = MagicMock()
+    acc.num_processes = 2
+    acc.device = torch.device("cpu")
+    acc.gather.side_effect = lambda t: t
+    acc.free_memory.side_effect = lambda *objs: objs
+    return acc
+
+
 def _build_grpo_for_colocate_tests(
     grpo_factory,
     accelerator_factory,
@@ -3698,34 +3708,93 @@ class TestGRPOLearn:
         assert metrics == {"loss": 0.0, "kl": 0.0}
         grpo.clean_up()
 
-    def test_learn_early_return_waits_for_everyone_when_all_filtered(self):
+    def test_learn_multiprocess_all_filtered_masks_advantages_and_updates(self):
         grpo = _make_cpu_grpo_for_branch_tests(
             group_size=2,
             filter_zero_adv=True,
             adv_filter_eps=0.5,
             whiten_advantages=True,
         )
-        acc = MagicMock()
-        acc.num_processes = 2
-        acc.free_memory.side_effect = lambda *objs: objs
-        grpo.accelerator = acc
+        grpo.accelerator = _make_two_process_accelerator_mock()
         completion_ids, action_masks = _build_branch_experiences(batch_size=4)
         rewards = torch.tensor([1.0, 0.0, -1.0, 2.0], dtype=torch.float32)
+        seen_advantages: list[torch.Tensor] = []
+
+        def spy_loss(batch_size, minibatch_idxs, ids, masks, advantages, *args, **kw):
+            seen_advantages.append(advantages[minibatch_idxs])
+            return (
+                torch.tensor(0.0, dtype=torch.float32),
+                torch.tensor(0.0, dtype=torch.float32),
+            )
+
         with (
-            pytest.warns(
-                UserWarning,
-                match="All samples were filtered by advantage threshold; skipping GRPO update.",
-            ),
+            warnings.catch_warnings(),
             patch.object(
                 grpo,
                 "_calculate_advantage",
                 return_value=torch.zeros(4, 1, dtype=torch.float32),
             ),
+            patch.object(grpo, "_loss", side_effect=spy_loss) as mock_loss,
+            patch.object(grpo, "_backward_pass", return_value=None) as mock_backward,
         ):
+            warnings.filterwarnings(
+                "error", message="All samples were filtered by advantage threshold"
+            )
             metrics = grpo.learn((completion_ids, action_masks, rewards))
-        assert metrics == {"loss": 0.0, "kl": 0.0}
-        acc.wait_for_everyone.assert_called_once()
+        assert "completion_length" in metrics
+        assert mock_loss.call_count == mock_backward.call_count > 0
+        assert sum(adv.shape[0] for adv in seen_advantages) == 4
+        assert all(torch.all(adv == 0.0) for adv in seen_advantages)
+        grpo.accelerator.wait_for_everyone.assert_not_called()
         grpo.clean_up()
+
+    def test_learn_multiprocess_filtered_rank_matches_peer_and_has_zero_grads(self):
+        torch.manual_seed(42)
+        ranks = [
+            _make_cpu_grpo_for_branch_tests(
+                group_size=2,
+                filter_zero_adv=True,
+                adv_filter_eps=0.5,
+                beta=0.0,
+            )
+            for _ in range(2)
+        ]
+        backward_counts = []
+        for rank, rewards in zip(
+            ranks,
+            [
+                torch.tensor([1.0, 1.0, 2.0, 2.0], dtype=torch.float32),
+                torch.tensor([1.0, 1.0, -1.0, 2.0], dtype=torch.float32),
+            ],
+            strict=True,
+        ):
+            rank.accelerator = _make_two_process_accelerator_mock()
+            rank.micro_batch_size_per_gpu = 1
+            completion_ids, action_masks = _build_branch_experiences(batch_size=4)
+            with patch.object(
+                rank,
+                "_backward_pass",
+                side_effect=lambda loss: loss.backward(),
+            ) as mock_backward:
+                metrics = rank.learn((completion_ids, action_masks, rewards))
+            assert "completion_length" in metrics
+            backward_counts.append(mock_backward.call_count)
+        # Uniform rewards zero every advantage on rank 0 and half on rank 1;
+        # masking keeps all four samples on both ranks, so each runs the same
+        # four single-sample backward passes.
+        assert backward_counts == [4, 4]
+
+        filtered_grads = [
+            p.grad for p in ranks[0].actor.parameters() if p.grad is not None
+        ]
+        assert filtered_grads
+        assert all(torch.all(grad == 0.0) for grad in filtered_grads)
+        active_grads = [
+            p.grad for p in ranks[1].actor.parameters() if p.grad is not None
+        ]
+        assert any(torch.any(grad != 0.0) for grad in active_grads)
+        for rank in ranks:
+            rank.clean_up()
 
     def test_learn_raises_on_cross_rank_seq_len_mismatch(self):
         grpo = _make_cpu_grpo_for_branch_tests()


### PR DESCRIPTION
## What

`filter_zero_adv` decided per rank whether to drop samples — or skip the update entirely — which desynchronizes the collective schedule under data parallelism:

- When the filter dropped **every** sample on one rank, that rank warned, hit `wait_for_everyone()`, and returned early while its peers proceeded into the update's forward/backward/optimizer collectives. The mismatched schedules deadlock until the NCCL watchdog fires (observed on a CISPO multiturn run at DP=2 with mostly-uniform first-version rewards: one rank timed out on a 1-element ALLREDUCE 900s after the first learn step began).
- Even when every rank kept *some* samples, per-rank dropping breaks the equal micro-batch-count invariant that keeps ZeRO-3's per-micro-batch gather schedules aligned across ranks.

## Fix

When `accelerator.num_processes > 1`, the filter now **masks instead of drops**: every sample stays in the batch (identical collective schedule on every rank) and the advantages of samples with `|advantage| <= adv_filter_eps` are zeroed, so they contribute no policy gradient. Whitening statistics still exclude filtered samples, as before. Single-process runs keep the existing drop, where the compute saving is the point.

The all-filtered early return (and its barrier) is now reachable only single-process, so the barrier is removed.

## Tests

- `test_learn_multiprocess_all_filtered_masks_advantages_and_updates` — a 2-process rank whose samples are all under the threshold no longer skips: it runs the full update with all-zero advantages and never touches the barrier.
- `test_learn_multiprocess_filtered_rank_matches_peer_and_has_zero_grads` — two mocked ranks (one all-filtered via uniform group rewards, one half-filtered) run identical backward-pass counts, the filtered rank accumulates exactly zero gradient, and the active rank a nonzero one.
