### PR TITLE
Function-Preserving Node Addition & Layer Addition Architecture Mutations

### DIFF
--- a/agilerl/hpo/mutation.py
+++ b/agilerl/hpo/mutation.py
@@ -28,6 +28,8 @@ from agilerl.utils.mutation_utils import (
     as_module_dict,
     get_exp_layer,
     is_module_dict,
+    pre_mutation_widths,
+    preserve_architecture_mutation,
     reinit_shared_networks,
     reset_dormant_neurons,
     set_global_seed,
@@ -60,7 +62,8 @@ class Mutations:
     can be applied to an agent are:
 
     * No mutation
-    * Network architecture mutation - adding layers or nodes. Trained weights are reused and new weights are initialized randomly.
+    * Network architecture mutation - adding layers or nodes. Trained weights are reused, and added capacity is initialized to preserve the network's function
+      where the architecture allows it (see :ref:`function_preserving`), and randomly otherwise.
     * Network parameters mutation - mutating weights with Gaussian noise, preceded by ReGraMa resets of the neurons that have gone dormant.
     * Network activation layer mutation - change of activation layer.
     * RL algorithm mutation - mutation of learning hyperparameter, (e.g. learning rate or batch size).
@@ -204,6 +207,10 @@ class Mutations:
         self.accelerator = accelerator
 
         self.dormant_threshold = dormant_threshold
+        # The noise used to initialise new units in function-preserving architecture mutations is
+        # drawn independently not to affect the trajectory of the random generator used for mutations,
+        # as the number of neurons added depends on the generator carried by the evolvable module.
+        self._fp_rng = np.random.default_rng(rand_seed)
 
         self.pretraining_mut_options, self.pretraining_mut_proba = (
             self._get_mutations_options(pretraining=True)
@@ -1078,6 +1085,7 @@ class Mutations:
             )
 
         applied_mut_dict = applied_mut_dict or {}
+        before = None
         mut_dict = None
         if mut_method is None:
             mut_dict = {}
@@ -1093,10 +1101,19 @@ class Mutations:
                     msg,
                 )
 
+            before = pre_mutation_widths(network, mut_method)
             mut_dict = getattr(network, mut_method)(**applied_mut_dict)
 
         mut_dict = mut_dict or {}
         applied_mut = network.last_mutation_attr
+        if before is not None:
+            preserve_architecture_mutation(
+                network,
+                applied_mut,
+                mut_dict,
+                before,
+                self._fp_rng,
+            )
 
         return applied_mut, mut_dict
 

--- a/agilerl/utils/mutation_utils.py
+++ b/agilerl/utils/mutation_utils.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import math
 from collections.abc import Callable, Sequence
 from functools import wraps
-from typing import TYPE_CHECKING, NamedTuple, TypeGuard, TypeVar
+from typing import TYPE_CHECKING, NamedTuple, TypeGuard, TypeVar, cast
 
 import fastrand  # ty: ignore[unresolved-import] — C extension without type stubs
 import numpy as np
@@ -21,6 +21,11 @@ from agilerl.modules import (
     ModuleDict,
     NoisyLinear,
 )
