### PR TITLE
Require the runtime's training fields at Arena manifest validation

### DIFF
--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -220,7 +220,7 @@ class TrainingManifest(BaseModel):
 
     algorithm: AlgorithmFromManifest
     environment: EnvironmentFromManifest
-    training: TrainingSpec = Field(default_factory=TrainingSpec)
+    training: TrainingSpec
     network: NetworkFromManifest | None = Field(default=None)
     mutation: MutationSpec | None = Field(default=None)
     replay_buffer: ReplayBufferSpec | None = Field(default=None)

--- a/agilerl-arena/agilerl/arena/models/training.py
+++ b/agilerl-arena/agilerl/arena/models/training.py
@@ -51,11 +51,13 @@ class ReplayBufferSpec(BaseModel):
 class TrainingSpec(BaseModel):
     """Pydantic model for AgileRL training arguments.
 
-    :param max_steps: Maximum number of steps to train for. Defaults to 1,000,000.
-    :type max_steps: int
-    :param evo_steps: Number of steps to train between evolutions.
+    :param max_steps: Maximum number of steps to train for. Required by the runtime
+        unless ``num_epochs`` is set (epochs are converted to steps server-side).
+    :type max_steps: int | None
+    :param evo_steps: Number of steps to train between evolutions. Required by the
+        runtime unless ``num_epochs`` and ``evo_epochs`` are both set.
     :type evo_steps: int | None
-    :param pop_size: Number of agents in the population. Defaults to 1.
+    :param pop_size: Number of agents in the population.
     :type pop_size: int
     :param eval_steps: Number of steps to train for evaluation. Defaults to None.
     :type eval_steps: int | None
@@ -85,6 +87,9 @@ class TrainingSpec(BaseModel):
     :type evaluation_interval: int
     :param num_epochs: Number of epochs to train for.
     :type num_epochs: int | None
+    :param evo_epochs: Number of epochs between evolutions (converted to
+        ``evo_steps`` server-side alongside ``num_epochs``).
+    :type evo_epochs: int | None
     :param episode_steps: Number of steps to train for each episode (only applicable for bandits).
     :type episode_steps: int
     :param sum_scores: Whether to sum sub-agent scores (only applicable for multi-agent).
@@ -96,16 +101,16 @@ class TrainingSpec(BaseModel):
     :type experience_sharing: bool
     """
 
-    max_steps: int = Field(default=1_000_000, ge=1)
+    max_steps: int | None = Field(default=None, ge=1)
     evo_steps: int | None = Field(
         default=None,
-        ge=1,
+        ge=0,
         validation_alias=AliasChoices("metrics_interval", "evo_steps"),
     )
     pop_size: int = Field(
-        default=1, ge=1, validation_alias=AliasChoices("population_size", "pop_size")
+        ..., ge=1, validation_alias=AliasChoices("pop_size", "population_size")
     )
-    eval_steps: int | None = Field(default=None)
+    eval_steps: int | None = Field(default=None, ge=1)
     eval_loop: int = Field(default=1, ge=1)
     replay_buffer: ReplayBufferSpec | None = Field(default=None)
     hpo: bool = Field(default=True)
@@ -125,6 +130,7 @@ class TrainingSpec(BaseModel):
     # LLM-specific training parameters
     evaluation_interval: int = Field(default=10, ge=1)
     num_epochs: int | None = Field(default=None, ge=1)
+    evo_epochs: int | None = Field(default=None, ge=0)
 
     # Bandit-specific training parameters
     episode_steps: int = Field(default=500, ge=1)
@@ -140,10 +146,28 @@ class TrainingSpec(BaseModel):
 
     @model_validator(mode="after")
     def _validate_training_parameters(self) -> Self:
+        if self.max_steps is None and self.num_epochs is None:
+            msg = (
+                "max_steps is required (dataset-based training may set "
+                "num_epochs instead)."
+            )
+            raise ValueError(msg)
+        if self.evo_steps is None and (
+            self.num_epochs is None or self.evo_epochs is None
+        ):
+            msg = (
+                "evo_steps is required (dataset-based training may set "
+                "evo_epochs alongside num_epochs instead)."
+            )
+            raise ValueError(msg)
         if self.eval_steps is not None and self.eval_steps <= self.evaluation_interval:
             msg = "eval_steps must be greater than evaluation_interval"
             raise ValueError(msg)
