### PR TITLE
Close more arena-vs-runtime manifest gaps

### DIFF
--- a/agilerl-arena/agilerl/arena/models/algo.py
+++ b/agilerl-arena/agilerl/arena/models/algo.py
@@ -107,7 +107,7 @@ class AlgorithmSpec(BaseModel):
 
     """
 
-    batch_size: int = Field(default=128, ge=1)
+    batch_size: int | None = Field(default=None, ge=1)
     hp_config: dict[str, RLHyperparameter] | None = None
 
     default_evo_steps: ClassVar[int] = 10_000
@@ -159,14 +159,14 @@ class LLMAlgorithmSpec(AlgorithmSpec):
     ``"preference"``, ``"sft"``, ``"multiturn"``).
     """
 
-    beta: float = Field(default=0.001, ge=0.0, le=1.0)
+    beta: float | None = Field(default=None, ge=0.0, le=1.0)
     max_grad_norm: float = Field(default=0.1, ge=0.0)
     update_epochs: int = Field(default=1, ge=1)
     reduce_memory_peak: bool = Field(default=False)
-    use_separate_reference_adapter: bool = Field(default=False)
+    use_separate_reference_adapter: bool | None = Field(default=None)
     calc_position_embeddings: bool = Field(default=True)
     gradient_checkpointing: bool = Field(default=True)
-    use_liger_loss: bool = Field(default=False)
+    use_liger_loss: bool | None = Field(default=None)
     seed: int = Field(default=42)
 
     # These fields come from the "network" section of the manifest

--- a/agilerl-arena/agilerl/arena/models/algorithms/grpo.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/grpo.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from agilerl.arena.models.algo import LLMAlgorithmSpec, register
 from agilerl.arena.models.env import LLMEnvType
@@ -20,15 +20,36 @@ class GRPOSpec(LLMAlgorithmSpec):
 
     group_size: int = Field(..., ge=1)
     lr: float = Field(default=0.0001, ge=0.0)
-    clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
+    clip_coef: float | tuple[float, float] = Field(default=0.2)
     temperature: float = Field(default=0.9)
-    max_output_tokens: int | None = Field(default=1024, exclude=True)
+    max_output_tokens: int | None = Field(default=None, ge=1)
     min_output_tokens: int | None = Field(default=None)
     cosine_lr_schedule_config: CosineLRScheduleConfig | None = Field(default=None)
     vllm_config: VLLMConfig | None = Field(default=None)
     use_vllm: bool = Field(default=False)
 
     env_type: ClassVar[LLMEnvType] = LLMEnvType.REASONING
+
+    @field_validator("clip_coef", mode="before")
+    @classmethod
+    def _coerce_clip_coef(cls, value: object) -> float | tuple[float, float]:
+        """Accept a symmetric scalar or an explicit (min, max) ratio pair."""
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        if isinstance(value, (list, tuple)):
+            if len(value) != 2:
+                msg = "clip_coef list/tuple must contain exactly two values."
+                raise ValueError(msg)
+            return (float(value[0]), float(value[1]))
+        msg = "clip_coef must be a float or a list/tuple of two floats."
+        raise ValueError(msg)
+
+    @model_validator(mode="after")
+    def _validate_clip_coef(self) -> GRPOSpec:
+        if isinstance(self.clip_coef, float) and not 0.0 <= self.clip_coef <= 1.0:
+            msg = "clip_coef scalar must be between 0.0 and 1.0."
+            raise ValueError(msg)
+        return self
 
     @model_validator(mode="after")
     def _validate_vllm_config(self) -> GRPOSpec:

--- a/agilerl-arena/agilerl/arena/models/algorithms/llmppo.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/llmppo.py
@@ -18,14 +18,14 @@ from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
 class LLMPPOSpec(LLMAlgorithmSpec):
     """Specification for LLMPPO algorithm."""
 
-    lr_actor: float = Field(default=5e-6, ge=0.0)
-    lr_critic: float | None = Field(default=5e-6, ge=0.0)
+    lr_actor: float = Field(default=5e-7, ge=0.0)
+    lr_critic: float | None = Field(default=5e-5, ge=0.0)
     vf_coef: float = Field(default=0.5, ge=0.0)
     clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
