### PR TITLE
Use the released Nemotron 3.5 Lightning model id

### DIFF
--- a/tests/test_architectures/test_dispatch.py
+++ b/tests/test_architectures/test_dispatch.py
@@ -13,7 +13,7 @@ class TestDetectModelFamilies:
         "name",
         [
             "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-            "NVIDIA-Nemotron-3.5-Nano-30B-A3B-BF16/",
+            "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/",
             "nvidia/Nemotron-H-8B-Base-8K",
             "/ckpt/nemotron_local",
             r"C:\ckpt\Nemotron-H-8B",


### PR DESCRIPTION
NVIDIA released this checkpoint as `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`. The `-Nano-` id in our family-detection fixture was the dev preview name.

The Hub redirects the old id to the new repo, so nothing was broken — this just stops the fixture asserting on a name that no longer exists.

`detect_model_families` matches on the `nemotron` substring, so the dispatch result is unchanged; `tests/test_architectures/test_dispatch.py` passes (14 passed).

The `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` id on the line above is a **different** model (v3, not 3.5) and is deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)