-        if self.evo_steps is not None and self.evo_steps > self.max_steps:
+        if (
+            self.evo_steps is not None
+            and self.max_steps is not None
+            and self.evo_steps > self.max_steps
+        ):
             msg = f"evo_steps ({self.evo_steps}) must be less than or equal to max_steps ({self.max_steps})."
             raise ValueError(msg)
         if (

--- a/agilerl-arena/tests/generate_arena_manifests.py
+++ b/agilerl-arena/tests/generate_arena_manifests.py
@@ -99,7 +99,7 @@ def _build_manifest_dict(algorithm, algo_name: str) -> dict[str, Any]:
     data: dict[str, Any] = {
         "algorithm": algorithm,
         "environment": ArenaEnvSpec(name=_DEFAULT_ENV[algorithm.agent_type]),
-        "training": TrainingSpec(),
+        "training": TrainingSpec(max_steps=100_000, evo_steps=1_000, pop_size=1),
         "mutation": MutationSpec(),
         "selection_strategy": TournamentSelectionSpec(),
     }

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -42,6 +42,9 @@ def _manifest(**sections) -> dict:
     data = {
         "algorithm": sections.pop("algorithm", {"name": "DQN"}),
         "environment": sections.pop("environment", {"name": "CartPole-v1"}),
+        "training": sections.pop(
+            "training", {"max_steps": 10_000, "evo_steps": 100, "pop_size": 1}
+        ),
     }
     data.update(sections)
     return data
@@ -60,7 +63,7 @@ def test_env_spec_defaults() -> None:
 
 def test_training_and_replay_buffer_aliases() -> None:
     training = TrainingSpec.model_validate(
-        {"population_size": 4, "metrics_interval": 123}
+        {"max_steps": 1000, "population_size": 4, "metrics_interval": 123}
     )
     assert training.pop_size == 4
     assert training.evo_steps == 123
@@ -196,7 +199,11 @@ def test_get_validated_no_warning_for_aliased_fields() -> None:
         TrainingManifest.get_validated(
             _manifest(
                 algorithm={"name": "DQN", "lr": 3e-4},
-                training={"population_size": 4, "metrics_interval": 123},
+                training={
+                    "max_steps": 1000,
+                    "population_size": 4,
+                    "metrics_interval": 123,
+                },
                 replay_buffer={"memory_size": 4096},
             )
         )
@@ -383,21 +390,82 @@ def test_training_spec_rejects_invalid_eval_steps() -> None:
     with pytest.raises(
         ValueError, match="eval_steps must be greater than evaluation_interval"
     ):
-        TrainingSpec(eval_steps=10, evaluation_interval=10)
+        TrainingSpec(
+            max_steps=1000,
+            evo_steps=10,
+            pop_size=1,
+            eval_steps=10,
+            evaluation_interval=10,
+        )
 
 
 def test_training_spec_rejects_evo_steps_above_max_steps() -> None:
     with pytest.raises(
         ValueError, match=r"evo_steps .* must be less than or equal to max_steps"
     ):
-        TrainingSpec(max_steps=100, evo_steps=200)
+        TrainingSpec(max_steps=100, evo_steps=200, pop_size=1)
 
 
 def test_training_spec_rejects_eps_start_below_eps_end() -> None:
     with pytest.raises(
         ValueError, match=r"eps_start .* must be greater than or equal to eps_end"
     ):
-        TrainingSpec(eps_start=0.1, eps_end=0.9)
+        TrainingSpec(
+            max_steps=1000, evo_steps=10, pop_size=1, eps_start=0.1, eps_end=0.9
+        )
+
+
+class TestRuntimeRequiredTrainingFields:
+    """The runtime ``TrainingSpec`` requires these fields with no defaults."""
+
+    def test_rejects_manifest_missing_training_section(self) -> None:
+        manifest = _manifest()
+        del manifest["training"]
+        with pytest.raises(ValidationError, match="training"):
+            TrainingManifest.get_validated(manifest)
+
+    @pytest.mark.parametrize("missing", ["max_steps", "evo_steps", "pop_size"])
+    def test_rejects_manifest_missing_each_runtime_required_field(
+        self, missing: str
+    ) -> None:
+        training = {"max_steps": 1000, "evo_steps": 10, "pop_size": 1}
+        del training[missing]
+        with pytest.raises(ValidationError, match=missing):
+            TrainingManifest.get_validated(_manifest(training=training))
+
+    def test_rejects_empty_training_section(self) -> None:
+        with pytest.raises(ValidationError):
+            TrainingManifest.get_validated(_manifest(training={}))
+
+    def test_accepts_epoch_based_training(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _manifest(training={"num_epochs": 3, "evo_epochs": 1, "pop_size": 1})
+        )
+        assert payload["training"]["num_epochs"] == 3
+        assert payload["training"]["evo_epochs"] == 1
+        assert "max_steps" not in payload["training"]
+        assert "evo_steps" not in payload["training"]
+
+    def test_rejects_evo_epochs_without_num_epochs(self) -> None:
+        with pytest.raises(ValidationError, match="evo_steps is required"):
+            TrainingManifest.get_validated(
+                _manifest(training={"max_steps": 1000, "evo_epochs": 1, "pop_size": 1})
+            )
+
+    def test_accepts_zero_evo_steps(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _manifest(training={"max_steps": 1000, "evo_steps": 0, "pop_size": 1})
+        )
+        assert payload["training"]["evo_steps"] == 0
+
+    def test_rejects_zero_eval_steps(self) -> None:
+        with pytest.raises(ValidationError, match="eval_steps"):
+            TrainingSpec(max_steps=1000, evo_steps=10, pop_size=1, eval_steps=0)
+
+    def test_payload_carries_the_runtime_required_fields(self) -> None:
+        payload = TrainingManifest.get_validated(_manifest())
+        for key in ("max_steps", "evo_steps", "pop_size"):
+            assert key in payload["training"]
 
 
 def test_registry_override_logs_warning() -> None:
@@ -438,6 +506,7 @@ def test_python_manifest_accepts_network_spec_object() -> None:
         {
             "algorithm": {"name": "DQN"},
             "environment": {"name": "CartPole-v1"},
+            "training": {"max_steps": 10_000, "evo_steps": 100, "pop_size": 1},
             "network": QNetworkSpec(
                 encoder_config=MlpSpec(hidden_size=[64]),
                 head_config=MlpSpec(hidden_size=[64]),

--- a/agilerl-arena/tests/test_cli_manifest.py
+++ b/agilerl-arena/tests/test_cli_manifest.py
@@ -574,6 +574,7 @@ class TestArenaArchOptional:
         raw = {
             "algorithm": {"name": "PPO"},
             "environment": {"name": "merge-env", "version": "v1"},
+            "training": {"max_steps": 10_000, "evo_steps": 100, "pop_size": 1},
             "network": {
                 "arch": "mlp",
                 "encoder_config": {"hidden_size": [64]},
@@ -591,6 +592,7 @@ class TestArenaArchOptional:
         raw = {
             "algorithm": {"name": "PPO"},
             "environment": {"name": "merge-env", "version": "v1"},
+            "training": {"max_steps": 10_000, "evo_steps": 100, "pop_size": 1},
             "network": {"latent_dim": 64, "encoder_config": {"hidden_size": [64]}},
         }
         out = TrainingManifest.get_validated(raw, mode="json")
@@ -617,6 +619,7 @@ class TestArenaSimbaRecurrentConflict:
         raw = {
             "algorithm": {"name": "PPO", "recurrent": True},
             "environment": {"name": "merge-env", "version": "v1"},
+            "training": {"max_steps": 10_000, "evo_steps": 100, "pop_size": 1},
             "network": {"simba": True, "head_config": {"hidden_size": [64]}},
         }
         with pytest.raises(ValueError, match="cannot both be set"):
@@ -629,6 +632,7 @@ class TestArenaSimbaRecurrentConflict:
         raw = {
             "algorithm": {"name": "PPO"},
             "environment": {"name": "merge-env", "version": "v1"},
+            "training": {"max_steps": 10_000, "evo_steps": 100, "pop_size": 1},
             "network": {"simba": True, "head_config": {"hidden_size": [64]}},
         }
         manifest = TrainingManifest.model_validate(raw)

--- a/agilerl/models/training.py
+++ b/agilerl/models/training.py
@@ -182,6 +182,9 @@ class TrainingSpec(BaseModel):
     :type evaluation_interval: int
     :param num_epochs: Number of epochs to train for.
     :type num_epochs: int | None
+    :param evo_epochs: Number of epochs between evolutions (Arena converts to
+        ``evo_steps`` server-side alongside ``num_epochs``).
+    :type evo_epochs: int | None
     :param max_wall_seconds: Wall-clock limit for multi-turn LLM fine-tuning runs.
     :type max_wall_seconds: float | None
     :param episode_steps: Number of steps to train for each episode (only applicable for bandits).
@@ -224,6 +227,7 @@ class TrainingSpec(BaseModel):
     # LLM-specific training parameters
     evaluation_interval: int = Field(default=10, ge=1)
     num_epochs: int | None = Field(default=None, ge=1)
+    evo_epochs: int | None = Field(default=None, ge=0)
     max_wall_seconds: float | None = Field(default=None, gt=0)
 
     # Bandit-specific training parameters

--- a/configs/training/llm_finetuning/cispo.yaml
+++ b/configs/training/llm_finetuning/cispo.yaml
@@ -35,6 +35,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/configs/training/llm_finetuning/cispo_gemma4_group5.yaml
+++ b/configs/training/llm_finetuning/cispo_gemma4_group5.yaml
@@ -48,6 +48,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     max_wall_seconds: 200000
     pop_size: 1
     eval_loop: 1

--- a/configs/training/llm_finetuning/cispo_quant_bench.yaml
+++ b/configs/training/llm_finetuning/cispo_quant_bench.yaml
@@ -44,6 +44,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/configs/training/llm_finetuning/cispo_quant_bench_qwen.yaml
+++ b/configs/training/llm_finetuning/cispo_quant_bench_qwen.yaml
@@ -42,6 +42,7 @@ environment:
 
 training:
     max_steps: 4096
+    evo_steps: 4096
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/configs/training/llm_finetuning/grpo_multiturn.yaml
+++ b/configs/training/llm_finetuning/grpo_multiturn.yaml
@@ -23,6 +23,7 @@ environment:
 
 training:
     max_steps: 4096
+    evo_steps: 4096
     pop_size: 1
     evaluation_interval: 10
 

--- a/configs/training/llm_finetuning/gspo.yaml
+++ b/configs/training/llm_finetuning/gspo.yaml
@@ -35,6 +35,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/configs/training/llm_finetuning/ppo_llm_quant_bench.yaml
+++ b/configs/training/llm_finetuning/ppo_llm_quant_bench.yaml
@@ -49,6 +49,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/configs/training/llm_finetuning/reinforce_llm.yaml
+++ b/configs/training/llm_finetuning/reinforce_llm.yaml
@@ -36,6 +36,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/configs/training/llm_finetuning/reinforce_quant_bench.yaml
+++ b/configs/training/llm_finetuning/reinforce_quant_bench.yaml
@@ -39,6 +39,7 @@ environment:
 
 training:
     max_steps: 100000
+    evo_steps: 100000
     pop_size: 1
     eval_loop: 1
     evaluation_interval: 5

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -1030,11 +1030,20 @@ class TestTrainingManifestArenaBridge:
         core = TrainingManifest.from_trainer_specs(
             algorithm=PPOSpec(learn_step=64),
             environment=ArenaEnvSpec(name="CartPole-v1"),
-            training=TrainingSpec(max_steps=200),
+            training=TrainingSpec(max_steps=200, evo_steps=100),
         )
         submission = TrainingManifest.to_arena_manifest(core)
         assert submission["algorithm"]["name"] == "PPO"
         assert submission["environment"]["name"] == "CartPole-v1"
+
+    def test_to_arena_manifest_requires_evo_steps(self):
+        core = TrainingManifest.from_trainer_specs(
+            algorithm=PPOSpec(learn_step=64),
+            environment=ArenaEnvSpec(name="CartPole-v1"),
+            training=TrainingSpec(max_steps=200),
+        )
+        with pytest.raises(ValidationError, match="evo_steps is required"):
+            TrainingManifest.to_arena_manifest(core)
 
     def test_to_arena_manifest_from_yaml_path(self, tmp_path):
         manifest_path = tmp_path / "manifest.yaml"


### PR DESCRIPTION
## What

`arena experiments submit` accepts manifests the runtime rejects: a submitted experiments' manifest omitted `training.evo_steps`, validated clean, and killed a provisioned GPU cluster ~25 minutes later at runtime `TrainingSpec` build. Nine shipped `llm_finetuning` configs (including `cispo.yaml`, the source of that manifest) had the same omission.

## How

- Arena `TrainingSpec` now requires the runtime's required fields — `max_steps`, `evo_steps`, `pop_size` — with `num_epochs` / `evo_epochs` accepted as the epoch-based alternative the runtime converts to steps. Bounds aligned (`evo_steps` `ge=0`, `eval_steps` `ge=1`); `training:` section required; `evo_epochs` field added (arena + core, keeping the parity test true).
- Regression tests (`TestRuntimeRequiredTrainingFields`): a manifest missing each runtime-required field is rejected at validation time; epoch-based manifests accepted.
- The nine configs get `evo_steps` (all are `pop_size: 1`, so `evo_steps == max_steps`, the single-pop convention).