-    gamma: float = Field(default=0.99, ge=0.0, le=1.0)
-    gae_lambda: float = Field(default=0.95, ge=0.0, le=1.0)
+    gamma: float = Field(default=1.0, ge=0.0, le=1.0)
+    gae_lambda: float = Field(default=1.0, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
-    max_output_tokens: int | None = Field(default=1024, exclude=True)
+    max_output_tokens: int | None = Field(default=None, ge=1)
     min_output_tokens: int | None = Field(default=None)
     action_granularity: Literal["turn", "token", "auto"] = Field(default="auto")
     cosine_lr_schedule_config: CosineLRScheduleConfig | None = Field(default=None)

--- a/agilerl-arena/agilerl/arena/models/algorithms/llmreinforce.py
+++ b/agilerl-arena/agilerl/arena/models/algorithms/llmreinforce.py
@@ -18,11 +18,11 @@ from agilerl.arena.models.networks import CosineLRScheduleConfig, VLLMConfig
 class LLMREINFORCESpec(LLMAlgorithmSpec):
     """Specification for LLMREINFORCE algorithm."""
 
-    lr: float = Field(default=5e-6, ge=0.0)
+    lr: float = Field(default=5e-7, ge=0.0)
     clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
-    gamma: float = Field(default=0.99, ge=0.0, le=1.0)
+    gamma: float = Field(default=1.0, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
-    max_output_tokens: int | None = Field(default=1024, exclude=True)
+    max_output_tokens: int | None = Field(default=None, ge=1)
     min_output_tokens: int | None = Field(default=None)
     action_granularity: Literal["turn", "token", "auto"] = Field(default="auto")
     cosine_lr_schedule_config: CosineLRScheduleConfig | None = Field(default=None)

--- a/agilerl-arena/agilerl/arena/models/manifest.py
+++ b/agilerl-arena/agilerl/arena/models/manifest.py
@@ -27,6 +27,7 @@ from agilerl.arena.models.algo import (
     AlgoSpec,
     LLMAlgorithmSpec,
 )
+from agilerl.arena.models.env import LLMEnvType
 from agilerl.arena.models.hpo import MutationSpec, TournamentSelectionSpec
 from agilerl.arena.models.networks import FinetuningNetworkSpec
 from agilerl.arena.models.training import ReplayBufferSpec, TrainingSpec
@@ -265,16 +266,33 @@ class TrainingManifest(BaseModel):
             )
             self.algorithm.max_model_len = llm_network.max_context_length
 
-        if (
-            isinstance(self.algorithm, LLMAlgorithmSpec)
-            and self.algorithm.pretrained_model_name_or_path is None
-        ):
-            msg = (
-                "Required field 'pretrained_model_name_or_path' wasn't found in the manifest. "
-                "This is required for LLM finetuning algorithms, and can be added under either the "
-                "'algorithm' or 'network' sections."
+        if isinstance(self.algorithm, LLMAlgorithmSpec):
+            if self.algorithm.pretrained_model_name_or_path is None:
+                msg = (
+                    "Required field 'pretrained_model_name_or_path' wasn't found in the manifest. "
+                    "This is required for LLM finetuning algorithms, and can be added under either the "
+                    "'algorithm' or 'network' sections."
+                )
+                raise ValueError(msg)
+            network = dict(self.network or {})
+            lora_config = network.get("lora_config")
+            if lora_config is None and self.algorithm.lora_config is not None:
+                lora_config = self.algorithm.lora_config.model_dump(mode="json")
+            if lora_config is None:
+                msg = (
+                    "Required field 'lora_config' wasn't found in the manifest. "
+                    "LLM finetuning algorithms train a LoRA adapter, and the config can be added "
+                    "under either the 'algorithm' or 'network' sections."
+                )
+                raise ValueError(msg)
+            # The runtime reads both from the network section only.
+            network["lora_config"] = lora_config
+            network["pretrained_model_name_or_path"] = (
+                self.algorithm.pretrained_model_name_or_path
             )
-            raise ValueError(msg)
+            self.network = network
+
+        self._validate_environment()
 
         recurrent = bool(getattr(self.algorithm, "recurrent", False))
         simba = isinstance(self.network, dict) and bool(self.network.get("simba"))
@@ -286,6 +304,41 @@ class TrainingManifest(BaseModel):
             raise ValueError(msg)
 
         return self
+
+    def _validate_environment(self) -> None:
+        """Check the environment keys the runtime hard-requires per env kind."""
+        env_config = self.environment if isinstance(self.environment, dict) else {}
+
+        num_envs = env_config.get("num_envs")
+        if num_envs is not None and (
+            isinstance(num_envs, bool) or not isinstance(num_envs, int) or num_envs < 1
+        ):
+            msg = f"environment.num_envs must be an integer >= 1, got {num_envs!r}."
+            raise ValueError(msg)
+
+        if isinstance(self.algorithm, LLMAlgorithmSpec):
+            valid = ", ".join(t.value for t in LLMEnvType)
+            raw_env_type = env_config.get("env_type")
+            if raw_env_type is None:
+                msg = (
+                    "Required field 'environment.env_type' wasn't found in the manifest. "
+                    f"This is required for LLM finetuning algorithms; valid values: {valid}."
+                )
+                raise ValueError(msg)
+            try:
+                env_type = LLMEnvType(raw_env_type)
+            except ValueError as err:
+                msg = f"Invalid environment.env_type {raw_env_type!r}; valid values: {valid}."
+                raise ValueError(msg) from err
+            if env_type is LLMEnvType.MULTITURN and not env_config.get("entrypoint"):
+                msg = (
+                    "Required field 'environment.entrypoint' wasn't found in the manifest "
+                    "(required when environment.env_type is 'multiturn')."
+                )
+                raise ValueError(msg)
+        elif not env_config.get("name"):
+            msg = "Required field 'environment.name' wasn't found in the manifest."
+            raise ValueError(msg)
 
     @staticmethod
     def _load_yaml(path: str | Path) -> dict[str, Any]:

--- a/agilerl-arena/agilerl/arena/models/training.py
+++ b/agilerl-arena/agilerl/arena/models/training.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import AliasChoices, BaseModel, Field, model_validator
 from typing_extensions import Self
 
@@ -22,6 +24,12 @@ class PerBufferArgs(BaseModel):
 class ReplayBufferSpec(BaseModel):
     """Pydantic model for AgileRL replay buffers.
 
+    :param name: Buffer name forwarded to the runtime (the platform fills a
+        default when unset).
+    :type name: str | None
+    :param kind: Runtime buffer kind — ``"classic"`` (default) or ``"llm"``
+        (async rollout deque).
+    :type kind: Literal["classic", "llm"] | None
     :param memory_size: The memory size of the replay buffer. Defaults to 100,000.
     :type memory_size: int
     :param standard_buffer: Whether to use the standard replay buffer. Defaults to True.
@@ -38,6 +46,8 @@ class ReplayBufferSpec(BaseModel):
     :type n_step: int | None
     """
 
+    name: str | None = Field(default=None)
+    kind: Literal["classic", "llm"] | None = Field(default=None)
     max_size: int = Field(
         default=100_000, ge=1, validation_alias=AliasChoices("max_size", "memory_size")
     )

--- a/agilerl-arena/tests/generate_arena_manifests.py
+++ b/agilerl-arena/tests/generate_arena_manifests.py
@@ -86,7 +86,10 @@ def _attach_default_network(algorithm) -> None:
 def _default_algorithm_spec(name: str):
     spec_cls = ARENA_REGISTRY.get(name).spec_cls
     if issubclass(spec_cls, LLMAlgorithmSpec):
-        kwargs: dict = {"pretrained_model_name_or_path": _TINY_LLM}
+        kwargs: dict = {
+            "pretrained_model_name_or_path": _TINY_LLM,
+            "lora_config": {"lora_r": 8, "lora_alpha": 16},
+        }
         if name in _GRPO_FAMILY:
             kwargs["group_size"] = 2
         return spec_cls(**kwargs)
@@ -94,11 +97,19 @@ def _default_algorithm_spec(name: str):
     return spec_cls()
 
 
+def _default_environment(algorithm) -> dict[str, Any]:
+    """Environment section with the keys the runtime requires for the agent type."""
+    env = ArenaEnvSpec(name=_DEFAULT_ENV[algorithm.agent_type]).model_dump()
+    if isinstance(algorithm, LLMAlgorithmSpec):
+        env["env_type"] = str(type(algorithm).env_type)
+    return env
+
+
 def _build_manifest_dict(algorithm, algo_name: str) -> dict[str, Any]:
     """Assemble a manifest dict from arena model instances."""
     data: dict[str, Any] = {
         "algorithm": algorithm,
-        "environment": ArenaEnvSpec(name=_DEFAULT_ENV[algorithm.agent_type]),
+        "environment": _default_environment(algorithm),
         "training": TrainingSpec(max_steps=100_000, evo_steps=1_000, pop_size=1),
         "mutation": MutationSpec(),
         "selection_strategy": TournamentSelectionSpec(),

--- a/agilerl-arena/tests/test_arena_models.py
+++ b/agilerl-arena/tests/test_arena_models.py
@@ -313,10 +313,11 @@ def test_llm_pretrained_model_can_come_from_network_section() -> None:
     payload = TrainingManifest.get_validated(
         _manifest(
             algorithm={"name": "DPO"},
-            environment={"name": "my-llm-env"},
+            environment={"name": "my-llm-env", "env_type": "preference"},
             network={
                 "pretrained_model_name_or_path": "Qwen/Qwen2.5-0.5B-Instruct",
                 "max_context_length": 2048,
+                "lora_config": {"lora_r": 16},
             },
         )
     )
@@ -324,13 +325,16 @@ def test_llm_pretrained_model_can_come_from_network_section() -> None:
         "Qwen/Qwen2.5-0.5B-Instruct"
     )
     assert payload["algorithm"]["max_model_len"] == 2048
+    assert payload["network"]["pretrained_model_name_or_path"] == (
+        "Qwen/Qwen2.5-0.5B-Instruct"
+    )
 
 
 def test_llm_lora_and_max_output_tokens_excluded_from_algorithm() -> None:
     payload = TrainingManifest.get_validated(
         _manifest(
             algorithm={"name": "GRPO", "group_size": 8},
-            environment={"name": "my-llm-env"},
+            environment={"name": "my-llm-env", "env_type": "reasoning"},
             network={
                 "pretrained_model_name_or_path": "Qwen/Qwen2.5-0.5B-Instruct",
                 "max_context_length": 512,
@@ -466,6 +470,176 @@ class TestRuntimeRequiredTrainingFields:
         payload = TrainingManifest.get_validated(_manifest())
         for key in ("max_steps", "evo_steps", "pop_size"):
             assert key in payload["training"]
+
+
+def _llm_manifest(**sections) -> dict:
+    """Build an LLM (GRPO) manifest dict with runtime-valid defaults."""
+    data = {
+        "algorithm": sections.pop("algorithm", {"name": "GRPO", "group_size": 4}),
+        "environment": sections.pop(
+            "environment", {"env_type": "reasoning", "dataset": "my/dataset"}
+        ),
+        "network": sections.pop(
+            "network",
+            {
+                "pretrained_model_name_or_path": "Qwen/Qwen2.5-0.5B-Instruct",
+                "max_context_length": 512,
+                "lora_config": {"lora_r": 8},
+            },
+        ),
+    }
+    return _manifest(**data, **sections)
+
+
+class TestRuntimeContractDivergences:
+    """Payload shape the runtime hard-requires beyond the training section."""
+
+    def test_llm_manifest_requires_lora_config(self) -> None:
+        with pytest.raises(ValidationError, match="lora_config"):
+            TrainingManifest.get_validated(
+                _llm_manifest(
+                    network={
+                        "pretrained_model_name_or_path": "Qwen/Qwen2.5-0.5B-Instruct",
+                        "max_context_length": 512,
+                    }
+                )
+            )
+
+    def test_lora_config_from_algorithm_lands_in_network_section(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(
+                algorithm={
+                    "name": "GRPO",
+                    "group_size": 4,
+                    "pretrained_model_name_or_path": "Qwen/Qwen2.5-0.5B-Instruct",
+                    "lora_config": {"lora_r": 32},
+                },
+                network=None,
+            )
+        )
+        assert payload["network"]["lora_config"]["lora_r"] == 32
+        assert payload["network"]["pretrained_model_name_or_path"] == (
+            "Qwen/Qwen2.5-0.5B-Instruct"
+        )
+
+    def test_llm_manifest_requires_env_type(self) -> None:
+        with pytest.raises(ValidationError, match=r"environment\.env_type"):
+            TrainingManifest.get_validated(
+                _llm_manifest(environment={"dataset": "my/dataset"})
+            )
+
+    def test_llm_manifest_rejects_invalid_env_type(self) -> None:
+        with pytest.raises(ValidationError, match=r"Invalid environment\.env_type"):
+            TrainingManifest.get_validated(
+                _llm_manifest(environment={"env_type": "chat", "dataset": "d"})
+            )
+
+    def test_multiturn_requires_entrypoint(self) -> None:
+        with pytest.raises(ValidationError, match=r"environment\.entrypoint"):
+            TrainingManifest.get_validated(
+                _llm_manifest(environment={"env_type": "multiturn"})
+            )
+
+    def test_multiturn_with_entrypoint_validates(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(
+                environment={
+                    "env_type": "multiturn",
+                    "entrypoint": "game:GuessTheNumber-v0-easy",
+                }
+            )
+        )
+        assert payload["environment"]["entrypoint"] == "game:GuessTheNumber-v0-easy"
+
+    def test_rl_manifest_requires_environment_name(self) -> None:
+        with pytest.raises(ValidationError, match=r"environment\.name"):
+            TrainingManifest.get_validated(_manifest(environment={}))
+
+    def test_rejects_invalid_num_envs(self) -> None:
+        with pytest.raises(ValidationError, match="num_envs"):
+            TrainingManifest.get_validated(
+                _manifest(environment={"name": "CartPole-v1", "num_envs": 0})
+            )
+
+    def test_max_output_tokens_reaches_the_payload(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(
+                algorithm={"name": "GRPO", "group_size": 4, "max_output_tokens": 512}
+            )
+        )
+        assert payload["algorithm"]["max_output_tokens"] == 512
+
+    def test_max_output_tokens_absent_when_unset(self) -> None:
+        payload = TrainingManifest.get_validated(_llm_manifest())
+        assert "max_output_tokens" not in payload["algorithm"]
+
+    def test_clip_coef_accepts_a_ratio_pair(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(
+                algorithm={"name": "CISPO", "group_size": 4, "clip_coef": [0.8, 2.0]}
+            )
+        )
+        assert payload["algorithm"]["clip_coef"] == [0.8, 2.0]
+
+    def test_clip_coef_scalar_still_bounded(self) -> None:
+        with pytest.raises(ValidationError, match="clip_coef scalar"):
+            TrainingManifest.get_validated(
+                _llm_manifest(
+                    algorithm={"name": "GRPO", "group_size": 4, "clip_coef": 1.5}
+                )
+            )
+
+    def test_client_no_longer_injects_runtime_defaulted_fields(self) -> None:
+        payload = TrainingManifest.get_validated(_llm_manifest())
+        for key in (
+            "batch_size",
+            "beta",
+            "use_separate_reference_adapter",
+            "use_liger_loss",
+        ):
+            assert key not in payload["algorithm"]
+        rl_payload = TrainingManifest.get_validated(_manifest())
+        assert "batch_size" not in rl_payload["algorithm"]
+
+    def test_explicit_adapter_flags_reach_the_payload(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(
+                algorithm={
+                    "name": "GRPO",
+                    "group_size": 4,
+                    "use_separate_reference_adapter": False,
+                    "use_liger_loss": False,
+                }
+            )
+        )
+        assert payload["algorithm"]["use_separate_reference_adapter"] is False
+        assert payload["algorithm"]["use_liger_loss"] is False
+
+    def test_llmppo_defaults_match_the_runtime(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(algorithm={"name": "LLMPPO"})
+        )
+        algo = payload["algorithm"]
+        assert algo["lr_actor"] == 5e-7
+        assert algo["lr_critic"] == 5e-5
+        assert algo["gamma"] == 1.0
+        assert algo["gae_lambda"] == 1.0
+
+    def test_llmreinforce_defaults_match_the_runtime(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _llm_manifest(algorithm={"name": "LLMREINFORCE"})
+        )
+        assert payload["algorithm"]["lr"] == 5e-7
+        assert payload["algorithm"]["gamma"] == 1.0
+
+    def test_replay_buffer_name_and_kind_pass_through(self) -> None:
+        payload = TrainingManifest.get_validated(
+            _manifest(
+                replay_buffer={"name": "buffer", "kind": "classic", "max_size": 1000}
+            )
+        )
+        assert payload["replay_buffer"]["name"] == "buffer"
+        assert payload["replay_buffer"]["kind"] == "classic"
 
 
 def test_registry_override_logs_warning() -> None:

--- a/agilerl/models/algorithms/llmppo.py
+++ b/agilerl/models/algorithms/llmppo.py
@@ -24,12 +24,12 @@ else:
 class LLMPPOSpec(LLMAlgorithmSpec):
     """Specification for LLMPPO algorithm."""
 
-    lr_actor: float = Field(default=5e-6, ge=0.0)
-    lr_critic: float | None = Field(default=5e-6, ge=0.0)
+    lr_actor: float = Field(default=5e-7, ge=0.0)
+    lr_critic: float | None = Field(default=5e-5, ge=0.0)
     vf_coef: float = Field(default=0.5, ge=0.0)
     clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
-    gamma: float = Field(default=0.99, ge=0.0, le=1.0)
-    gae_lambda: float = Field(default=0.95, ge=0.0, le=1.0)
+    gamma: float = Field(default=1.0, ge=0.0, le=1.0)
+    gae_lambda: float = Field(default=1.0, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
     max_output_tokens: int | None = Field(default=1024)
     min_output_tokens: int | None = Field(default=None)

--- a/agilerl/models/algorithms/llmreinforce.py
+++ b/agilerl/models/algorithms/llmreinforce.py
@@ -24,9 +24,9 @@ else:
 class LLMREINFORCESpec(LLMAlgorithmSpec):
     """Specification for LLMREINFORCE algorithm."""
 
-    lr: float = Field(default=5e-6, ge=0.0)
+    lr: float = Field(default=5e-7, ge=0.0)
     clip_coef: float = Field(default=0.2, ge=0.0, le=1.0)
-    gamma: float = Field(default=0.99, ge=0.0, le=1.0)
+    gamma: float = Field(default=1.0, ge=0.0, le=1.0)
     temperature: float = Field(default=0.9)
     max_output_tokens: int | None = Field(default=1024)
     min_output_tokens: int | None = Field(default=None)

--- a/agilerl/models/training.py
+++ b/agilerl/models/training.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import AliasChoices, BaseModel, Field, model_validator
 from typing_extensions import Self
@@ -44,8 +44,14 @@ class ReplayBufferSpec(BaseModel):
     :type per_buffer_args: PerBufferArgs
     :param n_step: The number of steps to use for the n-step replay buffer. Defaults to None.
     :type n_step: int | None
+    :param name: Buffer name forwarded to the Arena runtime.
+    :type name: str | None
+    :param kind: Arena runtime buffer kind — ``"classic"`` (default) or ``"llm"``.
+    :type kind: Literal["classic", "llm"] | None
     """
 
+    name: str | None = Field(default=None)
+    kind: Literal["classic", "llm"] | None = Field(default=None)
     max_size: int = Field(
         default=100_000, ge=1, validation_alias=AliasChoices("max_size", "memory_size")
     )

--- a/configs/training/llm_finetuning/dpo.yaml
+++ b/configs/training/llm_finetuning/dpo.yaml
@@ -11,6 +11,7 @@ algorithm:
     use_separate_reference_adapter: true
 
 environment:
+    env_type: preference
     dataset: HumanLLMs/Human-Like-DPO-Dataset
 
 training:

--- a/configs/training/llm_finetuning/grpo_multiturn.yaml
+++ b/configs/training/llm_finetuning/grpo_multiturn.yaml
@@ -18,7 +18,7 @@ algorithm:
 
 environment:
     env_type: multiturn
-    env_name: game:GuessTheNumber-v0-easy
+    entrypoint: game:GuessTheNumber-v0-easy
     max_reward: 1.0
 
 training:

--- a/configs/training/llm_finetuning/reinforce_quant_bench.yaml
+++ b/configs/training/llm_finetuning/reinforce_quant_bench.yaml
@@ -33,7 +33,7 @@ algorithm:
 
 environment:
     env_type: multiturn
-    env_name: game:Sudoku-v0-hard
+    entrypoint: game:Sudoku-v0-hard
     max_turns: 50
     max_reward: 1.0
 

--- a/configs/training/sft.yaml
+++ b/configs/training/sft.yaml
@@ -10,6 +10,7 @@ algorithm:
     gradient_checkpointing: true
 
 environment:
+    env_type: sft
     dataset: HumanLLMs/Human-Like-DPO-Dataset
     response_column: chosen
 


### PR DESCRIPTION
## What

Fixes the remaining high-severity arena-vs-runtime schema divergences from the audit on #665 (its first comment): manifests that validate at submit but crash the provisioned cluster (missing `lora_config`, `env_type`, multiturn `entrypoint`, RL env `name`), client-injected hyperparameter defaults that silently override the runtime's (DPO `beta` 100× off, `batch_size` 128 vs 32, LLMPPO/LLMREINFORCE learning rates 10× off), `max_output_tokens` validated then discarded (`exclude=True`), the GRPO-family `clip_coef` ratio pair rejected at submit though valid at runtime, and `replay_buffer.name`/`kind` stripped from the payload. Verified end-to-end against the platform's ingest pipeline (strip lists + typed round trip), which determined where each fix belongs. Stacked on #665.

## How

- `TrainingManifest` now requires `lora_config` for LLM algorithms (accepted under `algorithm:` or `network:`, always normalised into the network section the runtime reads, killing the `KeyError`/`TypeError` class) and validates the environment keys the runtime hard-indexes: `env_type` (valid enum member) for LLM, `entrypoint` for multiturn, `name` for RL, `num_envs >= 1` when present.
- Client defaults for runtime-defaulted fields are no longer invented: `batch_size`, `beta`, `use_separate_reference_adapter`, `use_liger_loss` become unset-by-default (only explicit values are serialized; the DPO `beta` omission now correctly lands at 0.1). LLMPPO/LLMREINFORCE spec defaults are pinned to the algorithm constructors' values (`lr_actor` 5e-7, `lr_critic` 5e-5, `gamma`/`gae_lambda` 1.0; REINFORCE `lr` 5e-7, `gamma` 1.0) in both the arena and core models — the core specs had drifted from their own algorithms.
- `max_output_tokens` loses `exclude=True` (unset stays unset, explicit values finally reach the payload); GRPO-family `clip_coef` accepts the runtime's `(min, max)` ratio pair (unblocks the CISPO bench manifests); `replay_buffer` gains `name`/`kind` passthrough (`kind: classic | llm`, matching the runtime rename in !262).
- Shipped-config repairs: `grpo_multiturn.yaml` / `reinforce_quant_bench.yaml` used `env_name:`, a key the runtime never reads (→ `entrypoint:`); `dpo.yaml` / `sft.yaml` lacked `env_type`.
- 17 new regression tests (`TestRuntimeContractDivergences`); arena suite 1117 green, core model/trainer suites 644 green, parity tests green.

Companion platform MR (forwards the adapter/liger flags the platform previously stripped, and fixes `TurnPpoAlgorithmSpec`/`TurnReinforceAlgorithmSpec` missing `#[serde(default)]`): https://gitlab.agilerl.rlops.ai/containers/agilerl-platform/-/merge_requests/2023

Known residual (documented, deliberately not changed here): platform-injected defaults that differ from the runtime's (`batch_size` 16 for GRPO/DPO/SFT vs runtime 32; TurnPPO/TurnREINFORCE `lr`/`gamma`/`gae_lambda` struct defaults feed the UI and were left as a product decision), and `vllm_config`/`use_vllm`/`cosine_lr_schedule_config`/`seed` are still stripped server-side so arena values remain dead keys.