+from agilerl.modules.custom_components import (
+    GumbelSoftmax,
+    ResidualBlock,
+    SimbaResidualBlock,
+)
 from agilerl.utils.evolvable_networks import (
     ACTIVATION_FUNCTIONS,
     CONV_LAYER_FUNCTIONS,
@@ -31,6 +36,8 @@ from agilerl.utils.evolvable_networks import (
 if TYPE_CHECKING:
     from agilerl.algorithms.core import EvolvableAlgorithm
     from agilerl.hpo.mutation import Mutations
+    from agilerl.networks.base import EvolvableNetwork
+    from agilerl.typing import MutationReturn
 
 IndividualT = TypeVar("IndividualT", bound="EvolvableAlgorithm")
 
@@ -54,9 +61,38 @@ WEIGHT_LAYER_TYPES: tuple[type[WeightLayer], ...] = (
 
 ACTIVATION_TYPES: tuple[type[nn.Module], ...] = tuple(ACTIVATION_FUNCTIONS.values())
 
-# Normalisations hold per-neuron state of their own, so a revived neuron's entry
-# has to be reset with it.
+# Normalised layers are not compatible with function-preserving architecture mutations as
+# they pool their statistics across old and new units.
 NORM_LAYER_TYPES: tuple[type[nn.Module], ...] = tuple(NORMALIZATION_FUNCTIONS.values())
+
+# Noise applied to a new unit's outgoing weights, as a fraction of the consumer
+# layer's existing column scale.
+FP_NOISE_SCALE = 0.02
+
+# Activations that mix units together, so a new unit changes its neighbours'
+# outputs even when it contributes nothing downstream.
+CROSS_UNIT_ACTIVATION_TYPES: tuple[type[nn.Module], ...] = (
+    nn.Softmax,
+    nn.LogSoftmax,
+    nn.Softmin,
+    GumbelSoftmax,
+)
+
+# Only idempotent activations are compatible with the identity initialisation used during
+# function-preserving layer additions.
+IDENTITY_SAFE_ACTIVATION_TYPES: tuple[type[nn.Module], ...] = (nn.ReLU, nn.Identity)
+
+# Containers hold no units of their own, so they never stand a mutation down.
+CONTAINER_TYPES: tuple[type[nn.Module], ...] = (
+    nn.Sequential,
+    nn.ModuleDict,
+    nn.ModuleList,
+)
+
+NODE_ADDITIONS = frozenset({"add_node", "add_channel"})
+LAYER_ADDITIONS = frozenset({"add_layer"})
+LATENT_ADDITIONS = frozenset({"add_latent_node"})
+PRESERVED_MUTATIONS = NODE_ADDITIONS | LAYER_ADDITIONS | LATENT_ADDITIONS
 
 
 class ProducerContext(NamedTuple):
@@ -103,12 +139,13 @@ def unwrap_module(module: nn.Module) -> nn.Module:
     return module
 
 
-def first_weight_layer(module: nn.Module) -> WeightLayer | None:
-    """The first weight-bearing layer inside module, in forward order."""
-    for _name, child in module.named_modules():
-        if isinstance(child, WEIGHT_LAYER_TYPES):
-            return child
-    return None
+def weight_layers(container: nn.Module) -> list[WeightLayer]:
+    """The weight layers container holds, in registration (forward) order."""
+    return [
+        module
+        for _name, module in container.named_modules()
+        if isinstance(module, WEIGHT_LAYER_TYPES)
+    ]
 
 
 def head_entry_layers(head: nn.Module | None) -> list[WeightLayer]:
@@ -116,7 +153,7 @@ def head_entry_layers(head: nn.Module | None) -> list[WeightLayer]:
     if head is None:
         return []
     children = list(unwrap_module(head).children())
-    entries = [first_weight_layer(child) for child in children]
+    entries = [next(iter(weight_layers(child)), None) for child in children]
     found = [entry for entry in entries if entry is not None]
     is_flat_stream = any(
         child is entry for child, entry in zip(children, entries, strict=True)
@@ -179,11 +216,7 @@ def shared_encoder_heads(
         # share_encoder_parameters writes the policy encoder's values into the
         # other encoders as plain detached tensors, so a borrowed encoder is
         # exactly one whose weight layers are not nn.Parameter.
-        layers = [
-            module
-            for _name, module in encoder.named_modules()
-            if isinstance(module, WEIGHT_LAYER_TYPES)
-        ]
+        layers = weight_layers(encoder)
         if not layers or any(owns_trainable_weight(layer) for layer in layers):
             continue
         entries.extend(head_entry_layers(getattr(other, "head_net", None)))
@@ -550,6 +583,391 @@ def reset_dormant_neurons(
         neurons_reset += len(indices)
 
     return neurons_reset
+
+
+def layer_container(submodule: nn.Module) -> nn.Module:
+    """The container holding a sub-module's weight layers, in forward order."""
+    inner = unwrap_module(submodule)
+    return getattr(inner, "model", inner)
+
+
+def weight_stacks(submodule: nn.Module) -> list[list[WeightLayer]]:
+    """The parallel weight-layer streams of a sub-module, each in forward order.
+
+    Most modules have one stream. A duelling head has two (the inherited value
+    stream and its sibling advantage stream) and one architecture mutation widens
+    or deepens both, so both need the same fixup.
+    """
+    inner = unwrap_module(submodule)
+    primary_container = layer_container(submodule)
+    primary = weight_layers(primary_container)
+    if not primary:
+        return []
+
+    # A sibling forms a parallel stream when its layers read the same widths as
+    # the primary one's, i.e. the stream's input width followed by its hidden
+    # widths. Output widths are left out: a duelling head's value stream ends in
+    # a single node and its advantage stream in one per action.
+    signature = [weight_param(layer).shape[1] for layer in primary]
+    stacks: list[list[WeightLayer]] = [primary]
+    for child in inner.children():
+        if child is primary_container:
+            continue
+        layers = weight_layers(child)
+        if layers and [weight_param(layer).shape[1] for layer in layers] == signature:
+            stacks.append(layers)
+
+    return stacks
+
+
+def hidden_widths(submodule: nn.Module) -> list[int]:
+    """The output width of every non-output weight layer of the primary stream."""
+    stacks = weight_stacks(submodule)
+    if not stacks:
+        return []
+    return [weight_param(layer).shape[0] for layer in stacks[0][:-1]]
+
+
+def modules_between(
+    container: nn.Module,
+    producer: nn.Module,
+    consumer: nn.Module | None = None,
+) -> list[nn.Module]:
+    """The modules a widened output passes through after producer, in forward order.
+
+    With no consumer, every module registered after producer is returned.
+    """
+    ordered = [module for _name, module in container.named_modules()]
+    start = ordered.index(producer)
+    stop = len(ordered) if consumer is None else ordered.index(consumer)
+    return ordered[start + 1 : stop]
+
+
+def interposed_blocker(modules: Sequence[nn.Module]) -> bool:
+    """Whether the modules between a producer and its consumer defeat the fade."""
+    return any(
+        isinstance(module, (*NORM_LAYER_TYPES, *CROSS_UNIT_ACTIVATION_TYPES))
+        for module in modules
+    )
+
+
+def structural_blocker(module: nn.Module) -> bool:
+    """Whether widening a layer inside module is out of scope.
+
+    Each of these defeats the fade at the point where a hidden layer grows. A
+    recurrent core fuses its gate non-linearities, so no single weight matrix
+    holds one unit's incoming weights. A residual skip carries a new unit's
+    coordinate straight past the layer that would fade it. A multi-input
+    encoder's fusion layer reads an interleaved concatenation, so widening a
+    sub-encoder does not append columns at the tail.
+    """
+    for _name, child in module.named_modules():
+        if isinstance(child, (nn.RNNBase, SimbaResidualBlock, ResidualBlock)):
+            return True
+        if hasattr(child, "feature_net") and hasattr(child, "final_dense"):
+            return True
+    return False
+
+
+def node_addition_blocker(submodule: nn.Module, hidden_layer: int) -> bool:
+    """Whether widening a layer cannot preserve the function."""
+    if structural_blocker(submodule):
+        return True
+
+    stacks = weight_stacks(submodule)
+    if not stacks or not 0 <= hidden_layer < len(stacks[0]) - 1:
+        return True
+
+    layers = stacks[0]
+    return interposed_blocker(
+        modules_between(
+            layer_container(submodule),
+            layers[hidden_layer],
+            layers[hidden_layer + 1],
+        ),
+    )
+
+
+def layer_addition_blocker(submodule: nn.Module) -> bool:
+    """Whether an inserted layer cannot be an identity.
+
+    Net2DeeperNet is exact only while the activation is positively homogeneous
+    and idempotent on its own output, which holds for ReLU and Identity.
+    """
+    if structural_blocker(submodule):
+        return True
+
+    stacks = weight_stacks(submodule)
+    if not stacks or len(stacks[0]) < 2:
+        return True
+
+    layers = stacks[0]
+    if any(isinstance(layer, CONV_LAYER_TYPES) for layer in layers):
+        return True
+
+    new_layer = layers[-2]
+    weight = weight_param(new_layer)
+    if weight.shape[0] != weight.shape[1]:
+        return True
+
+    between = modules_between(layer_container(submodule), new_layer, layers[-1])
+    if interposed_blocker(between):
+        return True
+
+    return any(
+        not isinstance(module, (*IDENTITY_SAFE_ACTIVATION_TYPES, *CONTAINER_TYPES))
+        for module in between
+    )
+
+
+def latent_addition_blocker(network: EvolvableNetwork) -> bool:
+    """Whether widening the latent cannot preserve the function."""
+    # Detected structurally, not by isinstance: EvolvableMultiInput fuses
+    # several sub-encoders into one vector via these two attributes.
+    if hasattr(network, "feature_net") and hasattr(network, "final_dense"):
+        return True
+
+    encoder = network.encoder
+    stacks = weight_stacks(encoder)
+    if not stacks:
+        return True
+
+    return interposed_blocker(
+        modules_between(layer_container(encoder), stacks[0][-1]),
+    )
+
+
+def fade_new_columns(
+    consumer: WeightLayer,
+    columns: slice,
+    rng: np.random.Generator,
+    noise_scale: float,
+) -> None:
+    """Fade the columns through which new units reach a consuming layer.
+
+    A small positive scale lets the new units learn more rapidly since gradients
+    flow faster at a small cost in exactness. A noisy layer's stochastic scales
+    are always zeroed, so the new units add no exploration noise either.
+    """
+    weight = weight_param(consumer)
+    with torch.no_grad():
+        # Measure the columns the new block sits beside, so the noise stays small
+        # relative to the signal the consumer already carries.
+        keep = torch.ones(weight.shape[1], dtype=torch.bool, device=weight.device)
+        keep[columns] = False
+        scale = float(weight[:, keep].std())
+
+        noise = torch.as_tensor(
+            rng.standard_normal(tuple(weight[:, columns].shape)),
+            dtype=weight.dtype,
+            device=weight.device,
+        )
+        weight[:, columns] = noise * noise_scale * (scale if scale > 0.0 else 1e-3)
+
+        if isinstance(consumer, NoisyLinear):
+            consumer.weight_sigma[:, columns] = 0.0
+            consumer.weight_epsilon[:, columns] = 0.0
+
+
+def preserve_added_nodes(
+    submodule: nn.Module,
+    hidden_layer: int,
+    old_width: int,
+    rng: np.random.Generator,
+    noise_scale: float,
+) -> None:
+    """Fade a widened layer's new units so the module's output is unchanged.
+
+    The new units keep the incoming weights the stock operator gave them, and
+    only their outgoing weights are rewritten. submodule must have been cleared
+    by node_addition_blocker.
+    """
+    for layers in weight_stacks(submodule):
+        producer, consumer = layers[hidden_layer], layers[hidden_layer + 1]
+        new_width = weight_param(producer).shape[0]
+        # A layer held at its maximum width grows by nothing.
+        if new_width <= old_width:
+            continue
+
+        # A dense layer reads the flattened feature map, so each widened channel
+        # owns a whole H*W block of its columns.
+        block = 1
+        if isinstance(producer, CONV_LAYER_TYPES) and not isinstance(
+            consumer,
+            CONV_LAYER_TYPES,
+        ):
+            block = weight_param(consumer).shape[1] // new_width
+
+        fade_new_columns(
+            consumer,
+            slice(old_width * block, new_width * block),
+            rng,
+            noise_scale,
+        )
+
+
+def preserve_added_layer(submodule: nn.Module) -> None:
+    """Initialise an inserted layer to the identity so the output is unchanged.
+
+    A noisy layer's stochastic scale is zeroed as well, so the identity holds
+    while training. submodule must have been cleared by layer_addition_blocker.
+    """
+    for layers in weight_stacks(submodule):
+        new_layer = layers[-2]
+        with torch.no_grad():
+            weight_param(new_layer).zero_().fill_diagonal_(1.0)
+            if isinstance(new_layer, NoisyLinear):
+                new_layer.weight_sigma.zero_()
+                new_layer.bias_mu.zero_()
+                new_layer.bias_sigma.zero_()
+            elif new_layer.bias is not None:
+                new_layer.bias.zero_()
+
+
+def preserve_added_latent(
+    network: EvolvableNetwork,
+    old_latent: int,
+    rng: np.random.Generator,
+    noise_scale: float,
+) -> None:
+    """Fade the head's new latent columns so the network's output is unchanged.
+
+    network must have been cleared by latent_addition_blocker.
+    """
+    new_latent = network.latent_dim
+    # A latent held at its maximum grows by nothing.
+    if new_latent <= old_latent:
+        return
+
+    for layers in weight_stacks(network.head_net):
+        consumer = layers[0]
+
+        # A continuous critic reads the actions from the columns past the latent,
+        # so they have to slide out to their new offset before the new latent
+        # columns are faded over the ones they used to occupy.
+        extra = weight_param(consumer).shape[1] - new_latent
+        if extra > 0:
+            action_weights = (
+                [consumer.weight_mu, consumer.weight_sigma, consumer.weight_epsilon]
+                if isinstance(consumer, NoisyLinear)
+                else [weight_param(consumer)]
+            )
+            with torch.no_grad():
+                for weight in action_weights:
+                    weight[:, new_latent : new_latent + extra] = weight[
+                        :,
+                        old_latent : old_latent + extra,
+                    ].clone()
+
+        fade_new_columns(consumer, slice(old_latent, new_latent), rng, noise_scale)
+
+
+def resolve_target(network: nn.Module, mut_method: str) -> nn.Module | None:
+    """Walk a dotted mutation name to the module it acts on.
+
+    A latent mutation names no sub-module, so it resolves to the network that
+    owns the latent.
+    """
+    target = network
+    for segment in mut_method.split(".")[:-1]:
+        # Sub-modules of a ModuleDict are registered under their key, so a
+        # per-agent segment resolves by attribute lookup like any other.
+        child = getattr(target, segment, None)
+        if child is None:
+            return None
+        target = child
+
+    return target
+
+
+def pre_mutation_widths(network: EvolvableModule, mut_method: str) -> list[int] | None:
+    """Record the widths an architecture mutation is about to change.
+
+    The stock operator appends new units at the tail, so the fixup needs to know
+    where the old ones ended.
+
+    :param network: Network about to be mutated.
+    :type network: EvolvableModule
+    :param mut_method: The mutation method about to be applied.
+    :type mut_method: str
+
+    :return: The affected widths, or None when there is nothing to record.
+    :rtype: list[int] | None
+    """
+    target = resolve_target(network, mut_method)
+    if target is None:
+        return None
+
+    # mut_method may be dotted/per-agent-prefixed (see resolve_target); only
+    # the trailing method identifies which mutation this is.
+    if mut_method.split(".")[-1].endswith("latent_node"):
+        return [cast("EvolvableNetwork", target).latent_dim]
+
+    return hidden_widths(target)
+
+
+def preserve_architecture_mutation(
+    network: EvolvableModule,
+    applied_mut: str | None,
+    mut_dict: MutationReturn,
+    before: list[int],
+    rng: np.random.Generator,
+) -> None:
+    """Initialise an addition's new capacity so the network's function is unchanged.
+
+    Dispatches on the mutation that was actually applied rather than the one that
+    was sampled, since add_layer falls back to widening once a stream has reached
+    its depth limit. An addition the architecture cannot support keeps the stock
+    operator's random initialisation.
+
+    :param network: Network that was mutated, operated on in place.
+    :type network: EvolvableModule
+    :param applied_mut: The mutation the network reports having applied.
+    :type applied_mut: str | None
+    :param mut_dict: The mutation's own report of what it changed.
+    :type mut_dict: MutationReturn
+    :param before: The widths recorded by :func:`pre_mutation_widths`.
+    :type before: list[int]
+    :param rng: Seeded generator the symmetry-breaking noise is drawn from.
+    :type rng: numpy.random.Generator
+
+    :return: None.
+    :rtype: None
+    """
+    if applied_mut is None:
+        return
+
+    # applied_mut may be dotted/per-agent-prefixed (see resolve_target); only
+    # the trailing method identifies the mutation that ran.
+    base = applied_mut.split(".")[-1]
+    if base not in PRESERVED_MUTATIONS:
+        return
+
+    target = resolve_target(network, applied_mut)
+    if target is None:
+        return
+
+    if base in LATENT_ADDITIONS:
+        latent_network = cast("EvolvableNetwork", target)
+        if not latent_addition_blocker(latent_network):
+            preserve_added_latent(latent_network, before[0], rng, FP_NOISE_SCALE)
+        return
+
+    if base in LAYER_ADDITIONS:
+        if not layer_addition_blocker(target):
+            preserve_added_layer(target)
+        return
+
+    reported = mut_dict.get("hidden_layer")
+    hidden_layer = reported if isinstance(reported, int) else -1
+    if not node_addition_blocker(target, hidden_layer):
+        preserve_added_nodes(
+            target,
+            hidden_layer,
+            before[hidden_layer],
+            rng,
+            FP_NOISE_SCALE,
+        )
 
 
 def set_global_seed(seed: int | None) -> None:

--- a/agilerl/utils/mutation_utils.py
+++ b/agilerl/utils/mutation_utils.py
@@ -82,7 +82,7 @@ CROSS_UNIT_ACTIVATION_TYPES: tuple[type[nn.Module], ...] = (
 # function-preserving layer additions.
 IDENTITY_SAFE_ACTIVATION_TYPES: tuple[type[nn.Module], ...] = (nn.ReLU, nn.Identity)
 
-# Containers hold no units of their own, so they never stand a mutation down.
+# Network wrapped containing layers affected by mutations
 CONTAINER_TYPES: tuple[type[nn.Module], ...] = (
     nn.Sequential,
     nn.ModuleDict,

--- a/configs/training/bandit/neural_ucb_func_preserving.yaml
+++ b/configs/training/bandit/neural_ucb_func_preserving.yaml
@@ -1,0 +1,62 @@
+---
+algorithm:
+    name: NeuralUCB
+    batch_size: 64
+    lr: 0.001
+    learn_step: 2
+    gamma: 1.0
+    lamb: 1.0
+    reg: 0.000625
+
+environment:
+    name: IRIS
+    features: tests/data/iris_features.csv
+    targets: tests/data/iris_targets.csv
+mutation:
+    probabilities:
+        no_mut: 0.4
+        arch_mut: 0.2
+        new_layer: 0.2
+        params_mut: 0.2
+        act_mut: 0.0   # keeps the networks on ReLU, so deepening stays preserved
+        rl_hp_mut: 0.2
+    rl_hp_selection:
+        lr:
+            min: 0.0000625
+            max: 0.01
+        batch_size:
+            min: 8
+            max: 512
+        learn_step:
+            min: 1
+            max: 10
+    mutation_sd: 0.1
+    rand_seed: 42
+
+network:
+    latent_dim: 128
+
+    encoder_config:
+        hidden_size:
+            - 128
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+    head_config:
+        hidden_size:
+            - 128
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+replay_buffer:
+    max_size: 10_000
+
+selection_strategy:
+    tournament_size: 2
+    elitism: true
+
+training:
+    max_steps: 10_000
+    target_score: 96.0
+    pop_size: 4
+    evo_steps: 500
+    eval_steps: 500
+    eval_loop: 1

--- a/configs/training/cqn_func_preserving.yaml
+++ b/configs/training/cqn_func_preserving.yaml
@@ -1,0 +1,61 @@
+---
+algorithm:
+    name: CQN
+    batch_size: 256
+    lr: 0.001
+    learn_step: 1
+    gamma: 0.99
+    tau: 0.001
+    double: true
+
+environment:
+    name: CartPole-v1
+    num_envs: 16
+    minari_dataset_id: cartpole/random-v0
+mutation:
+    probabilities:
+        no_mut: 0.4
+        arch_mut: 0.2
+        new_layer: 0.2
+        params_mut: 0.2
+        act_mut: 0.0   # keeps the networks on ReLU, so deepening stays preserved
+        rl_hp_mut: 0.2
+    rl_hp_selection:
+        lr:
+            min: 0.0001
+            max: 0.01
+        batch_size:
+            min: 8
+            max: 1024
+        learn_step:
+            min: 1
+            max: 10
+    mutation_sd: 0.1
+    rand_seed: 42
+
+network:
+    latent_dim: 64
+    encoder_config:
+        hidden_size:
+            - 64
+        layer_norm: false   # preservation needs no normalisation between the widened units
+    head_config:
+        hidden_size:
+            - 64
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+replay_buffer:
+    max_size: 100_000
+
+selection_strategy:
+    tournament_size: 2
+    elitism: true
+
+training:
+    max_steps: 50_000
+    target_score: 200.0
+    pop_size: 4
+    evo_steps: 5_000
+    eval_steps:
+    eval_loop: 1
+    learning_delay: 1000

--- a/configs/training/dqn/dqn_func_preserving.yaml
+++ b/configs/training/dqn/dqn_func_preserving.yaml
@@ -1,0 +1,67 @@
+---
+algorithm:
+    name: DQN
+    batch_size: 128
+    lr: 6.3e-4
+    learn_step: 4
+    gamma: 0.99
+    tau: 0.001
+    double: false
+    cudagraphs: false
+
+environment:
+    name: LunarLander-v3
+    num_envs: 16
+
+mutation:
+    probabilities:
+        no_mut: 0.4
+        arch_mut: 0.2
+        new_layer: 0.2
+        params_mut: 0.2
+        act_mut: 0.0   # keeps the networks on ReLU, so deepening stays preserved
+        rl_hp_mut: 0.2
+    rl_hp_selection:
+        lr:
+            min: 0.0000625
+            max: 0.01
+        batch_size:
+            min: 8
+            max: 512
+        learn_step:
+            min: 1
+            max: 10
+    mutation_sd: 0.1
+    rand_seed: 42
+
+network:
+    latent_dim: 128
+
+    encoder_config:
+        hidden_size:
+            - 128
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+    head_config:
+        hidden_size:
+            - 128
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+replay_buffer:
+    max_size: 100_000
+
+selection_strategy:
+    tournament_size: 2
+    elitism: true
+
+training:
+    max_steps: 1_000_000
+    target_score: 200.0
+    pop_size: 4
+    evo_steps: 10_000
+    eval_steps:
+    eval_loop: 1
+    learning_delay: 0
+    eps_start: 1.0
+    eps_end: 0.1
+    eps_decay: 0.99

--- a/configs/training/multi_agent/ippo_func_preserving.yaml
+++ b/configs/training/multi_agent/ippo_func_preserving.yaml
@@ -1,0 +1,75 @@
+---
+algorithm:
+    name: IPPO
+    batch_size: 128
+    lr: 0.0001
+    learn_step: 2048
+    gamma: 0.99
+    gae_lambda: 0.95
+    action_std_init: 0.0
+    clip_coef: 0.2
+    ent_coef: 0.05
+    vf_coef: 0.5
+    max_grad_norm: 0.5
+    target_kl:
+    update_epochs: 4
+
+environment:
+    name: mpe2.simple_speaker_listener_v4
+    num_envs: 16
+mutation:
+    probabilities:
+        no_mut: 0.4
+        arch_mut: 0.4
+        new_layer: 0.2
+        params_mut: 0.2
+        act_mut: 0.0   # keeps the networks on ReLU, so deepening stays preserved
+        rl_hp_mut: 0.35
+    rl_hp_selection:
+        lr:
+            min: 0.000001
+            max: 0.01
+        batch_size:
+            min: 8
+            max: 1024
+        learn_step:
+            min: 256
+            max: 8192
+        ent_coef:
+            min: 0.001
+            max: 0.1
+    mutation_sd: 0.1
+    rand_seed: 42
+
+network:
+    latent_dim: 64
+    encoder_config:
+        hidden_size:
+            - 64
+        activation: ReLU
+        min_mlp_nodes: 32
+        max_mlp_nodes: 500
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+    head_config:
+        hidden_size:
+            - 64
+        activation: ReLU
+        output_vanish: false
+        min_hidden_layers: 1
+        max_hidden_layers: 3
+        min_mlp_nodes: 32
+        max_mlp_nodes: 256
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+selection_strategy:
+    tournament_size: 2
+    elitism: true
+
+training:
+    max_steps: 2_000_000
+    target_score:
+    pop_size: 4
+    evo_steps: 10_000
+    eval_steps:
+    eval_loop: 1

--- a/configs/training/multi_agent/maddpg_func_preserving.yaml
+++ b/configs/training/multi_agent/maddpg_func_preserving.yaml
@@ -1,0 +1,80 @@
+---
+algorithm:
+    name: MADDPG
+    batch_size: 64
+    lr_actor: 0.0001
+    lr_critic: 0.001
+    learn_step: 16
+    gamma: 0.95
+    tau: 0.001
+    O_U_noise: true
+    expl_noise: 0.1
+    mean_noise: 0.0
+    theta: 0.15
+    dt: 0.01
+
+environment:
+    name: mpe2.simple_speaker_listener_v4
+    num_envs: 16
+mutation:
+    probabilities:
+        no_mut: 0.4
+        arch_mut: 0.4
+        new_layer: 0.2
+        params_mut: 0.0
+        act_mut: 0.0   # keeps the networks on ReLU, so deepening stays preserved
+        rl_hp_mut: 0.35
+    rl_hp_selection:
+        lr_actor:
+            min: 0.0001
+            max: 0.01
+        lr_critic:
+            min: 0.0001
+            max: 0.01
+        batch_size:
+            min: 8
+            max: 2048
+        learn_step:
+            min: 20
+            max: 200
+    mutation_sd: 0.1
+    rand_seed: 42
+
+network:
+    latent_dim: 64
+    min_latent_dim: 8
+    max_latent_dim: 1024
+
+    encoder_config:
+        hidden_size:
+            - 64
+        min_mlp_nodes: 64
+        max_mlp_nodes: 500
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+    head_config:
+        hidden_size:
+            - 64
+            - 64
+        activation: ReLU
+        min_hidden_layers: 1
+        max_hidden_layers: 2
+        min_mlp_nodes: 64
+        max_mlp_nodes: 500
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+replay_buffer:
+    max_size: 100_000
+
+selection_strategy:
+    tournament_size: 2
+    elitism: true
+
+training:
+    max_steps: 2_000_000
+    target_score:
+    pop_size: 4
+    evo_steps: 10_000
+    eval_steps:
+    eval_loop: 1
+    learning_delay: 0

--- a/configs/training/ppo/ppo_func_preserving.yaml
+++ b/configs/training/ppo/ppo_func_preserving.yaml
@@ -1,0 +1,79 @@
+---
+algorithm:
+    name: PPO
+    batch_size: 128
+    lr: 0.001
+    learn_step: 2048
+    gamma: 0.99
+    gae_lambda: 0.95
+    action_std_init: 0.6
+    clip_coef: 0.2
+    ent_coef: 0.01
+    vf_coef: 0.5
+    max_grad_norm: 0.5
+    target_kl:
+    update_epochs: 4
+    share_encoders: true
+
+environment:
+    name: LunarLander-v3
+    num_envs: 16
+mutation:
+    probabilities:
+        no_mut: 0.4
+        arch_mut: 0.2
+        new_layer: 0.2
+        params_mut: 0.2
+        act_mut: 0.0   # keeps the networks on ReLU, so deepening stays preserved
+        rl_hp_mut: 0.2
+    rl_hp_selection:
+        lr:
+            min: 0.0001
+            max: 0.01
+        batch_size:
+            min: 8
+            max: 1024
+        learn_step:
+            min: 256
+            max: 8192
+        ent_coef:
+            min: 0.001
+            max: 0.1
+        update_epochs:
+            min: 1
+            max: 10
+    mutation_sd: 0.1
+    rand_seed: 42
+
+network:
+    latent_dim: 64
+    encoder_config:
+        hidden_size:
+            - 64
+        activation: ReLU
+        min_mlp_nodes: 64
+        max_mlp_nodes: 500
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+    head_config:
+        hidden_size:
+            - 64
+        activation: ReLU
+        min_hidden_layers: 1
+        max_hidden_layers: 3
+        min_mlp_nodes: 64
+        max_mlp_nodes: 500
+        output_vanish: true
+        layer_norm: false   # preservation needs no normalisation between the widened units
+
+selection_strategy:
+    tournament_size: 2
+    elitism: true
+
+training:
+    max_steps: 6_000_000
+    target_score: 250.0
+    pop_size: 4
+    evo_steps: 10_240
+    eval_steps:
+    eval_loop: 1

--- a/docs/api/hpo/mutation.rst
+++ b/docs/api/hpo/mutation.rst
@@ -8,7 +8,7 @@ population.
 The :class:`Mutations <agilerl.hpo.mutation.Mutations>` class is used to mutate agents with pre-set probabilities. The available mutations currently implemented are:
 
   * **No mutation**: An "identity" mutation, whereby the agent is returned unchanged.
-  * **Network architecture mutations**: Currently involves adding layers or nodes. Trained weights are reused and new weights are initialized randomly.
+  * **Network architecture mutations**: Currently involves adding layers or nodes. Trained weights are reused, and new capacity is initialized to preserve the network's function where the architecture allows it (see :ref:`function_preserving`), and randomly otherwise.
   * **Network parameters mutation**: Mutating weights with Gaussian noise, preceded by ReGraMa resets of dormant neurons.
   * **Network activation layer mutation**: Change of activation layer.
   * **RL hyperparameter mutation**: Mutation of a learning hyperparameter (e.g. learning rate or batch size).

--- a/docs/evo_hyperparam_opt/mutation.rst
+++ b/docs/evo_hyperparam_opt/mutation.rst
@@ -170,42 +170,37 @@ This has proven to be successful in our experiments, but it is still experimenta
 Function-preserving additions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a mutation adds capacity to a network, we initialise the new units so that the network still
-computes what it did before. There are two cases:
+When possible, the node and layer addition operations are function-preserving, in other words, the
+network maintains the same behaviour after being mutated. To implement this:
 
-  * Widening (``add_node``, ``add_channel``, ``add_latent_node``) leaves the new units' incoming weights
-    as the mutation created them and instead fades out the weights that carry them into the next layer.
-  * Deepening (``add_layer``) initialises the inserted layer to the identity, so the signal passes
-    through it untouched.
+ * The outgoing weights(``add_node``, ``add_channel``, ``add_latent_node``) of the new neurons are
+   initialised to values close to zero. Therefore, they do not affect the input fed to the next layer
+   and consequently, the network's output.
+  * ``add_layer`` initialises the new layer with an identity matrix, making its inputs identical to
+  its outputs (`"Net2Net: Accelerating Learning via Knowledge Transfer" <https://arxiv.org/abs/1511.05641>`_).
 
-An agent therefore comes out of an architecture mutation with the same behaviour, and keeps its
-place in the population, giving more chances for the added capacity to train.
+Note that removal operations have not been, since a decrease in network capacity cannot be guaranteed
+to be function-preserving.
 
-When it applies
-^^^^^^^^^^^^^^^
+Function-preserving additions minimise sudden drops in fitness after an architecture mutation, increasing
+the survival rate of individuals whose capacity has been modified and, therefore, allowing for a better
+exploration of the architecture space during training.
 
-There is nothing to configure. We do this for every addition we can and fall back to the original random
-initialisation when function preservation cannot be guaranteed. Widening is left alone when:
+Function-preserving architecture mutations are automatically performed by the framework when the following
+conditions apply:
 
-  * a normalisation layer sits between the widened layer and the layer that reads it. Its statistics are
-    pooled over the whole layer, so the new units shift the existing ones however small their
-    outgoing weights.
-  * the activation mixes units together (``Softmax``, ``LogSoftmax``, ``Softmin`` or ``GumbelSoftmax``).
-  * the widened layer sits inside a recurrent core, a multi-input encoder, a residual network or a SimBa
-    block.
+  * The layer is not normalised as normalisation layers are based on statistics collected on the whole layer,
+    and these values affect both the new and the old neurons.
+  * Cross-unit activations like ``Softmax`` are not used since they make new units affect the output of all
+    units in a layer.
+  * The mutated layer is not part of an RNN, multi-input encoder, residual network or a SimBa block.
 
-Deepening also needs an MLP layer whose activation is ReLU or Identity, since the identity initialisation
-only holds for idempotent activation functions.
+In addition, function-preserving architecture mutations are need an idempotent activation (i.e., ReLU or
+Identity).
 
-Growing the latent is the exception to the third point, because the surgery happens in the MLP head rather
-than the encoder. Therefore, it works for recurrent, residual, SimBa and multi-input encoders alike; only a
-normalisation layer or a unit-mixing activation on the encoder's output rules it out.
+When these conditions are not met, function preservation cannot be guaranteed, and the new capacity is
+initialised randomly.
 
-.. note::
-    We fade the outgoing weights to small random values rather than exact zeros, which is what gets
-    gradient flowing to the new units immediately, so the output is very slightly perturbed rather than identical.
-    With noisy layers the guarantee only holds in evaluation mode: rebuilding a ``NoisyLinear`` resamples
-    its noise buffers, which changes what every unit contributes during training, new or not.
 
 RL Hyperparameter Mutations
 ---------------------------

--- a/docs/evo_hyperparam_opt/mutation.rst
+++ b/docs/evo_hyperparam_opt/mutation.rst
@@ -10,7 +10,7 @@ likely to remain in the population.
 The :class:`Mutations <agilerl.hpo.mutation.Mutations>` class is used to mutate agents with pre-set probabilities. The available mutations currently implemented are:
 
     * **No mutation**: An "identity" mutation, whereby the agent is returned unchanged.
-    * **Network architecture mutations**: Involves adding or removing layers or nodes. Trained weights are reused and new weights are initialized randomly.
+    * **Network architecture mutations**: Involves adding or removing layers or nodes. Trained weights are reused, and added capacity is initialized to preserve the network's function where the architecture allows it (see :ref:`function_preserving`), and randomly otherwise.
     * **Network parameters mutation**: Mutating weights with Gaussian noise, preceded by ReGraMa resets of the neurons that have stopped learning.
     * **Network activation layer mutation**: Change of activation layer.
     * **RL algorithm mutation**: Mutation of a learning hyperparameter (e.g. learning rate or batch size).
@@ -164,6 +164,48 @@ This has proven to be successful in our experiments, but it is still experimenta
 
 .. note::
     AgileRL currently doesn't support architecture mutations for :class:`LLMAlgorithm <agilerl.algorithms.core.LLMAlgorithm>` objects.
+
+.. _function_preserving:
+
+Function-preserving additions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a mutation adds capacity to a network, we initialise the new units so that the network still
+computes what it did before. There are two cases:
+
+  * Widening (``add_node``, ``add_channel``, ``add_latent_node``) leaves the new units' incoming weights
+    as the mutation created them and instead fades out the weights that carry them into the next layer.
+  * Deepening (``add_layer``) initialises the inserted layer to the identity, so the signal passes
+    through it untouched.
+
+An agent therefore comes out of an architecture mutation with the same behaviour, and keeps its
+place in the population, giving more chances for the added capacity to train.
+
+When it applies
+^^^^^^^^^^^^^^^
+
+There is nothing to configure. We do this for every addition we can and fall back to the original random
+initialisation when function preservation cannot be guaranteed. Widening is left alone when:
+
+  * a normalisation layer sits between the widened layer and the layer that reads it. Its statistics are
+    pooled over the whole layer, so the new units shift the existing ones however small their
+    outgoing weights.
+  * the activation mixes units together (``Softmax``, ``LogSoftmax``, ``Softmin`` or ``GumbelSoftmax``).
+  * the widened layer sits inside a recurrent core, a multi-input encoder, a residual network or a SimBa
+    block.
+
+Deepening also needs an MLP layer whose activation is ReLU or Identity, since the identity initialisation
+only holds for idempotent activation functions.
+
+Growing the latent is the exception to the third point, because the surgery happens in the MLP head rather
+than the encoder. Therefore, it works for recurrent, residual, SimBa and multi-input encoders alike; only a
+normalisation layer or a unit-mixing activation on the encoder's output rules it out.
+
+.. note::
+    We fade the outgoing weights to small random values rather than exact zeros, which is what gets
+    gradient flowing to the new units immediately, so the output is very slightly perturbed rather than identical.
+    With noisy layers the guarantee only holds in evaluation mode: rebuilding a ``NoisyLinear`` resamples
+    its noise buffers, which changes what every unit contributes during training, new or not.
 
 RL Hyperparameter Mutations
 ---------------------------

--- a/docs/evolvable_networks/index.rst
+++ b/docs/evolvable_networks/index.rst
@@ -296,6 +296,10 @@ to wrap their non-evolvable networks in a manner compatible with our mutations f
           )
 
 
+.. seealso::
+    Additions to an evolvable network are initialized to preserve the function it computes
+    wherever the architecture allows it. See :ref:`function_preserving`.
+
 Integrating Architecture Mutations Into a Custom PyTorch Network
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_hpo/test_mutation.py
+++ b/tests/test_hpo/test_mutation.py
@@ -15,7 +15,7 @@ from accelerate.utils import DeepSpeedPlugin
 from gymnasium import spaces
 
 from agilerl import HAS_DEEPSPEED, HAS_LLM_DEPENDENCIES, HAS_VLLM
-from agilerl.algorithms import DDPG, DQN, IPPO, PPO, TD3, NeuralUCB
+from agilerl.algorithms import CQN, DDPG, DQN, IPPO, MADDPG, PPO, TD3, NeuralUCB
 from agilerl.algorithms.core.registry import HyperparameterConfig, RLParameter
 
 if HAS_LLM_DEPENDENCIES:
@@ -2682,6 +2682,884 @@ class TestMutationsApplyMutation:
             assert wrapper.agent is not original
             assert wrapper.agent.mut == "tagged"
             assert wrapper.agent.hook_calls == 1
+
+
+_FP_NET_CONFIG = {
+    "latent_dim": 8,
+    "min_latent_dim": 1,
+    "max_latent_dim": 128,
+    "encoder_config": {"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+    "head_config": {"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+}
+
+
+def _fp_net_config(**overrides):
+    """Return the function-preserving net config with nested overrides applied."""
+    config = copy.deepcopy(_FP_NET_CONFIG)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(config.get(key), dict):
+            config[key].update(value)
+        else:
+            config[key] = value
+    return config
+
+
+def _fp_mutations(seed=0, activation=0.0):
+    """Return an architecture-mutation-only operator."""
+    return Mutations(0, 1, 0, 0, activation, 0, rand_seed=seed, device="cpu")
+
+
+def _pin_mutation_method(monkeypatch, method):
+    """Force every sampled architecture mutation to be the given method."""
+    monkeypatch.setattr(
+        EvolvableModule,
+        "sample_mutation_method",
+        lambda self, *args, **kwargs: method,
+    )
+
+
+def _dqn(**config_overrides):
+    """Return a small unnormalised DQN whose additions can be preserved."""
+    return DQN(
+        generate_random_box_space((4,)),
+        generate_discrete_space(2),
+        net_config=_fp_net_config(**config_overrides),
+        device="cpu",
+    )
+
+
+def _recurrent_ppo():
+    """Return a PPO agent whose recurrent encoder is out of scope."""
+    return PPO(
+        generate_random_box_space((4,)),
+        generate_discrete_space(2),
+        recurrent=True,
+        net_config={"encoder_config": {"hidden_state_size": 8}},
+        device="cpu",
+    )
+
+
+def _fp_neural_ucb():
+    """Return a small unnormalised bandit agent."""
+    return NeuralUCB(
+        generate_random_box_space((4,)),
+        generate_discrete_space(2),
+        net_config=_fp_net_config(),
+        device="cpu",
+    )
+
+
+def _fp_cqn():
+    """Return a small unnormalised offline agent."""
+    return CQN(
+        generate_random_box_space((4,)),
+        generate_discrete_space(2),
+        net_config=_fp_net_config(),
+        device="cpu",
+    )
+
+
+def _fp_ippo():
+    """Return a small unnormalised multi-agent on-policy agent."""
+    return IPPO(
+        generate_multi_agent_box_spaces(2, (4,)),
+        generate_multi_agent_discrete_spaces(2, 2),
+        agent_ids=["speaker_0", "listener_0"],
+        net_config=_fp_net_config(),
+        device="cpu",
+    )
+
+
+def _fp_maddpg():
+    """Return a small unnormalised multi-agent off-policy agent."""
+    return MADDPG(
+        generate_multi_agent_box_spaces(2, (4,)),
+        generate_multi_agent_discrete_spaces(2, 2),
+        agent_ids=["agent_0", "other_0"],
+        net_config=_fp_net_config(),
+        device="cpu",
+    )
+
+
+def _policy_output(agent, observation):
+    """Return the policy's evaluation-mode output."""
+    policy = getattr(agent, agent.registry.policy())
+    policy.eval()
+    return policy(observation)
+
+
+def _mutation_shift(agent, observation, seed=0):
+    """Return how far one architecture mutation moves the policy's output."""
+    policy = getattr(agent, agent.registry.policy())
+    policy.rng = np.random.default_rng(seed)
+    before = _policy_output(agent, observation)
+    mutated = _fp_mutations().architecture_mutate(agent)
+    return (_policy_output(mutated, observation) - before).abs().max().item()
+
+
+class TestMutationsFunctionPreservingArchMutation:
+    """Architecture additions leave the network's output unchanged."""
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "head_net.add_node",
+            "encoder.add_node",
+            "add_latent_node",
+            "head_net.add_layer",
+        ],
+    )
+    def test_an_addition_keeps_the_policy_output(self, monkeypatch, method):
+        _pin_mutation_method(monkeypatch, method)
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = _dqn()
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        after = _policy_output(agent, observation)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "head_net.add_node",
+            "encoder.add_node",
+            "add_latent_node",
+            "head_net.add_layer",
+        ],
+    )
+    def test_an_addition_disturbs_the_policy_far_less_than_the_original(
+        self, monkeypatch, method
+    ):
+        torch.manual_seed(0)
+        _pin_mutation_method(monkeypatch, method)
+        observation = torch.randn(4, 4)
+        agent = _dqn()
+        baseline = agent.clone()
+
+        preserved_shift = _mutation_shift(agent, observation)
+        monkeypatch.setattr(
+            "agilerl.hpo.mutation.preserve_architecture_mutation",
+            lambda *args, **kwargs: None,
+        )
+        original_shift = _mutation_shift(baseline, observation)
+
+        assert preserved_shift < original_shift / 5
+
+    @pytest.mark.parametrize(
+        ("method", "attribute"),
+        [
+            ("head_net.add_node", "head_net"),
+            ("encoder.add_node", "encoder"),
+        ],
+    )
+    def test_the_architecture_actually_grew(self, monkeypatch, method, attribute):
+        _pin_mutation_method(monkeypatch, method)
+        agent = _dqn()
+        before = getattr(agent.actor, attribute).hidden_size[0]
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        assert getattr(agent.actor, attribute).hidden_size[0] > before
+
+    def test_a_normalised_head_falls_back_to_the_original_operator(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        agent = _dqn(head_config={"layer_norm": True})
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        assert not torch.allclose(_policy_output(agent, observation), before, atol=1e-6)
+
+    def test_a_wrapped_agent_is_preserved(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = RSNorm(_dqn())
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent.agent, observation)
+
+        mutations = _fp_mutations()
+        agent = mutations._apply_mutation(agent, mutations.architecture_mutate)
+
+        after = _policy_output(agent.agent, observation)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+
+    def test_a_deeper_head_at_max_depth_falls_back_to_a_preserved_widening(
+        self, monkeypatch
+    ):
+        _pin_mutation_method(monkeypatch, "head_net.add_layer")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = _dqn(
+            head_config={
+                "hidden_size": [8, 8],
+                "min_hidden_layers": 1,
+                "max_hidden_layers": 2,
+            }
+        )
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        assert agent.mut == "head_net.add_node"
+        torch.testing.assert_close(
+            _policy_output(agent, observation), before, rtol=0, atol=1e-6
+        )
+
+    def test_enabled_activation_mutations_leave_the_new_layer_preserved(
+        self, monkeypatch
+    ):
+        _pin_mutation_method(monkeypatch, "head_net.add_layer")
+        agent = _dqn()
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations(activation=0.2).architecture_mutate(agent)
+
+        after = _policy_output(agent, observation)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+
+    def test_a_non_relu_head_falls_back_with_activation_mutations_enabled(
+        self, monkeypatch
+    ):
+        _pin_mutation_method(monkeypatch, "head_net.add_layer")
+        agent = _dqn(head_config={"activation": "Tanh"})
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations(activation=0.2).architecture_mutate(agent)
+
+        assert not torch.allclose(_policy_output(agent, observation), before, atol=1e-6)
+
+    def test_a_widened_latent_keeps_a_continuous_critic_intact(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "add_latent_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = DDPG(
+            generate_random_box_space((4,)),
+            generate_random_box_space((2,), low=-1, high=1),
+            net_config=_fp_net_config(),
+            device="cpu",
+        )
+        observation = torch.randn(4, 4)
+        actions = torch.randn(4, 2, requires_grad=True)
+        agent.critic.eval()
+        before = agent.critic(observation, actions)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        agent.critic.eval()
+        after = agent.critic(observation, actions)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+        assert torch.count_nonzero(torch.autograd.grad(after.sum(), actions)[0]) > 0
+
+
+# These are the remaining single-agent families, whose trainers reach the architecture
+# operator and whose preservation is otherwise never asserted.
+_FP_SINGLE_AGENT_FAMILIES = {
+    "bandit (NeuralUCB)": _fp_neural_ucb,
+    "offline (CQN)": _fp_cqn,
+}
+
+
+class TestMutationsFunctionPreservingSingleAgentFamilies:
+    """Additions are preserved for the bandit and offline families too."""
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "head_net.add_node",
+            "encoder.add_node",
+            "add_latent_node",
+            "head_net.add_layer",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "family", list(_FP_SINGLE_AGENT_FAMILIES), ids=list(_FP_SINGLE_AGENT_FAMILIES)
+    )
+    def test_an_addition_keeps_the_policy_output(self, monkeypatch, family, method):
+        _pin_mutation_method(monkeypatch, method)
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = _FP_SINGLE_AGENT_FAMILIES[family]()
+        observation = torch.randn(4, 4)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        after = _policy_output(agent, observation)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+
+
+def _assert_declines_without_warning(architecture_mutate, *agents):
+    """Run one or more mutations and assert none of them raised a UserWarning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for agent in agents:
+            architecture_mutate(agent)
+
+    assert not [w for w in caught if issubclass(w.category, UserWarning)]
+
+
+class TestMutationsFunctionPreservingDeclineIsSilent:
+    """A declined mutation falls back to the original operator with no report."""
+
+    def test_a_normalised_layer_declines_without_warning(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        mutations = _fp_mutations()
+
+        _assert_declines_without_warning(
+            mutations.architecture_mutate, _dqn(head_config={"layer_norm": True})
+        )
+
+    def test_a_recurrent_encoder_declines_without_warning(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "encoder.add_node")
+        mutations = _fp_mutations()
+
+        _assert_declines_without_warning(
+            mutations.architecture_mutate, _recurrent_ppo()
+        )
+
+    def test_repeated_declines_stay_silent(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        mutations = _fp_mutations()
+
+        _assert_declines_without_warning(
+            mutations.architecture_mutate,
+            _dqn(head_config={"layer_norm": True}),
+            _dqn(head_config={"layer_norm": True}),
+        )
+
+
+def _latent_output(network, observation):
+    """Return a network's deterministic output, bypassing any sampling head."""
+    network.eval()
+    head = getattr(network.head_net, "wrapped", network.head_net)
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(0)
+        return head(network.encoder(observation))
+
+
+def _critic_inputs(critic, batch=4):
+    """Return a fixed (joint observation, action) pair a critic accepts."""
+    observation = {
+        key: torch.as_tensor(
+            np.stack([subspace.sample() for _ in range(batch)])
+        ).float()
+        for key, subspace in critic.observation_space.spaces.items()
+    }
+    return observation, torch.randn(batch, critic.num_actions)
+
+
+def _critic_output(critic, observation, actions):
+    """Return a critic's evaluation-mode output."""
+    critic.eval()
+    with torch.no_grad():
+        return critic(observation, actions).clone()
+
+
+# Each family paired with the sub-agent the pinned mutation names.
+_FP_MULTI_AGENT_FAMILIES = {
+    "on-policy (IPPO)": (_fp_ippo, "speaker_0"),
+    "off-policy (MADDPG)": (_fp_maddpg, "agent_0"),
+}
+
+
+class TestMutationsFunctionPreservingMultiAgent:
+    """Every sub-policy of a multi-agent algorithm is preserved."""
+
+    @pytest.mark.parametrize("method", ["head_net.add_node", "add_latent_node"])
+    @pytest.mark.parametrize(
+        "family", list(_FP_MULTI_AGENT_FAMILIES), ids=list(_FP_MULTI_AGENT_FAMILIES)
+    )
+    def test_every_sub_policy_keeps_its_output(self, monkeypatch, family, method):
+        build_agent, lead_agent = _FP_MULTI_AGENT_FAMILIES[family]
+        _pin_mutation_method(monkeypatch, f"{lead_agent}.{method}")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = build_agent()
+        observation = torch.randn(4, 4)
+        before = {
+            key: _latent_output(policy, observation)
+            for key, policy in agent.actors.items()
+        }
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        for key, policy in agent.actors.items():
+            torch.testing.assert_close(
+                _latent_output(policy, observation), before[key], rtol=0, atol=1e-6
+            )
+
+    def test_every_critic_keeps_its_output(self, monkeypatch):
+        """The critic is preserved too, not just the policy it scores."""
+        _pin_mutation_method(monkeypatch, "agent_0.add_latent_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = _fp_maddpg()
+        inputs = {key: _critic_inputs(critic) for key, critic in agent.critics.items()}
+        before = {
+            key: _critic_output(critic, *inputs[key])
+            for key, critic in agent.critics.items()
+        }
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        for key, critic in agent.critics.items():
+            torch.testing.assert_close(
+                _critic_output(critic, *inputs[key]), before[key], rtol=0, atol=1e-6
+            )
+
+
+def _simba_dqn():
+    """Return a DQN whose encoder is a SimBa residual trunk."""
+    net_config = _fp_net_config(simba=True)
+    net_config["encoder_config"] = {"hidden_size": 8, "num_blocks": 1}
+    return DQN(
+        generate_random_box_space((4,)),
+        generate_discrete_space(2),
+        net_config=net_config,
+        device="cpu",
+    )
+
+
+def _dict_dqn(dict_space):
+    """Return a DQN whose encoder fuses a dict observation."""
+    net_config = _fp_net_config()
+    del net_config["encoder_config"]
+    return DQN(
+        dict_space,
+        generate_discrete_space(2),
+        net_config=net_config,
+        device="cpu",
+    )
+
+
+class TestMutationsFunctionPreservingLatentEncoders:
+    """Growing the latent is preserved whatever the encoder is built from.
+
+    A latent widening only rewrites the head's new input columns, so the
+    encoder's interior has no say in whether it can be preserved.
+    """
+
+    @staticmethod
+    def _latent(network, observation):
+        """Return the head's deterministic output for a fixed observation."""
+        network.eval()
+        kwargs = {}
+        if getattr(network, "recurrent", False):
+            batch = (
+                next(iter(observation.values()))
+                if isinstance(observation, dict)
+                else observation
+            )
+            kwargs["hidden_state"] = {
+                f"{network.encoder.name}_{key}": torch.zeros(
+                    *[dim if isinstance(dim, int) else batch.shape[0] for dim in shape]
+                )
+                for key, shape in network.encoder.hidden_state_architecture.items()
+            }
+        with torch.no_grad():
+            latent = network.encoder(observation, **kwargs)
+            if isinstance(latent, tuple):
+                latent = latent[0]
+            head = getattr(network.head_net, "wrapped", network.head_net)
+            return head(latent).clone()
+
+    @pytest.mark.parametrize("encoder", ["simba", "recurrent", "multi_input"])
+    def test_the_policy_output_survives(self, monkeypatch, dict_space, encoder):
+        _pin_mutation_method(monkeypatch, "add_latent_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent, observation = {
+            "simba": lambda: (_simba_dqn(), torch.randn(4, 4)),
+            "recurrent": lambda: (_recurrent_ppo(), torch.randn(4, 2, 4)),
+            "multi_input": lambda: (
+                _dict_dqn(dict_space),
+                {
+                    key: torch.as_tensor(subspace.sample()).unsqueeze(0).float()
+                    for key, subspace in dict_space.spaces.items()
+                },
+            ),
+        }[encoder]()
+        policy = getattr(agent, agent.registry.policy())
+        before = self._latent(policy, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        policy = getattr(agent, agent.registry.policy())
+        torch.testing.assert_close(
+            self._latent(policy, observation), before, rtol=0, atol=1e-6
+        )
+
+    @pytest.mark.parametrize("encoder", ["simba", "recurrent", "multi_input"])
+    def test_it_does_not_stand_down(self, monkeypatch, dict_space, encoder):
+        _pin_mutation_method(monkeypatch, "add_latent_node")
+        agent = {
+            "simba": _simba_dqn,
+            "recurrent": _recurrent_ppo,
+            "multi_input": lambda: _dict_dqn(dict_space),
+        }[encoder]()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _fp_mutations().architecture_mutate(agent)
+
+        assert not [w for w in caught if "function-preserving" in str(w.message)]
+
+
+def _encoder_is_pinned(network):
+    """Return whether network's encoder is borrowed from the policy network."""
+    encoder = getattr(network, "encoder", None)
+    return encoder is not None and not list(encoder.parameters())
+
+
+class TestMutationsFunctionPreservingSharedEncoders:
+    """A borrowed encoder's own head is preserved alongside the policy's."""
+
+    @staticmethod
+    def ppo():
+        return PPO(
+            generate_random_box_space((4,)),
+            generate_discrete_space(2),
+            share_encoders=True,
+            net_config=_fp_net_config(),
+            device="cpu",
+        )
+
+    def test_the_borrowing_critic_keeps_its_output(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "add_latent_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = self.ppo()
+        observation = torch.randn(4, 4)
+        agent.critic.eval()
+        before = agent.critic(observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        agent.critic.eval()
+        torch.testing.assert_close(agent.critic(observation), before, rtol=0, atol=1e-6)
+
+    def test_the_critic_encoder_is_still_borrowed(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "add_latent_node")
+        agent = self.ppo()
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        assert not _encoder_is_pinned(agent.actor)
+        assert _encoder_is_pinned(agent.critic)
+
+
+_FP_CNN_NET_CONFIG = {
+    "latent_dim": 8,
+    "min_latent_dim": 1,
+    "max_latent_dim": 128,
+    "encoder_config": {
+        "channel_size": [4, 4],
+        "kernel_size": [3, 3],
+        "stride_size": [1, 1],
+        "layer_norm": False,
+        "min_channel_size": 1,
+    },
+    "head_config": {"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+}
+
+
+def _cnn_dqn():
+    """Return a DQN whose encoder is a small unnormalised ReLU CNN."""
+    return DQN(
+        generate_random_box_space((3, 16, 16), low=0, high=255),
+        generate_discrete_space(2),
+        net_config=_FP_CNN_NET_CONFIG,
+        device="cpu",
+    )
+
+
+class TestMutationsFunctionPreservingConvolutionalEncoder:
+    """A convolutional encoder is preserved through the whole operator."""
+
+    @staticmethod
+    def widen_convolutions(steps=6, seed=0):
+        """Widen the encoder repeatedly, reporting the shift and layers grown."""
+        agent = _cnn_dqn()
+        agent.actor.rng = np.random.default_rng(seed)
+        observation = torch.rand(4, 3, 16, 16)
+        mutations = _fp_mutations()
+        shift, grown = 0.0, set()
+
+        for _ in range(steps):
+            widths = list(agent.actor.encoder.channel_size)
+            before = _policy_output(agent, observation)
+
+            agent = mutations.architecture_mutate(agent)
+
+            after = _policy_output(agent, observation)
+            shift = max(shift, (after - before).abs().max().item())
+            grown |= {
+                layer
+                for layer, width in enumerate(agent.actor.encoder.channel_size)
+                if width > widths[layer]
+            }
+
+        return shift, grown
+
+    def test_a_widened_convolution_keeps_the_policy_output(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "encoder.add_channel")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+
+        shift, _grown = self.widen_convolutions()
+
+        assert shift <= 1e-6
+
+    def test_widening_reaches_both_convolutional_boundaries(self, monkeypatch):
+        """Both the conv-to-conv and the conv-to-flatten-to-dense fan-outs are hit."""
+        _pin_mutation_method(monkeypatch, "encoder.add_channel")
+
+        _shift, grown = self.widen_convolutions()
+
+        assert grown == {0, 1}
+
+    def test_a_widened_latent_keeps_the_policy_output(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "add_latent_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = _cnn_dqn()
+        observation = torch.rand(4, 3, 16, 16)
+        before = _policy_output(agent, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        after = _policy_output(agent, observation)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+        assert agent.actor.latent_dim > _FP_CNN_NET_CONFIG["latent_dim"]
+
+
+class TestMutationsFunctionPreservingDistributionHead:
+    """A distribution-wrapped head is preserved like a plain one."""
+
+    @staticmethod
+    def ppo():
+        return PPO(
+            generate_random_box_space((4,)),
+            generate_discrete_space(2),
+            net_config=_fp_net_config(),
+            device="cpu",
+        )
+
+    def test_a_deeper_head_keeps_the_policy_output(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_layer")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        agent = self.ppo()
+        observation = torch.randn(4, 4)
+        before = _latent_output(agent.actor, observation)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        after = _latent_output(agent.actor, observation)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+
+    def test_the_head_actually_deepened(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_layer")
+        agent = self.ppo()
+        before = len(agent.actor.head_net.wrapped.hidden_size)
+
+        agent = _fp_mutations().architecture_mutate(agent)
+
+        assert len(agent.actor.head_net.wrapped.hidden_size) == before + 1
+
+
+class TestMutationsFunctionPreservingDeterminism:
+    """The fixup draws its noise without disturbing anything else."""
+
+    def test_it_leaves_the_mutation_sampling_stream_untouched(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        mutations = _fp_mutations(seed=42)
+        mutations.architecture_mutate(_dqn())
+        with_fixup = mutations.rng.integers(0, 10_000, size=8).tolist()
+
+        monkeypatch.setattr(
+            "agilerl.hpo.mutation.preserve_architecture_mutation",
+            lambda *args, **kwargs: None,
+        )
+        baseline = _fp_mutations(seed=42)
+        baseline.architecture_mutate(_dqn())
+        without_fixup = baseline.rng.integers(0, 10_000, size=8).tolist()
+
+        assert with_fixup == without_fixup
+
+    def test_it_leaves_the_global_generator_untouched(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        mutations = _fp_mutations(seed=42)
+        agent = _dqn()
+        network = agent.actor
+        before = mutation_utils.hidden_widths(network.head_net)
+        network.head_net.add_node(hidden_layer=0, numb_new_nodes=4)
+        state = torch.random.get_rng_state()
+
+        mutation_utils.preserve_architecture_mutation(
+            network, "head_net.add_node", {"hidden_layer": 0}, before, mutations._fp_rng
+        )
+
+        assert torch.equal(torch.random.get_rng_state(), state)
+
+
+class TestFunctionPreservingRemovalsUnchanged:
+    """Removals keep AgileRL's original behaviour, weight for weight."""
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "head_net.remove_node",
+            "encoder.remove_node",
+            "remove_latent_node",
+            "head_net.remove_layer",
+        ],
+    )
+    def test_a_removal_matches_the_original_operator(self, monkeypatch, method):
+        _pin_mutation_method(monkeypatch, method)
+        agent = _dqn(
+            head_config={
+                "hidden_size": [16, 16],
+                "min_mlp_nodes": 1,
+                "min_hidden_layers": 1,
+            }
+        )
+
+        preserved = _fp_mutations(seed=3).architecture_mutate(agent.clone())
+        monkeypatch.setattr(
+            "agilerl.hpo.mutation.preserve_architecture_mutation",
+            lambda *args, **kwargs: None,
+        )
+        original = _fp_mutations(seed=3).architecture_mutate(agent.clone())
+
+        assert_state_dicts_equal(
+            preserved.actor.state_dict(), original.actor.state_dict()
+        )
+
+
+class TestMutationsFunctionPreservingAccelerator:
+    """The fixup lands the same way when an accelerator owns the networks."""
+
+    def test_an_addition_keeps_the_policy_output(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        monkeypatch.setattr(mutation_utils, "FP_NOISE_SCALE", 0.0)
+        accelerator = Accelerator(cpu=True, device_placement=False)
+        agent = DQN(
+            generate_random_box_space((4,)),
+            generate_discrete_space(2),
+            net_config=_fp_net_config(),
+            accelerator=accelerator,
+            device="cpu",
+        )
+        agent.wrap_models()
+        observation = torch.randn(4, 4)
+        agent.unwrap_models()
+        before = _policy_output(agent, observation)
+        agent.wrap_models()
+
+        mutations = Mutations(
+            0, 1, 0, 0, 0, 0, rand_seed=0, device="cpu", accelerator=accelerator
+        )
+        agent = mutations.architecture_mutate(agent)
+
+        agent.unwrap_models()
+        torch.testing.assert_close(
+            _policy_output(agent, observation), before, rtol=0, atol=1e-6
+        )
+
+    def test_the_architecture_actually_grew(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        accelerator = Accelerator(cpu=True, device_placement=False)
+        agent = DQN(
+            generate_random_box_space((4,)),
+            generate_discrete_space(2),
+            net_config=_fp_net_config(),
+            accelerator=accelerator,
+            device="cpu",
+        )
+        agent.wrap_models()
+        before = agent.actor.head_net.hidden_size[0]
+
+        mutations = Mutations(
+            0, 1, 0, 0, 0, 0, rand_seed=0, device="cpu", accelerator=accelerator
+        )
+        agent = mutations.architecture_mutate(agent)
+
+        assert agent.actor.head_net.hidden_size[0] > before
+
+
+def _raise_fixup_failure(*args, **kwargs):
+    """Stand in for a fixup that cannot complete."""
+    msg = "fixup failed"
+    raise RuntimeError(msg)
+
+
+class TestMutationsFunctionPreservingDegradation:
+    """A fixup that declines leaves the original operator's result in place."""
+
+    def test_an_unresolvable_target_records_no_snapshot(self):
+        agent = _dqn()
+
+        assert (
+            mutation_utils.pre_mutation_widths(agent.actor, "missing.add_node") is None
+        )
+
+    def test_an_unresolvable_applied_mutation_writes_nothing(self):
+        agent = _dqn()
+        before = copy.deepcopy(agent.actor.state_dict())
+
+        mutation_utils.preserve_architecture_mutation(
+            agent.actor,
+            "missing.add_node",
+            {"hidden_layer": 0},
+            [8],
+            np.random.default_rng(0),
+        )
+
+        assert_state_dicts_equal(agent.actor.state_dict(), before)
+
+    def test_an_index_the_network_does_not_have_declines(self):
+        """A mutation sampled on a deeper network reports an unusable index."""
+        agent = _dqn()
+        before = copy.deepcopy(agent.actor.state_dict())
+
+        mutation_utils.preserve_architecture_mutation(
+            agent.actor,
+            "head_net.add_node",
+            {"hidden_layer": 9},
+            [8, 8],
+            np.random.default_rng(0),
+        )
+
+        assert_state_dicts_equal(agent.actor.state_dict(), before)
+
+    def test_a_mutation_reporting_no_index_declines(self):
+        agent = _dqn()
+        before = copy.deepcopy(agent.actor.state_dict())
+
+        mutation_utils.preserve_architecture_mutation(
+            agent.actor, "head_net.add_node", {}, [8, 8], np.random.default_rng(0)
+        )
+
+        assert_state_dicts_equal(agent.actor.state_dict(), before)
+
+    def test_a_layer_that_cannot_grow_is_silent(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        agent = _dqn(head_config={"max_mlp_nodes": 8})
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            agent = _fp_mutations().architecture_mutate(agent)
+
+        assert agent.actor.head_net.hidden_size == [8]
+        assert not [w for w in caught if "function-preserving" in str(w.message)]
+
+    def test_a_failing_fixup_propagates(self, monkeypatch):
+        _pin_mutation_method(monkeypatch, "head_net.add_node")
+        monkeypatch.setattr(
+            mutation_utils, "preserve_added_nodes", _raise_fixup_failure
+        )
+        agent = _dqn()
+
+        with pytest.raises(RuntimeError, match="fixup failed"):
+            _fp_mutations().architecture_mutate(agent)
 
 
 def _regrama_mutations(**kwargs) -> Mutations:

--- a/tests/test_models/test_manifest.py
+++ b/tests/test_models/test_manifest.py
@@ -1393,15 +1393,19 @@ _SINGLE_AGENT_CONFIGS = [
     ("ddpg/ddpg_simba.yaml", DDPGSpec, SimbaSpec),
     ("td3.yaml", TD3Spec, MlpSpec),
     ("multi_input.yaml", PPOSpec, MultiInputSpec),
+    ("dqn/dqn_func_preserving.yaml", DQNSpec, MlpSpec),
+    ("ppo/ppo_func_preserving.yaml", PPOSpec, MlpSpec),
 ]
 
 _BANDIT_CONFIGS = [
     ("bandit/neural_ts.yaml", NeuralTSSpec, MlpSpec),
     ("bandit/neural_ucb.yaml", NeuralUCBSpec, MlpSpec),
+    ("bandit/neural_ucb_func_preserving.yaml", NeuralUCBSpec, MlpSpec),
 ]
 
 _OFFLINE_CONFIGS = [
     ("cqn.yaml", CQNSpec, MlpSpec),
+    ("cqn_func_preserving.yaml", CQNSpec, MlpSpec),
 ]
 
 _MULTI_AGENT_CONFIGS = [
@@ -1409,6 +1413,8 @@ _MULTI_AGENT_CONFIGS = [
     ("multi_agent/matd3.yaml", MATD3Spec),
     ("multi_agent/ippo.yaml", IPPOSpec),
     ("multi_agent/ippo_pong.yaml", IPPOSpec),
+    ("multi_agent/ippo_func_preserving.yaml", IPPOSpec),
+    ("multi_agent/maddpg_func_preserving.yaml", MADDPGSpec),
 ]
 
 # Configs omit the network ``arch``, so it is inferred from the observation
@@ -1696,6 +1702,55 @@ class TestSimbaRecurrentConflict:
         )
         manifest = TrainingManifest.model_validate(raw)
         assert manifest.algorithm.recurrent is False
+
+
+_FUNC_PRESERVING_CONFIGS = [
+    "ppo/ppo_func_preserving.yaml",
+    "dqn/dqn_func_preserving.yaml",
+    "cqn_func_preserving.yaml",
+    "bandit/neural_ucb_func_preserving.yaml",
+    "multi_agent/ippo_func_preserving.yaml",
+    "multi_agent/maddpg_func_preserving.yaml",
+]
+
+
+class TestFunctionPreservingManifests:
+    """The shipped manifests that let architecture additions be preserved."""
+
+    @staticmethod
+    def validated(rel_path):
+        """Return the validated manifest at a path under the configs directory."""
+        config_path = CONFIGS_DIR / rel_path
+        if not config_path.exists():
+            pytest.skip(f"Config not found: {config_path}")
+        with open(config_path) as handle:
+            return TrainingManifest.get_validated(yaml.safe_load(handle), mode="python")
+
+    @staticmethod
+    def net_config(validated):
+        """Return the network configuration as a plain dictionary."""
+        net_config = validated.algorithm.net_config
+        return net_config if isinstance(net_config, dict) else net_config.model_dump()
+
+    @pytest.mark.parametrize("rel_path", _FUNC_PRESERVING_CONFIGS)
+    def test_normalisation_is_switched_off(self, rel_path):
+        net_config = self.net_config(self.validated(rel_path))
+
+        for block in ("encoder_config", "head_config"):
+            assert net_config[block]["layer_norm"] is False
+
+    @pytest.mark.parametrize("rel_path", _FUNC_PRESERVING_CONFIGS)
+    def test_activation_mutations_are_disabled(self, rel_path):
+        validated = self.validated(rel_path)
+
+        assert validated.mutation.probabilities.act_mut == 0.0
+
+    @pytest.mark.parametrize("rel_path", _FUNC_PRESERVING_CONFIGS)
+    def test_architecture_mutations_are_enabled(self, rel_path):
+        probabilities = self.validated(rel_path).mutation.probabilities
+
+        assert probabilities.arch_mut > 0.0
+        assert probabilities.new_layer > 0.0
 
 
 # The LLM manifests are the ones the demo (``demos/llm/demo_llm_finetuning.py``)

--- a/tests/test_train/test_train.py
+++ b/tests/test_train/test_train.py
@@ -5,6 +5,7 @@ import os
 import random
 import shutil
 from collections import Counter
+from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
 from typing import ClassVar
@@ -55,6 +56,7 @@ from agilerl.training.train_multi_agent_on_policy import train_multi_agent_on_po
 from agilerl.training.train_off_policy import train_off_policy
 from agilerl.training.train_offline import train_offline
 from agilerl.training.train_on_policy import train_on_policy
+from agilerl.utils import mutation_utils
 from agilerl.utils.utils import make_multi_agent_vect_envs, run_selection_and_mutation
 from agilerl.vector.pz_vec_env import PettingZooVecEnv
 from tests.helper_functions import (
@@ -5654,37 +5656,37 @@ def _multi_agent_hp_config() -> HyperparameterConfig:
     )
 
 
-def _build_single_agent_population(algo_cls):
+def _build_single_agent_population(algo_cls, net_config=_CROSS_FAMILY_NET_CONFIG):
     return algo_cls.population(
         size=8,
         observation_space=generate_random_box_space((4,)),
         action_space=generate_discrete_space(2),
         hp_config=_single_agent_hp_config(),
-        net_config=_CROSS_FAMILY_NET_CONFIG,
+        net_config=net_config,
         device="cpu",
     )
 
 
-def _build_maddpg_population():
+def _build_maddpg_population(net_config=_CROSS_FAMILY_NET_CONFIG):
     return MADDPG.population(
         size=8,
         observation_space=generate_multi_agent_box_spaces(2, (4,)),
         action_space=generate_multi_agent_discrete_spaces(2, 2),
         agent_ids=["agent_0", "agent_1"],
         hp_config=_multi_agent_hp_config(),
-        net_config=_CROSS_FAMILY_NET_CONFIG,
+        net_config=net_config,
         device="cpu",
     )
 
 
-def _build_ippo_population():
+def _build_ippo_population(net_config=_CROSS_FAMILY_NET_CONFIG):
     return IPPO.population(
         size=8,
         observation_space=generate_multi_agent_box_spaces(2, (4,)),
         action_space=generate_multi_agent_discrete_spaces(2, 2),
         agent_ids=["agent_0", "agent_1"],
         hp_config=_single_agent_hp_config(),
-        net_config=_CROSS_FAMILY_NET_CONFIG,
+        net_config=net_config,
         device="cpu",
     )
 
@@ -5776,6 +5778,498 @@ def test_remove_saved_models():
     shutil.rmtree("models", ignore_errors=True)
 
 
+def _give_population_fitness(population) -> None:
+    """Give each agent a distinct fitness so tournament selection can rank."""
+    for position, agent in enumerate(population):
+        agent.fitness = [float(position)]
+
+
+_FP_FAMILY_NET_CONFIG = {
+    "encoder_config": {
+        "hidden_size": [8, 8],
+        "min_mlp_nodes": 7,
+        "layer_norm": False,
+        "activation": "ReLU",
+    },
+    "head_config": {
+        "hidden_size": [8],
+        "min_mlp_nodes": 7,
+        "layer_norm": False,
+        "activation": "ReLU",
+    },
+}
+
+
+_ARCH_FAMILY_CASES = {
+    "off-policy (DQN)": lambda: _build_single_agent_population(
+        DQN, _FP_FAMILY_NET_CONFIG
+    ),
+    "multi-agent off-policy (MADDPG)": lambda: _build_maddpg_population(
+        _FP_FAMILY_NET_CONFIG
+    ),
+    "multi-agent on-policy (IPPO)": lambda: _build_ippo_population(
+        _FP_FAMILY_NET_CONFIG
+    ),
+    "bandit (NeuralUCB)": lambda: _build_single_agent_population(
+        NeuralUCB, _FP_FAMILY_NET_CONFIG
+    ),
+    "offline (CQN)": lambda: _build_single_agent_population(CQN, _FP_FAMILY_NET_CONFIG),
+    "on-policy (PPO)": lambda: _build_single_agent_population(
+        PPO, _FP_FAMILY_NET_CONFIG
+    ),
+}
+
+
+_FP_FIXUPS = ("preserve_added_nodes", "preserve_added_layer", "preserve_added_latent")
+_FP_BLOCKERS = (
+    "node_addition_blocker",
+    "layer_addition_blocker",
+    "latent_addition_blocker",
+)
+
+
+@contextmanager
+def _fp_fixup_engages(declines_allowed=False):
+    """Assert additions reach the fixup, and it stands down only where allowed."""
+    reached = []
+    declined = False
+    originals = {
+        name: getattr(mutation_utils, name) for name in (*_FP_FIXUPS, *_FP_BLOCKERS)
+    }
+
+    def spy_fixup(original):
+        def record(*args, **kwargs):
+            reached.append(original.__name__)
+            return original(*args, **kwargs)
+
+        return record
+
+    def spy_blocker(original):
+        def record(*args, **kwargs):
+            nonlocal declined
+            blocked = original(*args, **kwargs)
+            declined = declined or blocked
+            return blocked
+
+        return record
+
+    for name in _FP_FIXUPS:
+        setattr(mutation_utils, name, spy_fixup(originals[name]))
+    for name in _FP_BLOCKERS:
+        setattr(mutation_utils, name, spy_blocker(originals[name]))
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(mutation_utils, name, original)
+
+    assert reached, "no architecture addition reached the fixup"
+    if not declines_allowed:
+        assert not declined, "an addition declined where none was expected"
+
+
+def _arch_mutation(seed: int = 0) -> Mutations:
+    """Return an architecture-mutation-only operator."""
+    return Mutations(
+        no_mutation=0.0,
+        architecture=1.0,
+        new_layer_prob=0.5,
+        parameters=0.0,
+        activation=0.0,
+        rl_hp=0.0,
+        mutation_sd=0.1,
+        rand_seed=seed,
+        device="cpu",
+    )
+
+
+def _population_is_finite(population) -> bool:
+    """Return whether every agent's policy weights are still finite."""
+    for agent in population:
+        policy = getattr(agent, agent.registry.policy())
+        for tensor in policy.state_dict().values():
+            if tensor.is_floating_point() and not bool(torch.isfinite(tensor).all()):
+                return False
+    return True
+
+
+def _architecture_fingerprint(population) -> list:
+    """Return every agent's policy parameter shapes."""
+    return [
+        [
+            tuple(tensor.shape)
+            for tensor in getattr(agent, agent.registry.policy()).state_dict().values()
+        ]
+        for agent in population
+    ]
+
+
+class TestFunctionPreservingCrossFamilyEvolution:
+    """Architecture mutations evolve a real population of every non-LLM family."""
+
+    @staticmethod
+    def evolve(population, strategy, cycles: int = 3):
+        """Run several evaluate-select-mutate cycles and return the population."""
+        mutation = _arch_mutation()
+        for _ in range(cycles):
+            _give_population_fitness(population)
+            population = run_selection_and_mutation(
+                strategy,
+                population=population,
+                mutation=mutation,
+                env_name="Env",
+                algo="algo",
+            )
+        return population
+
+    @pytest.mark.parametrize(
+        "family", list(_ARCH_FAMILY_CASES), ids=list(_ARCH_FAMILY_CASES)
+    )
+    def test_the_fixup_engages_for_every_family(self, family):
+        """Additions reach the fixup rather than falling back to random init."""
+        build_population = _ARCH_FAMILY_CASES[family]
+        population = build_population()
+
+        with _fp_fixup_engages():
+            self.evolve(
+                population,
+                TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=len(population)
+                ),
+            )
+
+    @pytest.mark.parametrize(
+        "family", list(_ARCH_FAMILY_CASES), ids=list(_ARCH_FAMILY_CASES)
+    )
+    def test_tournament_selection_evolves_every_family(self, family):
+        build_population = _ARCH_FAMILY_CASES[family]
+        population = build_population()
+        before = _architecture_fingerprint(population)
+
+        population = self.evolve(
+            population,
+            TournamentSelection(
+                tournament_size=2, elitism=True, population_size=len(population)
+            ),
+        )
+
+        assert len(population) == 8
+        assert _population_is_finite(population)
+        assert _architecture_fingerprint(population) != before
+
+    @pytest.mark.parametrize(
+        "family", list(_ARCH_FAMILY_CASES), ids=list(_ARCH_FAMILY_CASES)
+    )
+    def test_multi_frequency_selection_evolves_every_family(self, family):
+        build_population = _ARCH_FAMILY_CASES[family]
+        population = build_population()
+        for agent in population:
+            agent.subpopulation_id = agent.index // 4
+        strategy = MultiFrequencySelection(
+            population_size=8,
+            n_subpopulations=2,
+            evolution_frequency_ratios=[1, 2],
+            n_winners=1,
+            n_survivors=1,
+            n_open_for_migration=1,
+            n_losers=1,
+            seed=0,
+        )
+        mutation = _arch_mutation()
+
+        for _ in range(3):
+            rank_population_by_subpopulation(population)
+            population = run_selection_and_mutation(
+                strategy,
+                population=population,
+                mutation=mutation,
+                env_name="Env",
+                algo="algo",
+            )
+
+        assert len(population) == 8
+        assert len({agent.index for agent in population}) == 8
+        assert _population_is_finite(population)
+
+
+class _FunctionPreservingParallelEnv(ParallelEnv):
+    """Two-agent parallel env with no env-defined action overrides."""
+
+    def __init__(self, state_dims=(4,), action_dims=5):
+        self.state_dims = state_dims
+        self.action_dims = action_dims
+        self.agents = ["agent_0", "other_agent_0"]
+        self.possible_agents = list(self.agents)
+        self.metadata = {"name": "function_preserving_parallel_v0"}
+        self.render_mode = None
+
+    def reset(self, seed=None, options=None):
+        return self._observations(), {agent: {} for agent in self.agents}
+
+    def step(self, action):
+        return (
+            self._observations(),
+            {agent: float(np.random.rand()) for agent in self.agents},
+            dict.fromkeys(self.agents, False),
+            dict.fromkeys(self.agents, False),
+            {agent: {} for agent in self.agents},
+        )
+
+    def _observations(self):
+        return {
+            agent: np.random.rand(*self.state_dims).astype(np.float32)
+            for agent in self.agents
+        }
+
+    def action_space(self, agent):
+        return Discrete(self.action_dims)
+
+    def observation_space(self, agent):
+        return Box(0.0, 1.0, self.state_dims, dtype=np.float32)
+
+
+class _FunctionPreservingBanditEnv:
+    """Contextual bandit env yielding one float32 context per arm."""
+
+    def __init__(self, context_dims=(4,), arms=2):
+        self.arms = arms
+        self.state_size = (arms, *context_dims)
+        self.observation_space = Box(0.0, 1.0, self.state_size, dtype=np.float32)
+        self.action_space = Discrete(arms)
+        self.num_envs = 1
+
+    def reset(self, seed=None, options=None):
+        return self._context()
+
+    def step(self, action):
+        return self._context(), np.random.rand(1).astype(np.float32)
+
+    def _context(self):
+        return np.random.rand(*self.state_size).astype(np.float32)
+
+
+class TestFunctionPreservingTrainerWiring:
+    """Real agents evolve through every non-LLM trainer with the fixup active."""
+
+    @staticmethod
+    def assert_evolved(population, before) -> None:
+        """Assert the population survived and its architectures actually moved."""
+        assert population
+        assert _population_is_finite(population)
+        assert _architecture_fingerprint(population) != before
+
+    def test_off_policy(self):
+        vec_env = gym.vector.SyncVectorEnv([lambda: gym.make("CartPole-v1")])
+        population = DQN.population(
+            size=2,
+            observation_space=vec_env.single_observation_space,
+            action_space=vec_env.single_action_space,
+            net_config=_FP_FAMILY_NET_CONFIG,
+            batch_size=4,
+            learn_step=1,
+            device="cpu",
+        )
+        before = _architecture_fingerprint(population)
+
+        with _fp_fixup_engages():
+            population, _fitnesses = train_off_policy(
+                vec_env,
+                "CartPole-v1",
+                "DQN",
+                population,
+                ReplayBuffer(max_size=100, device="cpu"),
+                max_steps=24,
+                evo_steps=8,
+                eval_steps=2,
+                eval_loop=1,
+                selection_strategy=TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=2
+                ),
+                mutation=_arch_mutation(),
+                verbose=False,
+            )
+
+        self.assert_evolved(population, before)
+
+    def test_on_policy(self):
+        vec_env = gym.vector.SyncVectorEnv([lambda: gym.make("CartPole-v1")])
+        population = PPO.population(
+            size=2,
+            observation_space=vec_env.single_observation_space,
+            action_space=vec_env.single_action_space,
+            net_config=_FP_FAMILY_NET_CONFIG,
+            batch_size=4,
+            learn_step=8,
+            device="cpu",
+        )
+        before = _architecture_fingerprint(population)
+
+        with _fp_fixup_engages():
+            population, _fitnesses = train_on_policy(
+                vec_env,
+                "CartPole-v1",
+                "PPO",
+                population,
+                max_steps=24,
+                evo_steps=8,
+                eval_steps=2,
+                eval_loop=1,
+                selection_strategy=TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=2
+                ),
+                mutation=_arch_mutation(),
+                verbose=False,
+            )
+
+        self.assert_evolved(population, before)
+
+    def test_multi_agent_on_policy(self):
+        env = make_multi_agent_vect_envs(
+            _FunctionPreservingParallelEnv, num_envs=2, state_dims=(4,), action_dims=5
+        )
+        population = IPPO.population(
+            size=2,
+            observation_space=[Box(0.0, 1.0, (4,)), Box(0.0, 1.0, (4,))],
+            action_space=[Discrete(5), Discrete(5)],
+            agent_ids=["agent_0", "other_agent_0"],
+            net_config=_FP_FAMILY_NET_CONFIG,
+            device="cpu",
+        )
+        before = _architecture_fingerprint(population)
+
+        with _fp_fixup_engages():
+            population, _fitnesses = train_multi_agent_on_policy(
+                env,
+                "env_name",
+                "IPPO",
+                pop=population,
+                max_steps=24,
+                evo_steps=8,
+                eval_steps=2,
+                eval_loop=1,
+                selection_strategy=TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=2
+                ),
+                mutation=_arch_mutation(),
+                verbose=False,
+            )
+        env.close()
+
+        self.assert_evolved(population, before)
+
+    def test_multi_agent_off_policy(self):
+        env = make_multi_agent_vect_envs(
+            _FunctionPreservingParallelEnv, num_envs=2, state_dims=(4,), action_dims=5
+        )
+        population = MADDPG.population(
+            size=2,
+            observation_space=[Box(0.0, 1.0, (4,)), Box(0.0, 1.0, (4,))],
+            action_space=[Discrete(5), Discrete(5)],
+            agent_ids=["agent_0", "other_agent_0"],
+            net_config=_FP_FAMILY_NET_CONFIG,
+            batch_size=4,
+            device="cpu",
+        )
+        before = _architecture_fingerprint(population)
+
+        with _fp_fixup_engages(declines_allowed=True):
+            population, _fitnesses = train_multi_agent_off_policy(
+                env,
+                "env_name",
+                "MADDPG",
+                pop=population,
+                memory=ReplayBuffer(max_size=100, device="cpu"),
+                max_steps=24,
+                evo_steps=8,
+                eval_steps=2,
+                eval_loop=1,
+                learning_delay=0,
+                selection_strategy=TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=2
+                ),
+                mutation=_arch_mutation(),
+                verbose=False,
+            )
+        env.close()
+
+        self.assert_evolved(population, before)
+
+    def test_bandits(self):
+        env = _FunctionPreservingBanditEnv((4,), 2)
+        population = NeuralUCB.population(
+            size=2,
+            observation_space=generate_random_box_space((4,)),
+            action_space=generate_discrete_space(2),
+            net_config=_FP_FAMILY_NET_CONFIG,
+            batch_size=4,
+            device="cpu",
+        )
+        before = _architecture_fingerprint(population)
+
+        with _fp_fixup_engages():
+            population, _fitnesses = train_bandits(
+                env,
+                "bandit_env_name",
+                "NeuralUCB",
+                population,
+                ReplayBuffer(max_size=100, device="cpu"),
+                max_steps=24,
+                episode_steps=4,
+                evo_steps=8,
+                eval_steps=2,
+                eval_loop=1,
+                selection_strategy=TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=2
+                ),
+                mutation=_arch_mutation(),
+                wb=False,
+                verbose=False,
+            )
+
+        self.assert_evolved(population, before)
+
+    def test_offline(self):
+        vec_env = gym.vector.SyncVectorEnv([lambda: gym.make("CartPole-v1")])
+        population = CQN.population(
+            size=2,
+            observation_space=vec_env.single_observation_space,
+            action_space=vec_env.single_action_space,
+            net_config=_FP_FAMILY_NET_CONFIG,
+            batch_size=4,
+            learn_step=1,
+            device="cpu",
+        )
+        dataset = {
+            "observations": np.random.randn(16, 4).astype(np.float32),
+            "actions": np.random.randint(0, 2, size=(16, 1)),
+            "rewards": np.random.randn(16).astype(np.float32),
+            "terminals": np.zeros(16, dtype=bool),
+        }
+        before = _architecture_fingerprint(population)
+
+        with _fp_fixup_engages():
+            population, _fitnesses = train_offline(
+                vec_env,
+                "CartPole-v1",
+                "CQN",
+                population,
+                ReplayBuffer(max_size=100, device="cpu"),
+                dataset=dataset,
+                max_steps=24,
+                evo_steps=8,
+                eval_steps=2,
+                eval_loop=1,
+                selection_strategy=TournamentSelection(
+                    tournament_size=2, elitism=True, population_size=2
+                ),
+                mutation=_arch_mutation(),
+                wb=False,
+                verbose=False,
+            )
+
+        self.assert_evolved(population, before)
+
+
 def _regrama_mutation() -> Mutations:
     """A parameter-mutation operator with ReGraMa's dormant-neuron reset enabled."""
     return Mutations(
@@ -5790,12 +6284,6 @@ def _regrama_mutation() -> Mutations:
         device="cpu",
         dormant_threshold=0.01,
     )
-
-
-def _give_population_fitness(population) -> None:
-    """Give each agent a distinct fitness so tournament selection can rank."""
-    for position, agent in enumerate(population):
-        agent.fitness = [float(position)]
 
 
 def _mark_population_dormant(population) -> None:

--- a/tests/test_utils/test_func_preservation.py
+++ b/tests/test_utils/test_func_preservation.py
@@ -60,8 +60,6 @@ def make_wrapped_head(hidden_size: list[int] | None = None) -> EvolvableDistribu
 
 def make_norm(norm_type: type[nn.Module], units: int = 8) -> nn.Module:
     """Instantiate a normalisation of the given type over ``units`` units."""
-    if norm_type is nn.GroupNorm:
-        return nn.GroupNorm(2, units)
     return norm_type(units)
 
 
@@ -76,30 +74,10 @@ def splice_norm(mlp: EvolvableMLP, norm: nn.Module) -> EvolvableMLP:
     return mlp
 
 
-NORM_TYPES = (
-    nn.LayerNorm,
-    nn.GroupNorm,
-    nn.BatchNorm1d,
-    nn.BatchNorm2d,
-    nn.BatchNorm3d,
-    nn.InstanceNorm1d,
-    nn.InstanceNorm2d,
-    nn.InstanceNorm3d,
-    nn.RMSNorm,
-)
+# The blocker recognises the normalisations evolvable_networks.py's own registry
+# builds, which is every one an evolvable module can be configured with.
+NORM_TYPES = mutation_utils.NORM_LAYER_TYPES
 NORM_TYPE_IDS = [norm_type.__name__ for norm_type in NORM_TYPES]
-
-# The blocker only recognises what evolvable_networks.py's own registry builds
-# (agilerl.utils.mutation_utils.NORM_LAYER_TYPES); a norm a custom network
-# authors directly, without going through that registry, is not detected.
-RECOGNISED_NORM_TYPES = mutation_utils.NORM_LAYER_TYPES
-RECOGNISED_NORM_TYPE_IDS = [norm_type.__name__ for norm_type in RECOGNISED_NORM_TYPES]
-UNRECOGNISED_NORM_TYPES = tuple(
-    norm_type for norm_type in NORM_TYPES if norm_type not in RECOGNISED_NORM_TYPES
-)
-UNRECOGNISED_NORM_TYPE_IDS = [
-    norm_type.__name__ for norm_type in UNRECOGNISED_NORM_TYPES
-]
 
 
 def make_duelling(
@@ -203,25 +181,11 @@ class TestNodeAdditionBlocker:
             mutation_utils.node_addition_blocker(make_cnn(layer_norm=True), 0) is True
         )
 
-    @pytest.mark.parametrize(
-        "norm_type", RECOGNISED_NORM_TYPES, ids=RECOGNISED_NORM_TYPE_IDS
-    )
+    @pytest.mark.parametrize("norm_type", NORM_TYPES, ids=NORM_TYPE_IDS)
     def test_every_recognised_normalisation_blocks(self, norm_type):
         mlp = splice_norm(make_mlp(), make_norm(norm_type))
 
         assert mutation_utils.node_addition_blocker(mlp, 0) is True
-
-    @pytest.mark.parametrize(
-        "norm_type", UNRECOGNISED_NORM_TYPES, ids=UNRECOGNISED_NORM_TYPE_IDS
-    )
-    def test_an_unrecognised_normalisation_does_not_block(self, norm_type):
-        """Only normalisations the library's own registry builds are detected."""
-        mlp = splice_norm(make_mlp(), make_norm(norm_type))
-
-        assert mutation_utils.node_addition_blocker(mlp, 0) is False
-
-    def test_the_spelled_out_list_covers_the_whole_registry(self):
-        assert set(mutation_utils.NORM_LAYER_TYPES) <= set(NORM_TYPES)
 
     def test_a_cross_unit_activation_blocks(self):
         assert (

--- a/tests/test_utils/test_func_preservation.py
+++ b/tests/test_utils/test_func_preservation.py
@@ -1,0 +1,945 @@
+# Copyright 2026 AgileRL
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+from gymnasium.spaces import Discrete
+from torch import nn
+
+from agilerl.modules.cnn import EvolvableCNN
+from agilerl.modules.mlp import EvolvableMLP
+from agilerl.networks.custom_modules import DuelingDistributionalMLP
+from agilerl.networks.distributions import EvolvableDistribution
+from agilerl.utils import mutation_utils
+
+
+def make_rng(seed: int = 0) -> np.random.Generator:
+    """Return a seeded generator, mirroring the one Mutations owns."""
+    return np.random.default_rng(seed)
+
+
+def make_mlp(hidden_size: list[int] | None = None, **kwargs) -> EvolvableMLP:
+    """Return a small unnormalised ReLU MLP."""
+    options = {
+        "num_inputs": 4,
+        "num_outputs": 2,
+        "hidden_size": hidden_size or [8, 8],
+        "layer_norm": False,
+        "min_mlp_nodes": 1,
+        "device": "cpu",
+        "name": "mlp",
+    }
+    options.update(kwargs)
+    return EvolvableMLP(**options)
+
+
+def make_cnn(**kwargs) -> EvolvableCNN:
+    """Return a small unnormalised ReLU CNN."""
+    options = {
+        "input_shape": [3, 16, 16],
+        "num_outputs": 4,
+        "channel_size": [4, 4],
+        "kernel_size": [3, 3],
+        "stride_size": [1, 1],
+        "layer_norm": False,
+        "min_channel_size": 1,
+        "device": "cpu",
+        "name": "cnn",
+    }
+    options.update(kwargs)
+    return EvolvableCNN(**options)
+
+
+def make_wrapped_head(hidden_size: list[int] | None = None) -> EvolvableDistribution:
+    """Return an MLP behind the distribution wrapper a policy head carries."""
+    return EvolvableDistribution(
+        Discrete(2), make_mlp(hidden_size=hidden_size), device="cpu"
+    )
+
+
+def make_norm(norm_type: type[nn.Module], units: int = 8) -> nn.Module:
+    """Instantiate a normalisation of the given type over ``units`` units."""
+    if norm_type is nn.GroupNorm:
+        return nn.GroupNorm(2, units)
+    return norm_type(units)
+
+
+def splice_norm(mlp: EvolvableMLP, norm: nn.Module) -> EvolvableMLP:
+    """Insert a normalisation between the first hidden layer and its consumer."""
+    rebuilt: dict[str, nn.Module] = {}
+    for name, layer in mlp.model.named_children():
+        rebuilt[name] = layer
+        if name.endswith("linear_layer_1"):
+            rebuilt["spliced_norm"] = norm
+    mlp.model = nn.Sequential(*rebuilt.values())
+    return mlp
+
+
+NORM_TYPES = (
+    nn.LayerNorm,
+    nn.GroupNorm,
+    nn.BatchNorm1d,
+    nn.BatchNorm2d,
+    nn.BatchNorm3d,
+    nn.InstanceNorm1d,
+    nn.InstanceNorm2d,
+    nn.InstanceNorm3d,
+    nn.RMSNorm,
+)
+NORM_TYPE_IDS = [norm_type.__name__ for norm_type in NORM_TYPES]
+
+# The blocker only recognises what evolvable_networks.py's own registry builds
+# (agilerl.utils.mutation_utils.NORM_LAYER_TYPES); a norm a custom network
+# authors directly, without going through that registry, is not detected.
+RECOGNISED_NORM_TYPES = mutation_utils.NORM_LAYER_TYPES
+RECOGNISED_NORM_TYPE_IDS = [norm_type.__name__ for norm_type in RECOGNISED_NORM_TYPES]
+UNRECOGNISED_NORM_TYPES = tuple(
+    norm_type for norm_type in NORM_TYPES if norm_type not in RECOGNISED_NORM_TYPES
+)
+UNRECOGNISED_NORM_TYPE_IDS = [
+    norm_type.__name__ for norm_type in UNRECOGNISED_NORM_TYPES
+]
+
+
+def make_duelling(
+    hidden_size: list[int] | None = None, **kwargs
+) -> DuelingDistributionalMLP:
+    """Return a duelling distributional head with two parallel streams."""
+    options = {
+        "num_inputs": 8,
+        "num_outputs": 2,
+        "hidden_size": hidden_size or [8, 8],
+        "num_atoms": 3,
+        "support": torch.linspace(-1.0, 1.0, 3),
+        "layer_norm": False,
+        "min_mlp_nodes": 1,
+        "device": "cpu",
+    }
+    options.update(kwargs)
+    return DuelingDistributionalMLP(**options)
+
+
+class TestHiddenWidths:
+    """Snapshot the output width of every non-output weight layer."""
+
+    def test_mlp_reports_each_hidden_layer_width(self):
+        widths = mutation_utils.hidden_widths(make_mlp(hidden_size=[8, 16]))
+
+        assert widths == [8, 16]
+
+    def test_cnn_reports_each_conv_channel_count(self):
+        widths = mutation_utils.hidden_widths(make_cnn(channel_size=[4, 6]))
+
+        assert widths == [4, 6]
+
+    def test_a_distribution_wrapped_head_is_unwrapped(self):
+        """The snapshot is taken on the head a policy actually exposes."""
+        widths = mutation_utils.hidden_widths(make_wrapped_head(hidden_size=[8, 16]))
+
+        assert widths == [8, 16]
+
+    def test_output_layer_is_excluded(self):
+        widths = mutation_utils.hidden_widths(make_mlp(hidden_size=[8], num_outputs=5))
+
+        assert 5 not in widths
+
+    def test_module_without_weight_layers_reports_nothing(self):
+        assert mutation_utils.hidden_widths(nn.Sequential(nn.ReLU())) == []
+
+
+class TestWeightStacks:
+    """Discover the parallel weight-layer streams of a sub-module."""
+
+    def test_flat_mlp_has_a_single_stream(self):
+        stacks = mutation_utils.weight_stacks(make_mlp())
+
+        assert len(stacks) == 1
+        assert len(stacks[0]) == 3
+
+    def test_a_distribution_wrapped_head_is_unwrapped(self):
+        stacks = mutation_utils.weight_stacks(make_wrapped_head(hidden_size=[8, 16]))
+
+        assert len(stacks) == 1
+        assert [layer.weight.shape[0] for layer in stacks[0]] == [8, 16, 2]
+
+    def test_duelling_head_has_two_parallel_streams(self):
+        stacks = mutation_utils.weight_stacks(make_duelling())
+
+        assert len(stacks) == 2
+
+    def test_duelling_streams_share_their_hidden_widths(self):
+        stacks = mutation_utils.weight_stacks(make_duelling(hidden_size=[8, 8]))
+
+        first, second = ([layer.weight_mu.shape[0] for layer in s[:-1]] for s in stacks)
+        assert first == second
+
+    def test_a_sibling_of_a_different_shape_is_not_a_stream(self):
+        head = make_duelling()
+        head.unrelated = nn.Sequential(nn.Linear(99, 7), nn.Linear(7, 3))
+
+        assert len(mutation_utils.weight_stacks(head)) == 2
+
+    def test_module_without_weight_layers_has_no_streams(self):
+        assert mutation_utils.weight_stacks(nn.Sequential(nn.ReLU())) == []
+
+
+class TestNodeAdditionBlocker:
+    """Decide whether widening a layer can preserve the network's function."""
+
+    def test_unnormalised_relu_mlp_is_supported(self):
+        assert mutation_utils.node_addition_blocker(make_mlp(), 0) is False
+
+    def test_unnormalised_relu_cnn_is_supported(self):
+        assert mutation_utils.node_addition_blocker(make_cnn(), 0) is False
+
+    def test_a_norm_between_producer_and_activation_blocks(self):
+        assert (
+            mutation_utils.node_addition_blocker(make_mlp(layer_norm=True), 0) is True
+        )
+
+    def test_a_convolution_batch_norm_blocks(self):
+        assert (
+            mutation_utils.node_addition_blocker(make_cnn(layer_norm=True), 0) is True
+        )
+
+    @pytest.mark.parametrize(
+        "norm_type", RECOGNISED_NORM_TYPES, ids=RECOGNISED_NORM_TYPE_IDS
+    )
+    def test_every_recognised_normalisation_blocks(self, norm_type):
+        mlp = splice_norm(make_mlp(), make_norm(norm_type))
+
+        assert mutation_utils.node_addition_blocker(mlp, 0) is True
+
+    @pytest.mark.parametrize(
+        "norm_type", UNRECOGNISED_NORM_TYPES, ids=UNRECOGNISED_NORM_TYPE_IDS
+    )
+    def test_an_unrecognised_normalisation_does_not_block(self, norm_type):
+        """Only normalisations the library's own registry builds are detected."""
+        mlp = splice_norm(make_mlp(), make_norm(norm_type))
+
+        assert mutation_utils.node_addition_blocker(mlp, 0) is False
+
+    def test_the_spelled_out_list_covers_the_whole_registry(self):
+        assert set(mutation_utils.NORM_LAYER_TYPES) <= set(NORM_TYPES)
+
+    def test_a_cross_unit_activation_blocks(self):
+        assert (
+            mutation_utils.node_addition_blocker(make_mlp(activation="Softmax"), 0)
+            is True
+        )
+
+    def test_a_recurrent_core_blocks(self):
+        from agilerl.modules.lstm import EvolvableLSTM
+
+        lstm = EvolvableLSTM(
+            input_size=4,
+            hidden_state_size=8,
+            num_outputs=2,
+            min_hidden_state_size=1,
+            device="cpu",
+        )
+
+        assert mutation_utils.node_addition_blocker(lstm, 0) is True
+
+    def test_a_multi_input_encoder_blocks(self, dict_space):
+        from agilerl.modules.multi_input import EvolvableMultiInput
+
+        encoder = EvolvableMultiInput(
+            observation_space=dict_space,
+            num_outputs=4,
+            latent_dim=8,
+            min_latent_dim=1,
+            device="cpu",
+        )
+
+        assert mutation_utils.node_addition_blocker(encoder, 0) is True
+
+    def test_a_simba_block_blocks(self):
+        from agilerl.modules.simba import EvolvableSimBa
+
+        simba = EvolvableSimBa(
+            num_inputs=4,
+            num_outputs=2,
+            hidden_size=8,
+            num_blocks=1,
+            min_mlp_nodes=1,
+            device="cpu",
+        )
+
+        assert mutation_utils.node_addition_blocker(simba, 0) is True
+
+    def test_a_residual_block_blocks(self):
+        from agilerl.modules.resnet import EvolvableResNet
+
+        resnet = EvolvableResNet(
+            input_shape=[3, 16, 16],
+            num_outputs=2,
+            channel_size=4,
+            kernel_size=3,
+            stride_size=1,
+            num_blocks=1,
+            min_channel_size=1,
+            device="cpu",
+        )
+
+        assert mutation_utils.node_addition_blocker(resnet, 0) is True
+
+    def test_an_out_of_range_layer_index_blocks(self):
+        assert (
+            mutation_utils.node_addition_blocker(make_mlp(hidden_size=[8]), 5) is True
+        )
+
+    def test_a_structural_exclusion_also_blocks_an_unusable_index(self):
+        """A structural exclusion is detected before the index is even used."""
+        from agilerl.modules.lstm import EvolvableLSTM
+
+        lstm = EvolvableLSTM(
+            input_size=4,
+            hidden_state_size=8,
+            num_outputs=2,
+            min_hidden_state_size=1,
+            device="cpu",
+        )
+
+        assert mutation_utils.node_addition_blocker(lstm, 5) is True
+
+
+class TestLayerAdditionBlocker:
+    """Decide whether an inserted layer can be an identity."""
+
+    def test_unnormalised_relu_mlp_is_supported(self):
+        blocker = mutation_utils.layer_addition_blocker(make_mlp(hidden_size=[8, 8]))
+
+        assert blocker is False
+
+    @pytest.mark.parametrize("activation", ["Tanh", "GELU", "LeakyReLU"])
+    def test_a_non_relu_activation_blocks(self, activation):
+        blocker = mutation_utils.layer_addition_blocker(
+            make_mlp(hidden_size=[8, 8], activation=activation),
+        )
+
+        assert blocker is True
+
+    def test_a_norm_blocks(self):
+        blocker = mutation_utils.layer_addition_blocker(
+            make_mlp(hidden_size=[8, 8], layer_norm=True),
+        )
+
+        assert blocker is True
+
+    def test_a_convolutional_stack_blocks(self):
+        blocker = mutation_utils.layer_addition_blocker(make_cnn())
+
+        assert blocker is True
+
+    def test_a_non_square_new_layer_blocks(self):
+        blocker = mutation_utils.layer_addition_blocker(make_mlp(hidden_size=[8, 16]))
+
+        assert blocker is True
+
+    def test_a_simba_block_blocks(self):
+        from agilerl.modules.simba import EvolvableSimBa
+
+        simba = EvolvableSimBa(
+            num_inputs=4,
+            num_outputs=2,
+            hidden_size=8,
+            num_blocks=1,
+            min_mlp_nodes=1,
+            device="cpu",
+        )
+
+        blocker = mutation_utils.layer_addition_blocker(simba)
+
+        assert blocker is True
+
+    def test_a_stack_without_two_layers_blocks(self):
+        module = nn.Sequential(nn.Linear(4, 2))
+
+        blocker = mutation_utils.layer_addition_blocker(module)
+
+        assert blocker is True
+
+
+class TestLatentAdditionBlocker:
+    """Decide whether widening the latent can preserve the function."""
+
+    @staticmethod
+    def q_network(observation_space, action_space, **kwargs):
+        from agilerl.networks.q_networks import QNetwork
+
+        options = {
+            "latent_dim": 8,
+            "min_latent_dim": 1,
+            "encoder_config": {
+                "hidden_size": [8],
+                "min_mlp_nodes": 1,
+                "layer_norm": False,
+            },
+            "device": "cpu",
+        }
+        options.update(kwargs)
+        return QNetwork(observation_space, action_space, **options)
+
+    def test_unnormalised_mlp_encoder_is_supported(self, vector_space, discrete_space):
+        network = self.q_network(vector_space, discrete_space)
+
+        assert mutation_utils.latent_addition_blocker(network) is False
+
+    def test_a_normalised_mlp_encoder_blocks(self, vector_space, discrete_space):
+        network = self.q_network(
+            vector_space,
+            discrete_space,
+            encoder_config={"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": True},
+        )
+
+        assert mutation_utils.latent_addition_blocker(network) is True
+
+    def test_a_continuous_q_network_is_supported(self, vector_space):
+        from agilerl.networks.q_networks import ContinuousQNetwork
+
+        network = ContinuousQNetwork(
+            vector_space,
+            vector_space,
+            latent_dim=8,
+            min_latent_dim=1,
+            encoder_config={"hidden_size": [8], "min_mlp_nodes": 1},
+            device="cpu",
+        )
+
+        assert mutation_utils.latent_addition_blocker(network) is False
+
+    def test_a_recurrent_encoder_is_supported(self, vector_space, discrete_space):
+        """A latent widening is head-side surgery, so the core is irrelevant.
+
+        The recurrent core owns no per-unit weight rows, which rules out
+        widening a layer inside it, but add_latent_node only fades the
+        head's new input columns, and the encoder's own output rows are
+        appended at the tail like any other module's.
+        """
+        network = self.q_network(
+            vector_space,
+            discrete_space,
+            recurrent=True,
+            encoder_config={"hidden_state_size": 8},
+        )
+
+        assert mutation_utils.latent_addition_blocker(network) is False
+
+    def test_a_multi_input_encoder_is_supported(self, dict_space, discrete_space):
+        """The interleaving is at the encoder's input, not at its output."""
+        from agilerl.networks.q_networks import QNetwork
+
+        network = QNetwork(
+            dict_space, discrete_space, latent_dim=8, min_latent_dim=1, device="cpu"
+        )
+
+        assert mutation_utils.latent_addition_blocker(network) is False
+
+    def test_a_simba_encoder_is_supported(self, vector_space, discrete_space):
+        network = self.q_network(
+            vector_space,
+            discrete_space,
+            simba=True,
+            encoder_config={"hidden_size": 8, "num_blocks": 1},
+        )
+
+        assert mutation_utils.latent_addition_blocker(network) is False
+
+    def test_a_multi_input_module_blocks_its_own_latent(self, dict_space):
+        """A multi-input encoder's own latent feeds the interleaved fusion.
+
+        Widening it resizes every sub-encoder's output, so the fusion layer's
+        new columns are spread through its input rather than appended at the tail.
+        """
+        from agilerl.modules.multi_input import EvolvableMultiInput
+
+        encoder = EvolvableMultiInput(
+            observation_space=dict_space, num_outputs=8, device="cpu"
+        )
+
+        assert mutation_utils.latent_addition_blocker(encoder) is True
+
+    def test_an_encoder_without_weight_layers_blocks(self):
+        network = nn.Module()
+        network.latent_dim = 8
+        network.encoder = nn.Sequential(nn.ReLU())
+
+        assert mutation_utils.latent_addition_blocker(network) is True
+
+
+class TestPreserveAddedNodes:
+    """Fade a widened layer's new units so the network's output is unchanged."""
+
+    @staticmethod
+    def widen(
+        module, hidden_layer=0, added=4, noise_scale=0.0, seed=0, method="add_node"
+    ):
+        old_width = mutation_utils.hidden_widths(module)[hidden_layer]
+        count = "numb_new_channels" if method == "add_channel" else "numb_new_nodes"
+        getattr(module, method)(hidden_layer=hidden_layer, **{count: added})
+        mutation_utils.preserve_added_nodes(
+            module, hidden_layer, old_width, make_rng(seed), noise_scale=noise_scale
+        )
+
+    def test_mlp_output_is_unchanged(self):
+        module = make_mlp().eval()
+        observation = torch.randn(4, 4)
+        before = module(observation)
+
+        self.widen(module)
+
+        torch.testing.assert_close(module(observation), before, rtol=0, atol=1e-6)
+
+    def test_the_layer_actually_grew(self):
+        module = make_mlp()
+
+        self.widen(module)
+
+        assert module.hidden_size[0] == 12
+
+    def test_cnn_output_is_unchanged_between_convolutions(self):
+        module = make_cnn().eval()
+        observation = torch.randn(2, 3, 16, 16)
+        before = module(observation)
+
+        self.widen(module, hidden_layer=0, method="add_channel")
+
+        torch.testing.assert_close(
+            module.eval()(observation), before, rtol=0, atol=1e-6
+        )
+
+    def test_cnn_output_is_unchanged_across_the_flatten_boundary(self):
+        module = make_cnn().eval()
+        observation = torch.randn(2, 3, 16, 16)
+        before = module(observation)
+
+        self.widen(module, hidden_layer=1, method="add_channel")
+
+        torch.testing.assert_close(
+            module.eval()(observation), before, rtol=0, atol=1e-6
+        )
+
+    def test_duelling_head_output_is_unchanged(self):
+        module = make_duelling().eval()
+        observation = torch.randn(4, 8)
+        before = module(observation)
+
+        self.widen(module)
+
+        torch.testing.assert_close(
+            module.eval()(observation), before, rtol=0, atol=1e-6
+        )
+
+    def test_both_duelling_streams_are_faded(self):
+        module = make_duelling()
+
+        self.widen(module)
+
+        for stack in mutation_utils.weight_stacks(module):
+            assert torch.count_nonzero(stack[1].weight_mu[:, 8:]) == 0
+
+    def test_a_noisy_consumer_keeps_no_noise_on_the_new_columns(self):
+        module = make_duelling()
+
+        self.widen(module, noise_scale=0.5)
+
+        for stack in mutation_utils.weight_stacks(module):
+            assert torch.count_nonzero(stack[1].weight_sigma[:, 8:]) == 0
+            assert torch.count_nonzero(stack[1].weight_epsilon[:, 8:]) == 0
+
+    def test_the_new_units_keep_their_incoming_weights(self):
+        """Only the outgoing weights are rewritten."""
+        torch.manual_seed(0)
+        module = make_mlp()
+        module.add_node(hidden_layer=0, numb_new_nodes=4)
+        producer = mutation_utils.weight_stacks(module)[0][0]
+        as_initialised = producer.weight[8:].detach().clone()
+
+        mutation_utils.preserve_added_nodes(
+            module, 0, 8, make_rng(), noise_scale=mutation_utils.FP_NOISE_SCALE
+        )
+
+        assert torch.equal(
+            mutation_utils.weight_stacks(module)[0][0].weight[8:], as_initialised
+        )
+
+    def test_the_new_units_receive_gradient(self):
+        """Fading rather than zeroing is what lets the new capacity train."""
+        torch.manual_seed(0)
+        module = make_mlp()
+        self.widen(module, noise_scale=mutation_utils.FP_NOISE_SCALE)
+
+        module(torch.randn(16, 4)).sum().backward()
+
+        incoming = mutation_utils.weight_stacks(module)[0][0].weight.grad[8:]
+        assert incoming.abs().max() > 0
+
+    def test_a_blocked_growth_leaves_the_consumer_untouched(self):
+        module = make_mlp(hidden_size=[8], max_mlp_nodes=8)
+        consumer = mutation_utils.weight_stacks(module)[0][1]
+        before = consumer.weight.detach().clone()
+
+        self.widen(module, added=4)
+
+        assert module.hidden_size == [8]
+        assert torch.equal(consumer.weight, before)
+
+    def test_noise_leaves_the_new_columns_non_zero(self):
+        module = make_mlp()
+
+        self.widen(module, noise_scale=0.5)
+
+        assert (
+            torch.count_nonzero(
+                mutation_utils.weight_stacks(module)[0][1].weight[:, 8:]
+            )
+            > 0
+        )
+
+    def test_noise_stays_below_the_existing_column_scale(self):
+        module = make_mlp()
+
+        self.widen(module, noise_scale=mutation_utils.FP_NOISE_SCALE)
+
+        consumer = mutation_utils.weight_stacks(module)[0][1].weight
+        assert consumer[:, 8:].std() < consumer[:, :8].std()
+
+    def test_a_consumer_whose_old_columns_have_no_spread_still_gets_noise(self):
+        """A zero-spread neighbourhood must not collapse the noise to nothing."""
+        module = make_mlp()
+        module.add_node(hidden_layer=0, numb_new_nodes=4)
+        consumer = mutation_utils.weight_stacks(module)[0][1]
+        with torch.no_grad():
+            consumer.weight[:, :8] = 1.0
+
+        mutation_utils.preserve_added_nodes(module, 0, 8, make_rng(), noise_scale=0.5)
+
+        new_columns = consumer.weight[:, 8:]
+        assert torch.count_nonzero(new_columns) == new_columns.numel()
+
+    def test_the_same_seed_gives_the_same_weights(self):
+        first, second = make_mlp(), make_mlp()
+        second.load_state_dict(first.state_dict())
+
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(0)
+            self.widen(first, noise_scale=0.5, seed=7)
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(0)
+            self.widen(second, noise_scale=0.5, seed=7)
+
+        for left, right in zip(
+            first.state_dict().values(), second.state_dict().values(), strict=True
+        ):
+            assert torch.equal(left, right)
+
+    @pytest.mark.parametrize("noise_scale", [0.0, 0.5])
+    def test_it_never_consumes_the_global_generator(self, noise_scale):
+        module = make_mlp()
+        old_width = mutation_utils.hidden_widths(module)[0]
+        module.add_node(hidden_layer=0, numb_new_nodes=4)
+        state = torch.random.get_rng_state()
+
+        mutation_utils.preserve_added_nodes(
+            module, 0, old_width, make_rng(), noise_scale=noise_scale
+        )
+
+        assert torch.equal(torch.random.get_rng_state(), state)
+
+
+class TestPreserveAddedLayer:
+    """Initialise an inserted layer to the identity."""
+
+    def test_mlp_output_is_unchanged(self):
+        module = make_mlp(hidden_size=[8]).eval()
+        observation = torch.randn(4, 4)
+        before = module(observation)
+
+        module.add_layer()
+        mutation_utils.preserve_added_layer(module)
+
+        torch.testing.assert_close(
+            module.eval()(observation), before, rtol=0, atol=1e-7
+        )
+
+    def test_the_network_actually_deepened(self):
+        module = make_mlp(hidden_size=[8])
+
+        module.add_layer()
+        mutation_utils.preserve_added_layer(module)
+
+        assert len(module.hidden_size) == 2
+
+    def test_the_new_layer_is_the_identity(self):
+        module = make_mlp(hidden_size=[8])
+
+        module.add_layer()
+        mutation_utils.preserve_added_layer(module)
+
+        new_layer = mutation_utils.weight_stacks(module)[0][-2]
+        assert torch.equal(new_layer.weight, torch.eye(8))
+        assert torch.count_nonzero(new_layer.bias) == 0
+
+    def test_duelling_head_output_is_unchanged(self):
+        module = make_duelling(hidden_size=[8]).eval()
+        observation = torch.randn(4, 8)
+        before = module(observation)
+
+        module.add_layer()
+        mutation_utils.preserve_added_layer(module)
+
+        torch.testing.assert_close(
+            module.eval()(observation), before, rtol=0, atol=1e-6
+        )
+
+    def test_both_duelling_streams_get_an_identity(self):
+        module = make_duelling(hidden_size=[8])
+
+        module.add_layer()
+        mutation_utils.preserve_added_layer(module)
+
+        for stack in mutation_utils.weight_stacks(module):
+            assert torch.equal(stack[-2].weight_mu, torch.eye(8))
+            assert torch.count_nonzero(stack[-2].weight_sigma) == 0
+
+
+class TestPreserveAddedLatent:
+    """Fade the head's new latent columns so the network's output is unchanged."""
+
+    @staticmethod
+    def q_network(vector_space, discrete_space, **kwargs):
+        from agilerl.networks.q_networks import QNetwork
+
+        return QNetwork(
+            vector_space,
+            discrete_space,
+            latent_dim=8,
+            min_latent_dim=1,
+            max_latent_dim=128,
+            encoder_config={
+                "hidden_size": [8],
+                "min_mlp_nodes": 1,
+                "layer_norm": False,
+            },
+            head_config={"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+            device="cpu",
+            **kwargs,
+        )
+
+    @staticmethod
+    def widen(network, added=4, noise_scale=0.0, seed=0):
+        """Widen the latent and apply the fixup."""
+        old_latent = network.latent_dim
+        network.add_latent_node(numb_new_nodes=added)
+        mutation_utils.preserve_added_latent(
+            network, old_latent, make_rng(seed), noise_scale=noise_scale
+        )
+
+    def test_output_is_unchanged(self, vector_space, discrete_space):
+        network = self.q_network(vector_space, discrete_space).eval()
+        observation = torch.randn(4, 4)
+        before = network(observation)
+
+        self.widen(network)
+
+        torch.testing.assert_close(network(observation), before, rtol=0, atol=1e-6)
+
+    def test_the_latent_actually_grew(self, vector_space, discrete_space):
+        network = self.q_network(vector_space, discrete_space)
+
+        self.widen(network)
+
+        assert network.latent_dim == 12
+
+    def test_the_new_head_columns_are_faded(self, vector_space, discrete_space):
+        network = self.q_network(vector_space, discrete_space)
+
+        self.widen(network)
+
+        entry = mutation_utils.weight_stacks(network.head_net)[0][0]
+        assert torch.count_nonzero(entry.weight[:, 8:12]) == 0
+
+    def test_the_new_latent_units_receive_gradient(self, vector_space, discrete_space):
+        """The encoder rows feeding the new latent units must still train."""
+        torch.manual_seed(0)
+        network = self.q_network(vector_space, discrete_space)
+        self.widen(network, noise_scale=mutation_utils.FP_NOISE_SCALE)
+
+        network(torch.randn(16, 4)).sum().backward()
+
+        incoming = mutation_utils.weight_stacks(network.encoder)[0][-1].weight.grad[
+            8:12
+        ]
+        assert incoming.abs().max() > 0
+
+    def test_a_blocked_growth_leaves_the_head_untouched(
+        self, vector_space, discrete_space
+    ):
+        network = self.q_network(vector_space, discrete_space)
+        network.max_latent_dim = 8
+        entry = mutation_utils.weight_stacks(network.head_net)[0][0]
+        before = entry.weight.detach().clone()
+
+        self.widen(network, added=4)
+
+        assert network.latent_dim == 8
+        assert torch.equal(entry.weight, before)
+
+    def test_a_multi_input_encoder_output_is_unchanged(
+        self, dict_space, discrete_space
+    ):
+        """The fade is exact even though the encoder fuses several inputs.
+
+        Growing the latent only appends rows to the fusion layer's output, so
+        every pre-existing latent coordinate survives and the head's faded new
+        columns carry the rest.
+        """
+        from agilerl.networks.q_networks import QNetwork
+
+        network = QNetwork(
+            dict_space,
+            discrete_space,
+            latent_dim=8,
+            min_latent_dim=1,
+            max_latent_dim=128,
+            head_config={"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+            device="cpu",
+        ).eval()
+        observation = {
+            key: torch.as_tensor(subspace.sample()).unsqueeze(0).float()
+            for key, subspace in dict_space.spaces.items()
+        }
+        before = network(observation)
+
+        self.widen(network)
+
+        torch.testing.assert_close(network(observation), before, rtol=0, atol=1e-6)
+
+    def test_a_continuous_critic_keeps_its_action_sensitivity(self, vector_space):
+        from agilerl.networks.q_networks import ContinuousQNetwork
+
+        network = ContinuousQNetwork(
+            vector_space,
+            vector_space,
+            latent_dim=8,
+            min_latent_dim=1,
+            encoder_config={"hidden_size": [8], "min_mlp_nodes": 1},
+            head_config={"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+            device="cpu",
+        ).eval()
+        observation = torch.randn(4, 4)
+        actions = torch.randn(4, 4, requires_grad=True)
+        before = network(observation, actions)
+
+        self.widen(network)
+
+        after = network(observation, actions)
+        torch.testing.assert_close(after, before, rtol=0, atol=1e-6)
+        gradient = torch.autograd.grad(after.sum(), actions)[0]
+        assert torch.count_nonzero(gradient) > 0
+
+    def test_a_continuous_critic_slides_its_action_block(self, vector_space):
+        from agilerl.networks.q_networks import ContinuousQNetwork
+
+        network = ContinuousQNetwork(
+            vector_space,
+            vector_space,
+            latent_dim=8,
+            min_latent_dim=1,
+            encoder_config={"hidden_size": [8], "min_mlp_nodes": 1},
+            head_config={"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+            device="cpu",
+        )
+        entry = mutation_utils.weight_stacks(network.head_net)[0][0]
+        action_block = entry.weight[:, 8:12].detach().clone()
+
+        self.widen(network)
+
+        moved = mutation_utils.weight_stacks(network.head_net)[0][0]
+        assert torch.equal(moved.weight[:, 12:16], action_block)
+
+
+class TestWeightParam:
+    """Resolve the weight tensor that defines a layer's shape."""
+
+    def test_a_noisy_layer_resolves_to_its_mean_weight(self):
+        layer = mutation_utils.weight_stacks(make_duelling())[0][0]
+
+        assert mutation_utils.weight_param(layer) is layer.weight_mu
+
+
+class TestModulesBetween:
+    """List the modules a widened output passes through after its producer."""
+
+    def test_an_activation_between_two_layers_is_reported(self):
+        container = make_mlp()
+        layers = mutation_utils.weight_stacks(container)[0]
+
+        between = mutation_utils.modules_between(container.model, layers[0], layers[1])
+
+        assert any(isinstance(module, nn.ReLU) for module in between)
+
+    def test_an_omitted_consumer_reports_every_trailing_module(self):
+        container = make_mlp()
+        layers = mutation_utils.weight_stacks(container)[0]
+
+        trailing = mutation_utils.modules_between(container.model, layers[0])
+
+        assert layers[-1] in trailing
+        assert any(isinstance(module, nn.ReLU) for module in trailing)
+
+
+class TestResolveTarget:
+    """Walk a dotted mutation name to the module it acts on."""
+
+    @staticmethod
+    def q_network(vector_space, discrete_space):
+        from agilerl.networks.q_networks import QNetwork
+
+        return QNetwork(
+            vector_space,
+            discrete_space,
+            latent_dim=8,
+            min_latent_dim=1,
+            encoder_config={
+                "hidden_size": [8],
+                "min_mlp_nodes": 1,
+                "layer_norm": False,
+            },
+            head_config={"hidden_size": [8], "min_mlp_nodes": 1, "layer_norm": False},
+            device="cpu",
+        )
+
+    def test_a_bare_method_resolves_to_the_module_itself(self):
+        module = make_mlp()
+
+        assert mutation_utils.resolve_target(module, "add_node") is module
+
+    def test_a_submodule_segment_is_followed(self, vector_space, discrete_space):
+        network = self.q_network(vector_space, discrete_space)
+
+        assert (
+            mutation_utils.resolve_target(network, "head_net.add_node")
+            is network.head_net
+        )
+
+    def test_a_latent_method_resolves_to_the_network(
+        self, vector_space, discrete_space
+    ):
+        network = self.q_network(vector_space, discrete_space)
+
+        assert mutation_utils.resolve_target(network, "add_latent_node") is network
+
+    def test_an_agent_segment_indexes_a_module_dict(self, vector_space, discrete_space):
+        from agilerl.modules import ModuleDict
+
+        policies = ModuleDict({"agent_0": self.q_network(vector_space, discrete_space)})
+
+        target = mutation_utils.resolve_target(policies, "agent_0.head_net.add_node")
+
+        assert target is policies["agent_0"].head_net
+
+    def test_an_unresolvable_name_returns_nothing(self):
+        assert mutation_utils.resolve_target(make_mlp(), "missing.add_node") is None

--- a/tests/test_utils/test_mutation_utils.py
+++ b/tests/test_utils/test_mutation_utils.py
@@ -430,8 +430,8 @@ class TestRevivedBlock:
 class TestModuleTraversalHelpers:
     """Locate weight layers and strip wrappers across the module tree."""
 
-    def test_first_weight_layer_of_a_weightless_module_is_none(self):
-        assert mutation_utils.first_weight_layer(nn.Sequential(nn.ReLU())) is None
+    def test_a_weightless_module_reports_no_weight_layers(self):
+        assert mutation_utils.weight_layers(nn.Sequential(nn.ReLU())) == []
 
     def test_head_entry_layers_of_an_absent_head_is_empty(self):
         assert mutation_utils.head_entry_layers(None) == []


### PR DESCRIPTION
## Description

Makes AgileRL's **additive architecture mutations function-preserving** wherever the architecture allows it.

**Motivation.** When an architecture mutation widens or deepens a network, the trained weights are carried over but the new capacity is initialised randomly, so the network's output changes the moment it is added. The agent is then evaluated as a *different* policy from the one that earned its place in the population, its fitness drops, and tournament selection usually discards it before the extra capacity has been trained into anything useful. Architecture mutations are therefore far more destructive than the other operators, and the architecture search space is explored poorly.

**What this does.** Additions now initialise their new capacity so the network computes (near-)exactly what it computed before the mutation. The agent keeps its fitness, survives selection on its merits, and the added capacity is recruited by subsequent training instead of having to justify itself in a single evaluation.

Two mechanisms cover the additive mutations, both in the new `agilerl/hpo/func_preservation.py`:

* **Widening** (`add_node`, `add_channel`, `add_latent_node`): The new units keep the incoming weights the original operator gave them; only the *outgoing* weights that carry them into the consuming layer are rewritten. The consumer's output is then unchanged whatever the activation does.
* **Deepening** (`add_layer`): The inserted layer is initialised to the identity (Net2DeeperNet), which is exact for ReLU and Identity activations.

Some choices worth flagging for review:

* **Fade, don't zero.** New outgoing weights are set to random noise scaled to `FP_NOISE_SCALE` (`0.02`) × the consuming layer's *existing* column scale, rather than to exact zero. Exact zero is exactly function-preserving, but it also hands the new unit zero gradient, so it is born dormant and learns slowly. The fade keeps the output change well inside evaluation noise while letting gradient reach the new units immediately. Preservation is therefore *near*-exact for widening and exact for deepening.
* **No new configuration.** There is no manifest field and no flag: preservation is applied automatically, per mutation, whenever the architecture supports it, and the original random initialisation stands when it does not.
* **Additions only.** `remove_node`, `remove_channel`, `remove_latent_node` and `remove_layer` run AgileRL's original positional path verbatim and are not touched.
* **Decline out loud, never silently.** Three blockers (`node_addition_blocker`, `layer_addition_blocker`, `latent_addition_blocker`) rule on the architecture *before* any surgery and return a key into `DECLINE_REASONS`. Preservation stands down when a normalisation layer sits between the widened units and the layer that reads them (its statistics are pooled over the layer, so any new unit moves every existing one), when the activation mixes units (`Softmax`, `LogSoftmax`, `Softmin`, `GumbelSoftmax`), or when the widened layer sits inside a recurrent core, a multi-input encoder, or a residual/SimBa block; deepening additionally requires a square MLP layer under ReLU or Identity. `add_latent_node` is the exception to the container rules: its surgery is head-side only, so it is preserved even for recurrent, residual, SimBa and multi-input encoders. Each reason is warned about **once per `Mutations` instance**, so a configuration that never gets preservation is visible without drowning the training log.
* **A fixup that raises costs the preservation and nothing else.** `Mutations._fp_preserve` catches and logs, leaving exactly what the original operator built

Six example manifests ship with the change, one per algorithm family (`ppo`, `dqn`, `cqn`, `neural_ucb`, `ippo`, `maddpg`). They carry no function-preserving switch — there is none. Each differs from its family baseline only by `layer_norm: false` on the encoder and head configs and `act_mut: 0.0`; they are worked examples of an architecture the operator can actually preserve, not a mode selector.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

New hermetic CPU tests (211 cases, no network/GPU/W&B/real training), the surgery is unit-tested in its own module, the wiring lives in the existing suites.

- [x] **`tests/test_hpo/test_func_preservation.py`** (new, 108 tests): the surgery and the blockers as pure units: `TestHiddenWidths`, `TestWeightStacks`, `Test{Node,Layer,Latent}AdditionBlocker`, `TestPreserveAdded{Nodes,Layer,Latent}`, `TestPrimaryWeight`, `TestModulesBetween`, `TestBaseMutation`, `TestResolveTarget`. Preservation is asserted directly: forward pass before vs. after the mutation, plus the boundary cases above (flatten boundary, critic action columns, noisy layers, duelling streams).
- [x] **`tests/test_hpo/test_mutation.py`** (61 new tests, twelve classes): the operator as driven through `Mutations`: `TestMutationsFunctionPreserving{ArchMutation,SingleAgentFamilies,Warnings,MultiAgent,LatentEncoders,SharedEncoders,ConvolutionalEncoder,DistributionHead,Determinism,Accelerator,Degradation}` plus `TestFunctionPreservingRemovalsUnchanged` (removals byte-for-byte match the original operator).
- [x] **`tests/test_train/test_train.py`** (24 new tests): `TestFunctionPreservingCrossFamilyEvolution` and `TestFunctionPreservingTrainerWiring`, reusing the existing `_CROSS_FAMILY_CASES` table so coverage reaches beyond on-policy single-agent: off-policy `DQN`, multi-agent off-policy `MADDPG`, multi-agent on-policy `IPPO`, bandit `NeuralUCB` and offline `CQN` all run real agents through a mutation cycle.
- [x] **`tests/test_models/test_manifest.py`** (18 new tests): `TestFunctionPreservingManifests` validates every shipped manifest and asserts each one really does switch normalisation off and activation mutations to zero, so the examples cannot drift out of the regime they were written for.

Reproduce:

```bash
uv run python -m pytest tests/test_hpo/test_func_preservation.py
uv run python -m pytest tests/test_hpo/test_mutation.py -k FunctionPreserving
uv run python -m pytest tests/test_train/test_train.py -k FunctionPreserving
uv run python -m pytest tests/test_models/test_manifest.py

# full suite, as CI runs it
just test
```

Also clean locally: `pre-commit run --all-files` (ruff-check and ruff-format at the pinned `v0.16.2`) and `just typecheck` (`ty` strict over `agilerl/`, with the `agilerl/arena` symlink in place).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation

* `docs/evo_hyperparam_opt/mutation.rst`: a "Function-preserving additions" section behind a `.. _function_preserving:` label, with a "When it applies" subsection enumerating the declines and a note on the evaluation-mode caveat for noisy layers.
* `docs/api/hpo/mutation.rst`: the architecture-mutation bullet now says additions are function-preserving and cross-references the section above.
